### PR TITLE
fix: correct Koraidon/Miraidon sprite IDs and paste parsing for items…

### DIFF
--- a/backend/src/test/java/com/yeskatronics/vs_recorder_backend/services/PokepasteServiceTest.java
+++ b/backend/src/test/java/com/yeskatronics/vs_recorder_backend/services/PokepasteServiceTest.java
@@ -181,4 +181,37 @@ class PokepasteServiceTest {
 
         assertEquals("Chien-Pao", result.getPokemon().get(5).getSpecies());
     }
+
+    @Test
+    void testKoraidonAbilityShield(){
+        String pasteText = loadTestFile("koraidon.txt");
+        when(restTemplate.getForObject(anyString(), eq(String.class)))
+                .thenReturn(pasteText);
+
+        PokepasteDTO.PasteData result = pokepasteService.fetchPasteData(
+                "https://pokepast.es/abc123");
+
+        assertNotNull(result);
+        assertEquals(6, result.getPokemon().size());
+
+        assertEquals("Calyrex-Shadow", result.getPokemon().get(0).getSpecies());
+        assertEquals("Focus Sash", result.getPokemon().get(0).getItem());
+
+        assertEquals("Incineroar", result.getPokemon().get(1).getSpecies());
+        assertEquals("Safety Goggles", result.getPokemon().get(1).getItem());
+
+        assertEquals("Weezing-Galar", result.getPokemon().get(2).getSpecies());
+        assertEquals("Covert Cloak", result.getPokemon().get(2).getItem());
+
+        assertEquals("Chi-Yu", result.getPokemon().get(3).getSpecies());
+        assertEquals("Choice Scarf", result.getPokemon().get(3).getItem());
+
+        assertEquals("Walking Wake", result.getPokemon().get(4).getSpecies());
+        assertEquals("Assault Vest", result.getPokemon().get(4).getItem());
+
+        assertEquals("Koraidon", result.getPokemon().get(5).getSpecies());
+        assertEquals("Ability Shield", result.getPokemon().get(5).getItem());
+        assertEquals("Orichalcum Pulse", result.getPokemon().get(5).getAbility());
+        assertEquals("Fire", result.getPokemon().get(5).getTeraType());
+    }
 }

--- a/backend/src/test/resources/pastes/koraidon.txt
+++ b/backend/src/test/resources/pastes/koraidon.txt
@@ -1,0 +1,59 @@
+Calyrex-Shadow @ Focus Sash
+Ability: As One (Spectrier)
+Tera Type: Ghost
+EVs: 4 Def / 252 SpA / 252 Spe
+Timid Nature
+- Astral Barrage
+- Psychic
+- Encore
+- Protect
+
+Incineroar @ Safety Goggles
+Ability: Intimidate
+Tera Type: Bug
+EVs: 244 HP / 188 Def / 76 SpD
+Careful Nature
+- Knock Off
+- Fake Out
+- Parting Shot
+- Protect
+
+Weezing-Galar @ Covert Cloak
+Ability: Neutralizing Gas
+Tera Type: Water
+EVs: 252 HP / 236 SpD / 20 Spe
+Careful Nature
+- Play Rough
+- Taunt
+- Will-O-Wisp
+- Protect
+
+Chi-Yu @ Choice Scarf
+Ability: Beads of Ruin
+Tera Type: Ghost
+EVs: 52 HP / 4 Def / 196 SpA / 4 SpD / 252 Spe
+Modest Nature
+- Heat Wave
+- Flamethrower
+- Dark Pulse
+- Snarl
+
+Walking Wake @ Assault Vest
+Ability: Protosynthesis
+Tera Type: Water
+EVs: 108 HP / 4 Def / 188 SpA / 4 SpD / 204 Spe
+Timid Nature
+- Hydro Steam
+- Draco Meteor
+- Snarl
+- Aqua Jet
+
+Koraidon @ Ability Shield
+Ability: Orichalcum Pulse
+Tera Type: Fire
+EVs: 252 HP / 156 Atk / 4 Def / 60 SpD / 36 Spe
+Adamant Nature
+- Flare Blitz
+- Flame Charge
+- Collision Course
+- Protect

--- a/frontend/src/services/PokemonService.js
+++ b/frontend/src/services/PokemonService.js
@@ -11,8 +11,8 @@ class PokemonService {
     // Static fallback data for most common VGC Pokemon
     static COMMON_VGC_POKEMON = {
         // Generation 9 VGC 2025 common picks
-        'miraidon': { id: 1007, name: 'Miraidon', types: ['electric', 'dragon'] },
-        'koraidon': { id: 1008, name: 'Koraidon', types: ['fighting', 'dragon'] },
+        'miraidon': { id: 1008, name: 'Miraidon', types: ['electric', 'dragon'] },
+        'koraidon': { id: 1007, name: 'Koraidon', types: ['fighting', 'dragon'] },
         'calyrex-shadow': { id: 898, name: 'Calyrex-Shadow', types: ['psychic', 'ghost'] },
         'calyrex-ice': { id: 898, name: 'Calyrex-Ice', types: ['psychic', 'ice'] },
         'urshifu': { id: 892, name: 'Urshifu', types: ['fighting', 'dark'] },

--- a/frontend/src/services/PokepasteService.js
+++ b/frontend/src/services/PokepasteService.js
@@ -4,7 +4,7 @@ import { extractPokemonFromPokepaste, isValidPokemonName } from '../utils/pokemo
 import apiClient from './api/client';
 
 class PokepasteService {
-    static CACHE_KEY = 'pokepaste_cache';
+    static CACHE_KEY = 'pokepaste_cache_v2';
     static CACHE_EXPIRY_HOURS = 24; // Cache for 24 hours
 
     // URL patterns
@@ -260,13 +260,14 @@ class PokepasteService {
             }
 
             // Check if this line starts a new Pokemon (doesn't contain colons and isn't a move)
-            const looksLikePokemonName = !trimmed.includes(':') &&
+            // ` @ ` only appears on Pokemon name lines (e.g. "Koraidon @ Ability Shield")
+            const hasItemSeparator = trimmed.includes(' @ ');
+            const looksLikePokemonName = hasItemSeparator || (
+                !trimmed.includes(':') &&
                 !trimmed.startsWith('-') &&
                 !trimmed.toLowerCase().includes('nature') &&
-                !trimmed.toLowerCase().includes('ability') &&
-                !trimmed.toLowerCase().includes('level') &&
-                !trimmed.toLowerCase().includes('evs') &&
-                !trimmed.toLowerCase().includes('ivs');
+                !trimmed.toLowerCase().includes('level')
+            );
 
             if (looksLikePokemonName && currentBlock.length > 0) {
                 // Save previous block and start new one

--- a/frontend/src/utils/pokemonNameUtils.js
+++ b/frontend/src/utils/pokemonNameUtils.js
@@ -325,15 +325,16 @@ export const extractPokemonFromPokepaste = (pokepasteText) => {
         const trimmedLine = line.trim();
 
         // Skip empty lines, comments, and stat/move lines
+        // ` @ ` only appears on Pokemon name lines (e.g. "Koraidon @ Ability Shield")
+        const hasItemSeparator = trimmedLine.includes(' @ ');
         if (!trimmedLine ||
             trimmedLine.startsWith('//') ||
-            trimmedLine.includes(':') ||
-            trimmedLine.startsWith('-') ||
-            trimmedLine.toLowerCase().includes('nature') ||
-            trimmedLine.toLowerCase().includes('ability') ||
-            trimmedLine.toLowerCase().includes('level') ||
-            trimmedLine.toLowerCase().includes('evs') ||
-            trimmedLine.toLowerCase().includes('ivs')) {
+            (!hasItemSeparator && (
+                trimmedLine.includes(':') ||
+                trimmedLine.startsWith('-') ||
+                trimmedLine.toLowerCase().includes('nature') ||
+                trimmedLine.toLowerCase().includes('level')
+            ))) {
             continue;
         }
 


### PR DESCRIPTION
… containing "ability"

Koraidon and Miraidon Pokedex IDs were swapped, showing wrong sprites. Pokepaste lines like "Koraidon @ Ability Shield" were rejected because the substring "ability" triggered a false negative in name detection. Use ` @ ` as a positive signal for Pokemon name lines and remove redundant substring checks already covered by the colon check. Bump pokepaste cache key to invalidate stale cached results.