### PR TITLE
Add opponent pokemon tag filtering to inner TeamPage tabs

### DIFF
--- a/frontend/src/components/GameByGameTab.jsx
+++ b/frontend/src/components/GameByGameTab.jsx
@@ -2,7 +2,9 @@
 import React, { useState } from 'react';
 import { Calendar, Filter, SortAsc, SortDesc } from 'lucide-react';
 import GameCard from './GameCard';
+import TagInput from './TagInput';
 import {formatTimeAgo} from "@/utils/timeUtils";
+import { matchesPokemonTags, getOpponentPokemonFromReplay } from '../utils/pokemonNameUtils';
 
 const GameByGameTab = ({ replays, onUpdateReplay }) => {
     const [sortBy, setSortBy] = useState('date');
@@ -11,6 +13,7 @@ const GameByGameTab = ({ replays, onUpdateReplay }) => {
     const [editingNoteId, setEditingNoteId] = useState(null);
     const [noteText, setNoteText] = useState('');
     const [savingNoteId, setSavingNoteId] = useState(null);
+    const [searchTags, setSearchTags] = useState([]);
 
     const startEditingNote = (replay) => {
         setEditingNoteId(replay.id);
@@ -56,10 +59,15 @@ const GameByGameTab = ({ replays, onUpdateReplay }) => {
         );
     }
 
-    // Filter replays based on result
+    // Filter replays based on result and pokemon tags
     const filteredReplays = replays.filter(replay => {
-        if (filterResult === 'all') return true;
-        return replay.result === filterResult;
+        if (searchTags.length > 0 && !matchesPokemonTags(getOpponentPokemonFromReplay(replay), searchTags)) {
+            return false;
+        }
+        if (filterResult !== 'all' && replay.result !== filterResult) {
+            return false;
+        }
+        return true;
     });
 
     // Sort replays
@@ -159,6 +167,14 @@ const GameByGameTab = ({ replays, onUpdateReplay }) => {
                 </div>
             </div>
 
+            <TagInput
+                tags={searchTags}
+                onAddTag={(tag) => setSearchTags(prev => [...prev, tag])}
+                onRemoveTag={(tag) => setSearchTags(prev => prev.filter(t => t !== tag))}
+                placeholder="Filter by opponent pokemon..."
+                className="mb-4"
+            />
+
             {/* Games List */}
             {sortedReplays.length === 0 ? (
                 <div className="text-center py-8">
@@ -168,6 +184,7 @@ const GameByGameTab = ({ replays, onUpdateReplay }) => {
                             setFilterResult('all');
                             setSortBy('date');
                             setSortOrder('desc');
+                            setSearchTags([]);
                         }}
                         className="mt-2 text-emerald-400 hover:text-emerald-300 text-sm"
                     >

--- a/frontend/src/utils/pokemonNameUtils.js
+++ b/frontend/src/utils/pokemonNameUtils.js
@@ -311,6 +311,40 @@ export const isValidPokemonName = (pokemonName) => {
 };
 
 /**
+ * AND-logic tag matcher: returns true if every tag matches at least one pokemon name
+ * (case-insensitive substring, matching both API format "flutter-mane" and display format "flutter mane")
+ * @param {string[]} pokemonNames - Array of cleaned pokemon names
+ * @param {string[]} tags - Array of search tags
+ * @returns {boolean} True if all tags match
+ */
+export const matchesPokemonTags = (pokemonNames, tags) => {
+    if (!tags || tags.length === 0) return true;
+    if (!pokemonNames || pokemonNames.length === 0) return false;
+
+    return tags.every(tag => {
+        const lowerTag = tag.toLowerCase();
+        return pokemonNames.some(name => {
+            const lowerName = name.toLowerCase();
+            // Match against API format (e.g. "flutter-mane") and display format (e.g. "flutter mane")
+            return lowerName.includes(lowerTag) || lowerName.replace(/-/g, ' ').includes(lowerTag);
+        });
+    });
+};
+
+/**
+ * Extracts opponent pokemon names from a replay's battleData
+ * @param {Object} replay - Replay object with battleData
+ * @returns {string[]} Array of cleaned pokemon names
+ */
+export const getOpponentPokemonFromReplay = (replay) => {
+    if (!replay?.battleData?.teams || !replay.battleData.opponentPlayer) {
+        return [];
+    }
+    const opponentTeam = replay.battleData.teams[replay.battleData.opponentPlayer] || [];
+    return opponentTeam.map(name => cleanPokemonName(name));
+};
+
+/**
  * Extract Pokemon names from a Pokepaste text block
  * @param {string} pokepasteText - Raw text from a Pokepaste
  * @returns {string[]} Array of cleaned Pokemon names


### PR DESCRIPTION
## Summary
- Adds opponent pokemon tag filtering (via `TagInput`) to **Replays**, **Game by Game**, **Match by Match**, and **Matchup Planner** tabs
- Shared utility functions `matchesPokemonTags` and `getOpponentPokemonFromReplay` in `pokemonNameUtils.js` for DRY AND-logic substring matching
- Copy button in Replays tab dynamically shows "Copy Filtered URLs" when filters are active and only copies filtered replay URLs
- Each tab shows filtered count, empty filtered state with clear-filters button, and composes with existing filters (e.g. result filter in Game by Game)

## Test plan
- [x] **ReplaysTab:** Add tag "flutter" → only replays vs opponents with Flutter Mane remain; copy button shows "Copy Filtered URLs"; remove tag → all replays restored
- [x] **GameByGameTab:** Add pokemon tag + set result to "Wins Only" → both filters compose; summary stats reflect combined filters; "Clear filters" resets both
- [x] **MatchByMatchTab:** Add tag → matches filtered; stats panel unchanged; clear filters works
- [x] **OpponentPlannerTab:** Add tag → opponent teams filtered by pokemon from their pokepaste; adding new opponent team still works while filter active
- [x] **Edge cases:** Replays without battleData not broken; empty tag input; duplicate tags prevented

🤖 Generated with [Claude Code](https://claude.com/claude-code)