### PR TITLE
feat: implement JWT refresh token mechanism

### DIFF
--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/dto/AuthDTO.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/dto/AuthDTO.java
@@ -48,24 +48,39 @@ public class AuthDTO {
 
     /**
      * Response DTO for login/register operations
-     * Returns JWT token and user information
+     * Returns JWT tokens and user information
      */
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
     public static class AuthResponse {
         private String token;
+        private String refreshToken;
         private String type = "Bearer";
+        private Long expiresIn; // Access token expiration in seconds
         private Long userId;
         private String username;
         private String email;
 
-        public AuthResponse(String token, Long userId, String username, String email) {
+        public AuthResponse(String token, String refreshToken, Long expiresIn, Long userId, String username, String email) {
             this.token = token;
+            this.refreshToken = refreshToken;
+            this.expiresIn = expiresIn;
             this.userId = userId;
             this.username = username;
             this.email = email;
         }
+    }
+
+    /**
+     * Request DTO for token refresh
+     */
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RefreshRequest {
+        @NotBlank(message = "Refresh token is required")
+        private String refreshToken;
     }
 
     /**

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -28,7 +28,10 @@ spring.h2.console.enabled=false
 # ========================================
 # Use environment variables for secrets in production
 jwt.secret=${JWT_SECRET}
-jwt.expiration=86400000
+# Access token expiration in milliseconds (900000 = 15 minutes)
+jwt.access-expiration=900000
+# Refresh token expiration in milliseconds (604800000 = 7 days)
+jwt.refresh-expiration=604800000
 
 # ========================================
 # Logging Configuration

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -43,8 +43,10 @@ logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 # Secret key for JWT signing (CHANGE THIS IN PRODUCTION!)
 # Must be at least 256 bits (32 characters)
 jwt.secret=your-very-secure-secret-key-change-this-in-production-minimum-256-bits-required
-# Token expiration in milliseconds (86400000 = 24 hours)
-jwt.expiration=86400000
+# Access token expiration in milliseconds (900000 = 15 minutes)
+jwt.access-expiration=900000
+# Refresh token expiration in milliseconds (604800000 = 7 days)
+jwt.refresh-expiration=604800000
 
 # ========================================
 # Notes for Migration to PostgreSQL

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -26,6 +26,7 @@ export const AuthProvider = ({ children }) => {
           // Token expired or invalid - clear storage
           console.error('Auth verification failed:', err);
           localStorage.removeItem('token');
+          localStorage.removeItem('refreshToken');
           localStorage.removeItem('user');
           setUser(null);
         }
@@ -46,8 +47,11 @@ export const AuthProvider = ({ children }) => {
       setError(null);
       const response = await authApi.register(credentials);
 
-      // Store token and user
+      // Store tokens and user
       localStorage.setItem('token', response.token);
+      if (response.refreshToken) {
+        localStorage.setItem('refreshToken', response.refreshToken);
+      }
       localStorage.setItem('user', JSON.stringify(response));
 
       setUser(response);
@@ -67,8 +71,11 @@ export const AuthProvider = ({ children }) => {
       setError(null);
       const response = await authApi.login(credentials);
 
-      // Store token and user
+      // Store tokens and user
       localStorage.setItem('token', response.token);
+      if (response.refreshToken) {
+        localStorage.setItem('refreshToken', response.refreshToken);
+      }
       localStorage.setItem('user', JSON.stringify(response));
 
       setUser(response);

--- a/frontend/src/services/api/authApi.js
+++ b/frontend/src/services/api/authApi.js
@@ -40,10 +40,18 @@ export const authApi = {
   changePassword: (data) => apiClient.post('/api/auth/change-password', data),
 
   /**
-   * Logout (client-side - clear token)
+   * Refresh access token using refresh token
+   * @param {string} refreshToken - The refresh token
+   * @returns {Promise<Object>} New tokens and user data
+   */
+  refresh: (refreshToken) => apiClient.post('/api/auth/refresh', { refreshToken }),
+
+  /**
+   * Logout (client-side - clear tokens)
    */
   logout: () => {
     localStorage.removeItem('token');
+    localStorage.removeItem('refreshToken');
     localStorage.removeItem('user');
   },
 

--- a/frontend/src/services/api/client.js
+++ b/frontend/src/services/api/client.js
@@ -13,6 +13,59 @@ const apiClient = axios.create({
 });
 
 /**
+ * Token refresh state management
+ */
+let isRefreshing = false;
+let failedQueue = [];
+
+/**
+ * Process queued requests after token refresh
+ */
+const processQueue = (error, token = null) => {
+  failedQueue.forEach((prom) => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve(token);
+    }
+  });
+  failedQueue = [];
+};
+
+/**
+ * Attempt to refresh the access token using the refresh token
+ */
+const refreshAccessToken = async () => {
+  const refreshToken = localStorage.getItem('refreshToken');
+  if (!refreshToken) {
+    throw new Error('No refresh token available');
+  }
+
+  // Use axios directly to avoid interceptor loops
+  const response = await axios.post(`${API_BASE_URL}/api/auth/refresh`, {
+    refreshToken,
+  });
+
+  const { token, refreshToken: newRefreshToken } = response.data;
+  localStorage.setItem('token', token);
+  if (newRefreshToken) {
+    localStorage.setItem('refreshToken', newRefreshToken);
+  }
+
+  return token;
+};
+
+/**
+ * Clear all auth data and redirect to login
+ */
+const clearAuthAndRedirect = () => {
+  localStorage.removeItem('token');
+  localStorage.removeItem('refreshToken');
+  localStorage.removeItem('user');
+  window.location.href = '/login';
+};
+
+/**
  * Request interceptor - add JWT token to all requests
  */
 apiClient.interceptors.request.use(
@@ -29,30 +82,63 @@ apiClient.interceptors.request.use(
 );
 
 /**
- * Response interceptor - handle errors globally
+ * Response interceptor - handle errors globally with automatic token refresh
  */
 apiClient.interceptors.response.use(
   (response) => {
     // Return just the data from successful responses
     return response.data;
   },
-  (error) => {
+  async (error) => {
+    const originalRequest = error.config;
+
     // Handle 401 Unauthorized - token expired or invalid
-    if (error.response?.status === 401) {
-      const requestUrl = error.config?.url || '';
-      const isAuthEndpoint = requestUrl.includes('/auth/login') || requestUrl.includes('/auth/register');
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      const requestUrl = originalRequest?.url || '';
+      const isAuthEndpoint =
+        requestUrl.includes('/auth/login') ||
+        requestUrl.includes('/auth/register') ||
+        requestUrl.includes('/auth/refresh');
       const isOnLoginPage = window.location.pathname === '/login';
 
-      // Only redirect if this isn't a login/register attempt
-      // If user is trying to login and fails, let the error show instead of redirecting
-      if (!isAuthEndpoint && !isOnLoginPage) {
+      // Don't retry for auth endpoints or if already on login page
+      if (isAuthEndpoint || isOnLoginPage) {
         localStorage.removeItem('token');
+        localStorage.removeItem('refreshToken');
         localStorage.removeItem('user');
-        window.location.href = '/login';
-      } else {
-        // Clear token but don't redirect (let login page handle the error)
-        localStorage.removeItem('token');
-        localStorage.removeItem('user');
+        return Promise.reject(error);
+      }
+
+      // If already refreshing, queue this request
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        })
+          .then((token) => {
+            originalRequest.headers.Authorization = `Bearer ${token}`;
+            return apiClient(originalRequest);
+          })
+          .catch((err) => {
+            return Promise.reject(err);
+          });
+      }
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      try {
+        const newToken = await refreshAccessToken();
+        processQueue(null, newToken);
+
+        // Retry original request with new token
+        originalRequest.headers.Authorization = `Bearer ${newToken}`;
+        return apiClient(originalRequest);
+      } catch (refreshError) {
+        processQueue(refreshError, null);
+        clearAuthAndRedirect();
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
       }
     }
 


### PR DESCRIPTION
Add refresh token support to prevent 403 errors during long-running operations like bulk imports. Access tokens now expire in 15 minutes with 7-day refresh tokens that automatically renew sessions.

Backend changes:
- Add generateRefreshToken() and isRefreshToken() to JwtUtil
- Add POST /api/auth/refresh endpoint
- Update AuthDTO with refreshToken and expiresIn fields
- Configure jwt.access-expiration (15min) and jwt.refresh-expiration (7d)

Frontend changes:
- Add automatic token refresh in axios interceptor with request queuing
- Store refresh token in localStorage on login/register
- Add refresh() method to authApi