### PR TITLE
fix: increase JWT access token expiration to 1 day

### DIFF
--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -28,8 +28,8 @@ spring.h2.console.enabled=false
 # ========================================
 # Use environment variables for secrets in production
 jwt.secret=${JWT_SECRET}
-# Access token expiration in milliseconds (900000 = 15 minutes)
-jwt.access-expiration=900000
+# Access token expiration in milliseconds (86400000 = 1 day)
+jwt.access-expiration=86400000
 # Refresh token expiration in milliseconds (604800000 = 7 days)
 jwt.refresh-expiration=604800000
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -43,8 +43,8 @@ logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 # Secret key for JWT signing (CHANGE THIS IN PRODUCTION!)
 # Must be at least 256 bits (32 characters)
 jwt.secret=your-very-secure-secret-key-change-this-in-production-minimum-256-bits-required
-# Access token expiration in milliseconds (900000 = 15 minutes)
-jwt.access-expiration=900000
+# Access token expiration in milliseconds (86400000 = 1 day)
+jwt.access-expiration=86400000
 # Refresh token expiration in milliseconds (604800000 = 7 days)
 jwt.refresh-expiration=604800000
 


### PR DESCRIPTION
Users were getting logged out after 15 minutes when the access token expired. The refresh mechanism wasn't working for users who logged in before the refresh token feature was deployed (their tokens lack the required 'type' claim).

Increasing access token duration from 15 minutes to 1 day reduces refresh frequency and provides better UX for daily usage sessions.

- application.properties: 900000 -> 86400000 ms
- application-prod.properties: 900000 -> 86400000 ms