### PR TITLE
Add team dashboard filtering by regulation and pokemon

### DIFF
--- a/frontend/src/components/RegulationFilter.jsx
+++ b/frontend/src/components/RegulationFilter.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const RegulationFilter = ({ regulations = [], value = '', onChange, className = '' }) => {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className={`bg-slate-700 border border-slate-600 rounded-lg px-3 py-1.5 text-gray-100 text-sm focus:outline-none focus:border-emerald-400 ${className}`}
+    >
+      <option value="">All Regulations</option>
+      {regulations.map((reg) => (
+        <option key={reg} value={reg}>
+          {reg}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+export default RegulationFilter;

--- a/frontend/src/components/TagInput.jsx
+++ b/frontend/src/components/TagInput.jsx
@@ -1,0 +1,60 @@
+import React, { useState, useRef } from 'react';
+import { X } from 'lucide-react';
+
+const TagInput = ({ tags = [], onAddTag, onRemoveTag, placeholder = 'Search...', className = '' }) => {
+  const [input, setInput] = useState('');
+  const inputRef = useRef(null);
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const trimmed = input.trim();
+      if (trimmed && !tags.includes(trimmed.toLowerCase())) {
+        onAddTag(trimmed.toLowerCase());
+      }
+      setInput('');
+    } else if (e.key === 'Escape') {
+      setInput('');
+      inputRef.current?.blur();
+    } else if (e.key === 'Backspace' && input === '' && tags.length > 0) {
+      onRemoveTag(tags[tags.length - 1]);
+    }
+  };
+
+  return (
+    <div
+      className={`flex flex-wrap items-center gap-1.5 bg-slate-700 border border-slate-600 rounded-lg px-3 py-1.5 focus-within:border-emerald-400 transition-colors ${className}`}
+      onClick={() => inputRef.current?.focus()}
+    >
+      {tags.map((tag) => (
+        <span
+          key={tag}
+          className="flex items-center gap-1 bg-slate-600 text-gray-200 px-2 py-0.5 rounded text-sm"
+        >
+          {tag}
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemoveTag(tag);
+            }}
+            className="text-gray-400 hover:text-gray-200 transition-colors"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </span>
+      ))}
+      <input
+        ref={inputRef}
+        type="text"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={tags.length === 0 ? placeholder : ''}
+        className="flex-1 min-w-[120px] bg-transparent text-gray-100 text-sm focus:outline-none placeholder-gray-400"
+      />
+    </div>
+  );
+};
+
+export default TagInput;

--- a/frontend/src/components/index.jsx
+++ b/frontend/src/components/index.jsx
@@ -17,3 +17,5 @@ export { default as MatchupStatsTab } from './MatchupStatsTab';
 export { default as MoveUsageTab } from './MoveUsageTab';
 export { default as ProtectedRoute } from './ProtectedRoute';
 export { default as PublicRoute } from './PublicRoute';
+export { default as TagInput } from './TagInput';
+export { default as RegulationFilter } from './RegulationFilter';

--- a/frontend/src/hooks/index.js
+++ b/frontend/src/hooks/index.js
@@ -3,3 +3,4 @@
  */
 export { useTeamStats, useMultipleTeamStats, useTeamComparison } from './useTeamStats';
 export { default as useOpponentTeams } from './useOpponentTeams';
+export { default as useTeamPokemon } from './useTeamPokemon';

--- a/frontend/src/hooks/useTeamPokemon.js
+++ b/frontend/src/hooks/useTeamPokemon.js
@@ -1,0 +1,60 @@
+import { useState, useEffect, useMemo } from 'react';
+import PokepasteService from '../services/PokepasteService';
+
+/**
+ * Hook that batch-resolves pokepaste URLs to pokemon names for all teams.
+ * Leverages the existing 24-hour PokepasteService cache.
+ */
+const useTeamPokemon = (teams) => {
+  const [teamPokemon, setTeamPokemon] = useState({});
+  const [loading, setLoading] = useState(false);
+
+  // Create a stable key based on team IDs and pokepaste URLs
+  const teamsKey = useMemo(() => {
+    if (!teams || teams.length === 0) return '';
+    return teams
+      .map(t => `${t.id}:${t.pokepaste || ''}`)
+      .join('|');
+  }, [teams]);
+
+  useEffect(() => {
+    if (!teams || teams.length === 0) {
+      setTeamPokemon({});
+      return;
+    }
+
+    let cancelled = false;
+
+    const resolveAll = async () => {
+      setLoading(true);
+
+      const results = await Promise.allSettled(
+        teams.map(async (team) => {
+          if (!team.pokepaste) return { teamId: team.id, names: [] };
+          const names = await PokepasteService.getPokemonNames(team.pokepaste, 6);
+          return { teamId: team.id, names };
+        })
+      );
+
+      if (cancelled) return;
+
+      const pokemon = {};
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          pokemon[result.value.teamId] = result.value.names;
+        }
+      }
+
+      setTeamPokemon(pokemon);
+      setLoading(false);
+    };
+
+    resolveAll();
+
+    return () => { cancelled = true; };
+  }, [teamsKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return { teamPokemon, loading };
+};
+
+export default useTeamPokemon;


### PR DESCRIPTION
## Summary
- Adds a filter bar to the Team Dashboard (`HomePage`) with a regulation dropdown and tag-based search input
- Teams can be filtered by regulation (exact match) and by team name or pokemon composition (substring, case-insensitive, AND logic across tags)
- New `useTeamPokemon` hook batch-resolves pokepaste URLs to pokemon names, leveraging the existing 24-hour `PokepasteService` cache
- `TagInput` and `RegulationFilter` components are designed for reuse in other tabs (Replay, Game by Game, Match by Match, Matchup Planner)

## Test plan
- [x] Verify regulation dropdown populates dynamically from user's teams
- [x] Select a regulation — only matching teams shown; "All Regulations" shows everything
- [x] Type a team name substring + Enter — tag appears, grid filters to matching teams
- [x] Type a pokemon name (e.g. "flutter mane" or "flutter-mane") + Enter — teams with that pokemon shown
- [x] Combine regulation + search tags — both filters apply (AND logic)
- [x] Click X on a tag — filter updates immediately
- [ ] "Clear all filters" button resets both regulation and tags
- [x] "Showing X of Y teams" subtitle appears when filters are active
- [ ] Teams without pokepaste URLs still appear (not filtered out by pokemon search unless a pokemon tag is active)
- [x] Duplicate tags are prevented; Escape clears input without adding a tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)