### PR TITLE
feat: customizable color for matchup planner cards

### DIFF
--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/GamePlanController.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/GamePlanController.java
@@ -254,7 +254,7 @@ public class GamePlanController {
         log.info("Updating team: {} in game plan: {}", teamId, gamePlanId);
 
         GamePlanTeam updates = gamePlanMapper.toEntity(new GamePlanDTO.AddTeamRequest(
-                request.getPokepaste(), request.getNotes()));
+                request.getPokepaste(), request.getNotes(), request.getColor()));
         GamePlanTeam updatedTeam = gamePlanService.updateGamePlanTeam(teamId, gamePlanId, userId, updates);
         GamePlanDTO.GamePlanTeamResponse response = gamePlanMapper.toResponse(updatedTeam);
 

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/dto/GamePlanDTO.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/dto/GamePlanDTO.java
@@ -97,6 +97,8 @@ public class GamePlanDTO {
         private String pokepaste;
 
         private String notes;
+
+        private String color;
     }
 
     /**
@@ -108,6 +110,7 @@ public class GamePlanDTO {
     public static class UpdateTeamRequest {
         private String pokepaste;
         private String notes;
+        private String color;
     }
 
     /**
@@ -121,6 +124,7 @@ public class GamePlanDTO {
         private Long gamePlanId;
         private String pokepaste;
         private String notes;
+        private String color;
         private List<TeamCompositionDTO> compositions;
         private LocalDateTime createdAt;
     }

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/entities/GamePlanTeam.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/entities/GamePlanTeam.java
@@ -39,6 +39,9 @@ public class GamePlanTeam {
     @Column(columnDefinition = "TEXT")
     private String notes;
 
+    @Column(length = 20)
+    private String color;
+
     /**
      * Team compositions stored as JSON array.
      * Each composition contains: lead1, lead2, back1, back2, notes

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/GamePlanService.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/GamePlanService.java
@@ -271,6 +271,9 @@ public class GamePlanService {
         if (updates.getNotes() != null) {
             existingTeam.setNotes(updates.getNotes());
         }
+        if (updates.getColor() != null) {
+            existingTeam.setColor(updates.getColor());
+        }
 
         GamePlanTeam savedTeam = gamePlanTeamRepository.save(existingTeam);
         log.info("Game plan team updated successfully: {}", id);

--- a/frontend/src/components/cards/OpponentTeamCard.jsx
+++ b/frontend/src/components/cards/OpponentTeamCard.jsx
@@ -7,8 +7,18 @@ import PokemonDropdown from '../PokemonDropdown';
 import ConfirmationModal from '../ConfirmationModal';
 import PokepasteService from '../../services/PokepasteService';
 
-// Consistent blue color for team cards
-const TEAM_COLOR = { border: 'border-l-blue-500', bg: 'bg-blue-500/10' };
+// Color options for team cards
+const COLOR_OPTIONS = {
+  blue:   { border: 'border-l-blue-500',   bg: 'bg-blue-500',   ring: 'ring-blue-400' },
+  red:    { border: 'border-l-red-500',    bg: 'bg-red-500',    ring: 'ring-red-400' },
+  green:  { border: 'border-l-green-500',  bg: 'bg-green-500',  ring: 'ring-green-400' },
+  yellow: { border: 'border-l-yellow-500', bg: 'bg-yellow-500', ring: 'ring-yellow-400' },
+  purple: { border: 'border-l-purple-500', bg: 'bg-purple-500', ring: 'ring-purple-400' },
+  pink:   { border: 'border-l-pink-500',   bg: 'bg-pink-500',   ring: 'ring-pink-400' },
+  orange: { border: 'border-l-orange-500', bg: 'bg-orange-500', ring: 'ring-orange-400' },
+  teal:   { border: 'border-l-teal-500',   bg: 'bg-teal-500',   ring: 'ring-teal-400' },
+  gray:   { border: 'border-l-gray-500',   bg: 'bg-gray-500',   ring: 'ring-gray-400' },
+};
 
 /**
  * Card component for displaying an opponent team and its strategies
@@ -38,6 +48,8 @@ const OpponentTeamCard = ({
   const [showDeletePlanModal, setShowDeletePlanModal] = useState(false);
   const [deletingPlanIndex, setDeletingPlanIndex] = useState(null);
   const [isAddingPlan, setIsAddingPlan] = useState(false);
+
+  const teamColor = COLOR_OPTIONS[opponentTeam.color] || COLOR_OPTIONS.blue;
 
   // Fetch paste title when pokepaste URL changes
   useEffect(() => {
@@ -104,7 +116,7 @@ const OpponentTeamCard = ({
   const compositions = opponentTeam.compositions || [];
 
   return (
-    <div className={`bg-slate-800/50 border border-slate-700 rounded-lg border-l-4 ${TEAM_COLOR.border}`}>
+    <div className={`bg-slate-800/50 border border-slate-700 rounded-lg border-l-4 ${teamColor.border}`}>
       {/* Header with Team Info and Notes */}
       <div className="p-4 bg-slate-700/30 border-b border-slate-700 rounded-t-lg">
         <div className="flex items-start gap-4">
@@ -171,6 +183,22 @@ const OpponentTeamCard = ({
                     rows={2}
                     placeholder="Add notes about this matchup..."
                   />
+                </div>
+                <div>
+                  <label className="text-xs text-gray-400 mb-1 block">Card Color</label>
+                  <div className="flex gap-1.5">
+                    {Object.entries(COLOR_OPTIONS).map(([key, val]) => (
+                      <button
+                        key={key}
+                        type="button"
+                        onClick={() => onUpdateNotes(opponentTeam.id, { color: key })}
+                        className={`w-5 h-5 rounded ${val.bg} hover:scale-110 transition-transform ${
+                          (opponentTeam.color || 'blue') === key ? 'ring-2 ring-white ring-offset-1 ring-offset-slate-700' : ''
+                        }`}
+                        title={key}
+                      />
+                    ))}
+                  </div>
                 </div>
                 <div className="flex gap-2">
                   <button

--- a/frontend/src/components/modals/AddOpponentTeamModal.jsx
+++ b/frontend/src/components/modals/AddOpponentTeamModal.jsx
@@ -4,6 +4,18 @@ import { createPortal } from 'react-dom';
 import { X, Link as LinkIcon, AlertCircle } from 'lucide-react';
 import PokepasteService from '../../services/PokepasteService';
 
+const COLOR_CHOICES = [
+  { key: 'blue',   bg: 'bg-blue-500' },
+  { key: 'red',    bg: 'bg-red-500' },
+  { key: 'green',  bg: 'bg-green-500' },
+  { key: 'yellow', bg: 'bg-yellow-500' },
+  { key: 'purple', bg: 'bg-purple-500' },
+  { key: 'pink',   bg: 'bg-pink-500' },
+  { key: 'orange', bg: 'bg-orange-500' },
+  { key: 'teal',   bg: 'bg-teal-500' },
+  { key: 'gray',   bg: 'bg-gray-500' },
+];
+
 /**
  * Modal for adding a new opponent team
  * @param {Function} onClose - Callback to close the modal
@@ -13,6 +25,7 @@ const AddOpponentTeamModal = ({ onClose, onSubmit }) => {
   const [formData, setFormData] = useState({
     pokepaste: '',
     notes: '',
+    color: 'blue',
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -59,6 +72,7 @@ const AddOpponentTeamModal = ({ onClose, onSubmit }) => {
       const teamData = {
         pokepaste: formData.pokepaste.trim(),
         notes: formData.notes.trim() || '',
+        color: formData.color,
       };
 
       await onSubmit(teamData);
@@ -129,6 +143,27 @@ const AddOpponentTeamModal = ({ onClose, onSubmit }) => {
             <p className="text-xs text-gray-400 mt-1">
               Tip: Start with the player's name for easy identification
             </p>
+          </div>
+
+          {/* Card Color */}
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-2">
+              Card Color
+            </label>
+            <div className="flex gap-2">
+              {COLOR_CHOICES.map(({ key, bg }) => (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => handleInputChange('color', key)}
+                  className={`w-6 h-6 rounded ${bg} hover:scale-110 transition-transform ${
+                    formData.color === key ? 'ring-2 ring-white ring-offset-1 ring-offset-slate-800' : ''
+                  }`}
+                  title={key}
+                  disabled={loading}
+                />
+              ))}
+            </div>
           </div>
 
           {/* Action Buttons */}

--- a/frontend/src/hooks/useOpponentTeams.js
+++ b/frontend/src/hooks/useOpponentTeams.js
@@ -32,6 +32,7 @@ export const useOpponentTeams = (teamId, options = {}) => {
     gamePlanId: team.gamePlanId,
     pokepaste: team.pokepaste,
     notes: team.notes || '',
+    color: team.color || 'blue',
     compositions: team.compositions || [],
     createdAt: team.createdAt,
   });
@@ -90,6 +91,7 @@ export const useOpponentTeams = (teamId, options = {}) => {
       const newTeam = await gamePlanApi.addTeam(gamePlanId, {
         pokepaste: data.pokepaste,
         notes: data.notes || '',
+        color: data.color,
       });
 
       const transformedTeam = transformTeam(newTeam);
@@ -114,6 +116,7 @@ export const useOpponentTeams = (teamId, options = {}) => {
       const updatedTeam = await gamePlanApi.updateTeam(gamePlanId, opponentTeamId, {
         pokepaste: updates.pokepaste,
         notes: updates.notes,
+        color: updates.color,
       });
 
       const transformedTeam = transformTeam(updatedTeam);


### PR DESCRIPTION
## Summary
- Add a `color` field to `GamePlanTeam` entity and DTOs, allowing each opponent team card to have a customizable border color
- Add color picker (9 options: blue, red, green, yellow, purple, pink, orange, teal, gray) inside the card edit mode and the Add Matchup Team modal
- Color persists via backend and defaults to blue for existing cards

## Test plan
- [x] Open Matchup Planner tab, create a new matchup team — verify color picker appears in modal and defaults to blue
- [x] Select a different color in the modal — verify the created card has the chosen border color
- [x] Click Edit on an existing card — verify color picker row appears in edit form
- [x] Click a color swatch — verify border color changes immediately
- [x] Refresh the page — verify chosen colors persist from the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)