### PR TITLE
Add Home Page dashboard, modals, and sidebar improvements (Phase 3)

### DIFF
--- a/frontend-rewrite/src/components/form/RegulationFilter.tsx
+++ b/frontend-rewrite/src/components/form/RegulationFilter.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+interface RegulationFilterProps {
+  value: string;
+  onChange: (value: string) => void;
+  regulations: string[];
+}
+
+function shortRegulation(reg: string): string {
+  const match = reg.match(/Regulation\s+([A-Z])$/);
+  return match ? `Reg ${match[1]}` : reg;
+}
+
+const RegulationFilter: React.FC<RegulationFilterProps> = ({
+  value,
+  onChange,
+  regulations,
+}) => {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className={`h-11 w-full appearance-none rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 pr-11 text-sm shadow-theme-xs focus:border-brand-300 focus:outline-hidden focus:ring-3 focus:ring-brand-500/10 dark:border-gray-700 dark:bg-gray-900 dark:focus:border-brand-800 ${
+        value ? "text-gray-800 dark:text-white/90" : "text-gray-400 dark:text-gray-400"
+      }`}
+    >
+      <option value="" className="text-gray-700 dark:bg-gray-900 dark:text-gray-400">
+        All Regulations
+      </option>
+      {regulations.map((reg) => (
+        <option
+          key={reg}
+          value={reg}
+          className="text-gray-700 dark:bg-gray-900 dark:text-gray-400"
+        >
+          {shortRegulation(reg)}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+export default RegulationFilter;

--- a/frontend-rewrite/src/components/form/SearchInput.tsx
+++ b/frontend-rewrite/src/components/form/SearchInput.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Search } from "lucide-react";
+
+interface SearchInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+const SearchInput: React.FC<SearchInputProps> = ({
+  value,
+  onChange,
+  placeholder = "Search...",
+}) => {
+  return (
+    <div className="relative">
+      <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 dark:text-gray-500" />
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="h-11 w-full rounded-lg border border-gray-300 bg-transparent pl-10 pr-4 py-2.5 text-sm shadow-theme-xs placeholder:text-gray-400 focus:border-brand-300 focus:outline-hidden focus:ring-3 focus:ring-brand-500/10 dark:border-gray-700 dark:bg-white/[0.03] dark:text-white/90 dark:placeholder:text-white/30 dark:focus:border-brand-800"
+      />
+    </div>
+  );
+};
+
+export default SearchInput;

--- a/frontend-rewrite/src/components/form/TagInput.tsx
+++ b/frontend-rewrite/src/components/form/TagInput.tsx
@@ -1,0 +1,75 @@
+import React, { useState, useRef } from "react";
+import { X } from "lucide-react";
+
+interface TagInputProps {
+  tags: string[];
+  onTagsChange: (tags: string[]) => void;
+  placeholder?: string;
+}
+
+const TagInput: React.FC<TagInputProps> = ({
+  tags,
+  onTagsChange,
+  placeholder = "Type and press Enter...",
+}) => {
+  const [input, setInput] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const addTag = (value: string) => {
+    const trimmed = value.trim();
+    if (trimmed && !tags.includes(trimmed)) {
+      onTagsChange([...tags, trimmed]);
+    }
+    setInput("");
+  };
+
+  const removeTag = (index: number) => {
+    onTagsChange(tags.filter((_, i) => i !== index));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      addTag(input);
+    } else if (e.key === "Backspace" && input === "" && tags.length > 0) {
+      removeTag(tags.length - 1);
+    }
+  };
+
+  return (
+    <div
+      className="flex min-h-[44px] flex-wrap items-center gap-1.5 rounded-lg border border-gray-300 bg-transparent px-3 py-2 shadow-theme-xs focus-within:border-brand-300 focus-within:ring-3 focus-within:ring-brand-500/10 dark:border-gray-700 dark:bg-white/[0.03] dark:focus-within:border-brand-800"
+      onClick={() => inputRef.current?.focus()}
+    >
+      {tags.map((tag, i) => (
+        <span
+          key={tag}
+          className="inline-flex items-center gap-1 rounded-md bg-brand-50 px-2 py-0.5 text-sm font-medium text-brand-700 dark:bg-brand-500/10 dark:text-brand-400"
+        >
+          {tag}
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              removeTag(i);
+            }}
+            className="text-brand-400 hover:text-brand-600 dark:text-brand-500 dark:hover:text-brand-300"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </span>
+      ))}
+      <input
+        ref={inputRef}
+        type="text"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={tags.length === 0 ? placeholder : ""}
+        className="min-w-[120px] flex-1 bg-transparent text-sm text-gray-800 placeholder:text-gray-400 focus:outline-none dark:text-white/90 dark:placeholder:text-white/30"
+      />
+    </div>
+  );
+};
+
+export default TagInput;

--- a/frontend-rewrite/src/components/header/UserDropdown.tsx
+++ b/frontend-rewrite/src/components/header/UserDropdown.tsx
@@ -28,12 +28,6 @@ export default function UserDropdown() {
         onClick={toggleDropdown}
         className="flex items-center text-gray-700 dropdown-toggle dark:text-gray-400"
       >
-        <span className="mr-3 flex h-11 w-11 items-center justify-center overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
-          <span className="text-sm font-medium text-gray-600 dark:text-gray-300">
-            {user?.username?.charAt(0).toUpperCase() || "U"}
-          </span>
-        </span>
-
         <span className="block mr-1 font-medium text-theme-sm">
           {user?.username || "User"}
         </span>

--- a/frontend-rewrite/src/components/modals/EditTeamModal.tsx
+++ b/frontend-rewrite/src/components/modals/EditTeamModal.tsx
@@ -1,0 +1,209 @@
+import React, { useState, useEffect, useRef } from "react";
+import { Modal } from "../ui/modal";
+import Label from "../form/Label";
+import TagInput from "../form/TagInput";
+import PokemonTeam from "../pokemon/PokemonTeam";
+import { teamApi } from "../../services/api/teamApi";
+import * as pokepasteService from "../../services/pokepasteService";
+import type { Team } from "../../types";
+
+interface EditTeamModalProps {
+  isOpen: boolean;
+  team: Team;
+  onClose: () => void;
+  onUpdated: (updatedTeam: Team) => void;
+}
+
+const REGULATIONS = [
+  "VGC 2025 Regulation H",
+  "VGC 2025 Regulation G",
+  "VGC 2025 Regulation F",
+  "VGC 2025 Regulation E",
+  "VGC 2025 Regulation D",
+  "VGC 2025 Regulation C",
+  "VGC 2025 Regulation B",
+  "VGC 2025 Regulation A",
+];
+
+function shortRegulation(reg: string): string {
+  const match = reg.match(/Regulation\s+([A-Z])$/);
+  return match ? `Reg ${match[1]}` : reg;
+}
+
+const EditTeamModal: React.FC<EditTeamModalProps> = ({ isOpen, team, onClose, onUpdated }) => {
+  const [name, setName] = useState("");
+  const [pokepaste, setPokepaste] = useState("");
+  const [regulation, setRegulation] = useState("");
+  const [showdownUsernames, setShowdownUsernames] = useState<string[]>([]);
+  const [previewNames, setPreviewNames] = useState<string[] | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+
+  // Populate form when modal opens or team changes
+  useEffect(() => {
+    if (isOpen && team) {
+      setName(team.name);
+      setPokepaste(team.pokepaste || "");
+      setRegulation(team.regulation || "");
+      setShowdownUsernames(team.showdownUsernames || []);
+      setPreviewNames(null);
+      setError(null);
+    }
+  }, [isOpen, team]);
+
+  // Debounced pokepaste preview
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    if (!pokepaste || !pokepasteService.isValidPokepasteUrl(pokepaste)) {
+      setPreviewNames(null);
+      return;
+    }
+
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const names = await pokepasteService.getPokemonNames(pokepaste, 6);
+        setPreviewNames(names);
+      } catch {
+        setPreviewNames(null);
+      }
+    }, 600);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [pokepaste]);
+
+  const isValidUrl = pokepaste === "" || pokepasteService.isValidPokepasteUrl(pokepaste);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    if (pokepaste && !pokepasteService.isValidPokepasteUrl(pokepaste)) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const updated = await teamApi.update(team.id, {
+        name: name.trim(),
+        pokepaste: pokepaste.trim(),
+        regulation,
+        showdownUsernames,
+      });
+      onUpdated(updated);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update team");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const canSubmit = name.trim() && !submitting && isValidUrl;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} className="max-w-lg p-6 sm:p-8">
+      <h2 className="mb-6 text-xl font-semibold text-gray-800 dark:text-white/90">
+        Edit Team
+      </h2>
+
+      <form onSubmit={handleSubmit} className="space-y-5">
+        {/* Team Name */}
+        <div>
+          <Label htmlFor="edit-team-name">Team Name</Label>
+          <input
+            id="edit-team-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="My Team"
+            className="h-11 w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 text-sm shadow-theme-xs placeholder:text-gray-400 focus:border-brand-300 focus:outline-hidden focus:ring-3 focus:ring-brand-500/10 dark:border-gray-700 dark:bg-white/[0.03] dark:text-white/90 dark:placeholder:text-white/30 dark:focus:border-brand-800"
+          />
+        </div>
+
+        {/* Pokepaste URL */}
+        <div>
+          <Label htmlFor="edit-pokepaste-url">Pokepaste URL</Label>
+          <input
+            id="edit-pokepaste-url"
+            type="text"
+            value={pokepaste}
+            onChange={(e) => setPokepaste(e.target.value)}
+            placeholder="https://pokepast.es/..."
+            className={`h-11 w-full rounded-lg border bg-transparent px-4 py-2.5 text-sm shadow-theme-xs placeholder:text-gray-400 focus:outline-hidden focus:ring-3 dark:bg-white/[0.03] dark:text-white/90 dark:placeholder:text-white/30 ${
+              !isValidUrl
+                ? "border-red-400 focus:border-red-400 focus:ring-red-500/10 dark:border-red-500"
+                : "border-gray-300 focus:border-brand-300 focus:ring-brand-500/10 dark:border-gray-700 dark:focus:border-brand-800"
+            }`}
+          />
+          {!isValidUrl && (
+            <p className="mt-1 text-xs text-red-500">Enter a valid pokepast.es or pokebin.com URL</p>
+          )}
+          {previewNames && previewNames.length > 0 && (
+            <div className="mt-3">
+              <PokemonTeam pokemonNames={previewNames} size="sm" />
+            </div>
+          )}
+        </div>
+
+        {/* Regulation */}
+        <div>
+          <Label htmlFor="edit-regulation">Regulation</Label>
+          <select
+            id="edit-regulation"
+            value={regulation}
+            onChange={(e) => setRegulation(e.target.value)}
+            className={`h-11 w-full appearance-none rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 pr-11 text-sm shadow-theme-xs focus:border-brand-300 focus:outline-hidden focus:ring-3 focus:ring-brand-500/10 dark:border-gray-700 dark:bg-gray-900 dark:focus:border-brand-800 ${
+              regulation ? "text-gray-800 dark:text-white/90" : "text-gray-400 dark:text-gray-400"
+            }`}
+          >
+            <option value="">Select regulation (optional)</option>
+            {REGULATIONS.map((reg) => (
+              <option key={reg} value={reg} className="text-gray-700 dark:bg-gray-900 dark:text-gray-400">
+                {shortRegulation(reg)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Showdown Usernames */}
+        <div>
+          <Label>Showdown Usernames</Label>
+          <TagInput
+            tags={showdownUsernames}
+            onTagsChange={setShowdownUsernames}
+            placeholder="Type a username and press Enter..."
+          />
+        </div>
+
+        {/* Error */}
+        {error && (
+          <p className="text-sm text-red-500">{error}</p>
+        )}
+
+        {/* Submit */}
+        <div className="flex justify-end gap-3 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-medium text-white hover:bg-brand-600 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {submitting ? "Saving..." : "Save Changes"}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default EditTeamModal;

--- a/frontend-rewrite/src/components/modals/ExportTeamModal.tsx
+++ b/frontend-rewrite/src/components/modals/ExportTeamModal.tsx
@@ -1,0 +1,250 @@
+import React, { useState, useEffect } from "react";
+import { Copy, Check, Download } from "lucide-react";
+import { Modal } from "../ui/modal";
+import { exportApi } from "../../services/api/exportApi";
+import type { Team, ExportOptions } from "../../types";
+
+interface ExportTeamModalProps {
+  isOpen: boolean;
+  team: Team;
+  onClose: () => void;
+}
+
+const ExportTeamModal: React.FC<ExportTeamModalProps> = ({ isOpen, team, onClose }) => {
+  const [options, setOptions] = useState<ExportOptions & { includeTeamMembers?: boolean }>({
+    includeReplays: true,
+    includeReplayNotes: true,
+    includeMatchNotes: true,
+    includeOpponentPlans: true,
+    includeTeamMembers: true,
+  });
+  const [exportData, setExportData] = useState<Record<string, any> | null>(null);
+  const [shareCode, setShareCode] = useState<{ code: string; isExisting: boolean } | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [generatingCode, setGeneratingCode] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copiedCode, setCopiedCode] = useState(false);
+  const [copiedJson, setCopiedJson] = useState(false);
+
+  // Fetch preview when modal opens or options change
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+
+    const fetchPreview = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await exportApi.previewExport(team.id, options);
+        if (!cancelled) setExportData(data);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to generate preview");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    fetchPreview();
+    return () => { cancelled = true; };
+  }, [isOpen, team.id, options]);
+
+  // Reset on open
+  useEffect(() => {
+    if (isOpen) {
+      setShareCode(null);
+      setCopiedCode(false);
+      setCopiedJson(false);
+      setError(null);
+    }
+  }, [isOpen]);
+
+  const toggleOption = (key: string) => {
+    setOptions((prev) => ({ ...prev, [key]: !prev[key as keyof typeof prev] }));
+    setShareCode(null);
+  };
+
+  const summary = exportData
+    ? {
+        replays: (exportData.replays as any[])?.length || 0,
+        matches: (exportData.matches as any[])?.length || 0,
+        opponentPlans: (exportData.opponentPlans as any[])?.length || 0,
+        pokemonNotes: (exportData.team as any)?.teamMembers?.length || 0,
+      }
+    : null;
+
+  const handleGenerateCode = async () => {
+    setGeneratingCode(true);
+    setError(null);
+    try {
+      const result = await exportApi.generateCode(team.id, options);
+      setShareCode({ code: result.code, isExisting: result.isExisting });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to generate code";
+      setError(msg.includes("Rate limit") ? "Daily limit reached (10 codes/day)." : msg);
+    } finally {
+      setGeneratingCode(false);
+    }
+  };
+
+  const handleCopyCode = async () => {
+    if (!shareCode) return;
+    await navigator.clipboard.writeText(shareCode.code);
+    setCopiedCode(true);
+    setTimeout(() => setCopiedCode(false), 2000);
+  };
+
+  const handleCopyJson = async () => {
+    if (!exportData) return;
+    await navigator.clipboard.writeText(JSON.stringify(exportData, null, 2));
+    setCopiedJson(true);
+    setTimeout(() => setCopiedJson(false), 2000);
+  };
+
+  const handleDownload = () => {
+    if (!exportData) return;
+    const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${team.name.replace(/[^a-z0-9]/gi, "_")}_export.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  const checkboxItems = [
+    { key: "includeReplays", label: "Include Replays", indent: false },
+    { key: "includeReplayNotes", label: "Include Replay Notes", indent: true, parent: "includeReplays" },
+    { key: "includeMatchNotes", label: "Include Match Notes", indent: true, parent: "includeReplays" },
+    { key: "includeOpponentPlans", label: "Include Opponent Plans", indent: false },
+    { key: "includeTeamMembers", label: "Include Pokemon Notes", indent: false },
+  ];
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} className="max-w-xl p-6 sm:p-8">
+      <h2 className="mb-6 text-xl font-semibold text-gray-800 dark:text-white/90">
+        Export Team
+      </h2>
+
+      <div className="space-y-5">
+        {/* Options */}
+        <div className="space-y-2">
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-400">Options</span>
+          {checkboxItems.map((item) => {
+            const disabled = item.parent ? !options[item.parent as keyof typeof options] : false;
+            return (
+              <label
+                key={item.key}
+                className={`flex items-center gap-2.5 cursor-pointer ${item.indent ? "ml-6" : ""} ${disabled ? "opacity-50" : ""}`}
+              >
+                <input
+                  type="checkbox"
+                  checked={!!options[item.key as keyof typeof options]}
+                  onChange={() => toggleOption(item.key)}
+                  disabled={disabled}
+                  className="h-4 w-4 rounded border-gray-300 text-brand-500 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800"
+                />
+                <span className="text-sm text-gray-700 dark:text-gray-300">{item.label}</span>
+              </label>
+            );
+          })}
+        </div>
+
+        {/* Summary */}
+        {summary && !loading && (
+          <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/50">
+            <span className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-400">Summary</span>
+            <div className="grid grid-cols-4 gap-2 text-center">
+              {[
+                { label: "Replays", value: summary.replays, color: "text-emerald-600 dark:text-emerald-400" },
+                { label: "Matches", value: summary.matches, color: "text-blue-600 dark:text-blue-400" },
+                { label: "Plans", value: summary.opponentPlans, color: "text-purple-600 dark:text-purple-400" },
+                { label: "Notes", value: summary.pokemonNotes, color: "text-amber-600 dark:text-amber-400" },
+              ].map((c) => (
+                <div key={c.label}>
+                  <div className={`text-lg font-bold ${c.color}`}>{c.value}</div>
+                  <div className="text-xs text-gray-500 dark:text-gray-400">{c.label}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {loading && (
+          <div className="rounded-lg border border-gray-200 bg-gray-50 p-6 text-center dark:border-gray-700 dark:bg-gray-800/50">
+            <div className="mx-auto h-5 w-5 animate-spin rounded-full border-2 border-gray-300 border-t-brand-500" />
+          </div>
+        )}
+
+        {/* Share Code Result */}
+        {shareCode && (
+          <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-4 dark:border-emerald-800 dark:bg-emerald-900/20">
+            <span className="mb-2 block text-sm font-medium text-emerald-700 dark:text-emerald-400">
+              Share Code
+            </span>
+            <div className="flex items-center gap-3">
+              <div className="flex-1 rounded-lg bg-white px-4 py-2.5 text-center font-mono text-xl tracking-widest text-emerald-600 dark:bg-gray-800 dark:text-emerald-400">
+                {shareCode.code}
+              </div>
+              <button
+                type="button"
+                onClick={handleCopyCode}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-500 px-3 py-2.5 text-sm font-medium text-white hover:bg-emerald-600"
+              >
+                {copiedCode ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                {copiedCode ? "Copied" : "Copy"}
+              </button>
+            </div>
+            {shareCode.isExisting && (
+              <p className="mt-1.5 text-xs text-emerald-600/70 dark:text-emerald-400/60">
+                Using existing code (no changes since last export)
+              </p>
+            )}
+          </div>
+        )}
+
+        {error && <p className="text-sm text-red-500">{error}</p>}
+
+        {/* Actions */}
+        <div className="flex flex-wrap gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            Close
+          </button>
+          <button
+            type="button"
+            onClick={handleCopyJson}
+            disabled={!exportData || loading}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            {copiedJson ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+            {copiedJson ? "Copied" : "Copy JSON"}
+          </button>
+          <button
+            type="button"
+            onClick={handleDownload}
+            disabled={!exportData || loading}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            <Download className="h-4 w-4" />
+            Download
+          </button>
+          <button
+            type="button"
+            onClick={handleGenerateCode}
+            disabled={!exportData || loading || generatingCode}
+            className="ml-auto rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-medium text-white hover:bg-brand-600 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {generatingCode ? "Generating..." : "Generate Share Code"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default ExportTeamModal;

--- a/frontend-rewrite/src/components/modals/ImportTeamModal.tsx
+++ b/frontend-rewrite/src/components/modals/ImportTeamModal.tsx
@@ -1,0 +1,350 @@
+import React, { useState, useEffect, useRef } from "react";
+import { Modal } from "../ui/modal";
+import { exportApi } from "../../services/api/exportApi";
+import PokemonTeam from "../pokemon/PokemonTeam";
+
+interface ImportTeamModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onImported: () => void;
+}
+
+type Tab = "code" | "json";
+
+interface PreviewData {
+  teamName: string;
+  pokepaste?: string;
+  replays: number;
+  matches: number;
+  opponentPlans: number;
+  pokemonNotes: number;
+}
+
+function extractPreview(data: Record<string, any>): PreviewData {
+  const team = data.team || data;
+  return {
+    teamName: team.name || data.teamName || "Unknown Team",
+    pokepaste: team.pokepaste || data.pokepaste,
+    replays: data.replays?.length || 0,
+    matches: data.matches?.length || 0,
+    opponentPlans: data.opponentPlans?.length || 0,
+    pokemonNotes: team.teamMembers?.length || 0,
+  };
+}
+
+function PreviewPanel({ data }: { data: PreviewData }) {
+  const counts = [
+    { label: "Replays", value: data.replays, color: "text-emerald-600 dark:text-emerald-400" },
+    { label: "Matches", value: data.matches, color: "text-blue-600 dark:text-blue-400" },
+    { label: "Plans", value: data.opponentPlans, color: "text-purple-600 dark:text-purple-400" },
+    { label: "Notes", value: data.pokemonNotes, color: "text-amber-600 dark:text-amber-400" },
+  ];
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/50">
+      <p className="mb-3 font-medium text-gray-800 dark:text-white/90">
+        {data.teamName}
+      </p>
+      {data.pokepaste && (
+        <div className="mb-3">
+          <PokemonTeam pokepasteUrl={data.pokepaste} size="sm" />
+        </div>
+      )}
+      <div className="grid grid-cols-4 gap-2 text-center">
+        {counts.map((c) => (
+          <div key={c.label}>
+            <div className={`text-lg font-bold ${c.color}`}>{c.value}</div>
+            <div className="text-xs text-gray-500 dark:text-gray-400">{c.label}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const ImportTeamModal: React.FC<ImportTeamModalProps> = ({ isOpen, onClose, onImported }) => {
+  const [tab, setTab] = useState<Tab>("code");
+
+  // Share code state
+  const [code, setCode] = useState("");
+  const [preview, setPreview] = useState<PreviewData | null>(null);
+  const [previewing, setPreviewing] = useState(false);
+
+  // JSON state
+  const [jsonText, setJsonText] = useState("");
+  const [jsonPreview, setJsonPreview] = useState<PreviewData | null>(null);
+  const [jsonValidating, setJsonValidating] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Shared state
+  const [importing, setImporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setTab("code");
+      setCode("");
+      setPreview(null);
+      setPreviewing(false);
+      setJsonText("");
+      setJsonPreview(null);
+      setJsonValidating(false);
+      setImporting(false);
+      setError(null);
+    }
+  }, [isOpen]);
+
+  // Reset state when switching tabs
+  useEffect(() => {
+    setError(null);
+    setPreview(null);
+    setJsonPreview(null);
+  }, [tab]);
+
+  const handlePreview = async () => {
+    if (!code.trim()) return;
+    setPreviewing(true);
+    setError(null);
+    setPreview(null);
+
+    try {
+      const data = await exportApi.getByCode(code.trim());
+      setPreview(extractPreview(data));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Invalid share code");
+    } finally {
+      setPreviewing(false);
+    }
+  };
+
+  const handleImportCode = async () => {
+    if (!code.trim()) return;
+    setImporting(true);
+    setError(null);
+
+    try {
+      const result = await exportApi.importFromCode(code.trim());
+      if (result.success) {
+        onImported();
+        onClose();
+      } else {
+        setError(result.error || "Import failed");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to import");
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setError(null);
+    setJsonPreview(null);
+
+    const reader = new FileReader();
+    reader.onload = (evt) => {
+      setJsonText(evt.target?.result as string);
+    };
+    reader.onerror = () => {
+      setError("Failed to read file");
+    };
+    reader.readAsText(file);
+  };
+
+  const handleValidateJson = () => {
+    if (!jsonText.trim()) return;
+    setJsonValidating(true);
+    setError(null);
+    setJsonPreview(null);
+
+    try {
+      const parsed = JSON.parse(jsonText.trim());
+      if (!parsed.team && !parsed.name && !parsed.teamName) {
+        setError("Invalid export format: missing team data");
+        return;
+      }
+      setJsonPreview(extractPreview(parsed));
+    } catch {
+      setError("Invalid JSON format");
+    } finally {
+      setJsonValidating(false);
+    }
+  };
+
+  const handleImportJson = async () => {
+    if (!jsonText.trim()) return;
+    setImporting(true);
+    setError(null);
+
+    try {
+      const result = await exportApi.importFromJson(jsonText.trim());
+      if (result.success) {
+        onImported();
+        onClose();
+      } else {
+        setError(result.error || "Import failed");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to import JSON");
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} className="max-w-lg p-6 sm:p-8">
+      <h2 className="mb-6 text-xl font-semibold text-gray-800 dark:text-white/90">
+        Import Team
+      </h2>
+
+      {/* Tab Toggle */}
+      <div className="mb-6 flex gap-1 rounded-lg bg-gray-100 p-1 dark:bg-gray-800">
+        <button
+          type="button"
+          onClick={() => setTab("code")}
+          className={`flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+            tab === "code"
+              ? "bg-white text-gray-800 shadow-sm dark:bg-gray-700 dark:text-white"
+              : "text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+          }`}
+        >
+          Share Code
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab("json")}
+          className={`flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+            tab === "json"
+              ? "bg-white text-gray-800 shadow-sm dark:bg-gray-700 dark:text-white"
+              : "text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+          }`}
+        >
+          JSON
+        </button>
+      </div>
+
+      {/* Share Code Tab */}
+      {tab === "code" && (
+        <div className="space-y-4">
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={code}
+              onChange={(e) => {
+                setCode(e.target.value);
+                setPreview(null);
+              }}
+              placeholder="Enter share code..."
+              className="h-11 flex-1 rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 text-sm uppercase shadow-theme-xs placeholder:normal-case placeholder:text-gray-400 focus:border-brand-300 focus:outline-hidden focus:ring-3 focus:ring-brand-500/10 dark:border-gray-700 dark:bg-white/[0.03] dark:text-white/90 dark:placeholder:text-white/30 dark:focus:border-brand-800"
+            />
+            <button
+              type="button"
+              onClick={handlePreview}
+              disabled={!code.trim() || previewing}
+              className="rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+            >
+              {previewing ? "Loading..." : "Preview"}
+            </button>
+          </div>
+
+          {preview && <PreviewPanel data={preview} />}
+
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleImportCode}
+              disabled={!code.trim() || importing}
+              className="rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-medium text-white hover:bg-brand-600 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {importing ? "Importing..." : "Import"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* JSON Tab */}
+      {tab === "json" && (
+        <div className="space-y-4">
+          <div>
+            <div className="flex items-center justify-between mb-1.5">
+              <span className="text-sm font-medium text-gray-700 dark:text-gray-400">
+                Paste JSON
+              </span>
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="text-xs font-medium text-brand-500 hover:text-brand-600 dark:text-brand-400 dark:hover:text-brand-300"
+              >
+                or load from file
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".json"
+                onChange={handleFileChange}
+                className="hidden"
+              />
+            </div>
+            <textarea
+              value={jsonText}
+              onChange={(e) => {
+                setJsonText(e.target.value);
+                setJsonPreview(null);
+              }}
+              placeholder='{"version": "1.0", "team": {...}}'
+              rows={6}
+              className="w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 font-mono text-sm shadow-theme-xs placeholder:text-gray-400 focus:border-brand-300 focus:outline-hidden focus:ring-3 focus:ring-brand-500/10 dark:border-gray-700 dark:bg-white/[0.03] dark:text-white/90 dark:placeholder:text-white/30 dark:focus:border-brand-800"
+            />
+          </div>
+
+          <button
+            type="button"
+            onClick={handleValidateJson}
+            disabled={!jsonText.trim() || jsonValidating}
+            className="rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            {jsonValidating ? "Validating..." : "Validate"}
+          </button>
+
+          {jsonPreview && <PreviewPanel data={jsonPreview} />}
+
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleImportJson}
+              disabled={!jsonText.trim() || importing}
+              className="rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-medium text-white hover:bg-brand-600 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {importing ? "Importing..." : "Import"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Error */}
+      {error && (
+        <p className="mt-4 text-sm text-red-500">{error}</p>
+      )}
+    </Modal>
+  );
+};
+
+export default ImportTeamModal;

--- a/frontend-rewrite/src/components/modals/NewTeamModal.tsx
+++ b/frontend-rewrite/src/components/modals/NewTeamModal.tsx
@@ -1,0 +1,206 @@
+import React, { useState, useEffect, useRef } from "react";
+import { Modal } from "../ui/modal";
+import Label from "../form/Label";
+import TagInput from "../form/TagInput";
+import PokemonTeam from "../pokemon/PokemonTeam";
+import { teamApi } from "../../services/api/teamApi";
+import * as pokepasteService from "../../services/pokepasteService";
+
+interface NewTeamModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+const REGULATIONS = [
+  "VGC 2025 Regulation H",
+  "VGC 2025 Regulation G",
+  "VGC 2025 Regulation F",
+  "VGC 2025 Regulation E",
+  "VGC 2025 Regulation D",
+  "VGC 2025 Regulation C",
+  "VGC 2025 Regulation B",
+  "VGC 2025 Regulation A",
+];
+
+function shortRegulation(reg: string): string {
+  const match = reg.match(/Regulation\s+([A-Z])$/);
+  return match ? `Reg ${match[1]}` : reg;
+}
+
+const NewTeamModal: React.FC<NewTeamModalProps> = ({ isOpen, onClose, onCreated }) => {
+  const [name, setName] = useState("");
+  const [pokepaste, setPokepaste] = useState("");
+  const [regulation, setRegulation] = useState("");
+  const [showdownUsernames, setShowdownUsernames] = useState<string[]>([]);
+  const [previewNames, setPreviewNames] = useState<string[] | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+
+  // Reset form when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setName("");
+      setPokepaste("");
+      setRegulation("");
+      setShowdownUsernames([]);
+      setPreviewNames(null);
+      setError(null);
+    }
+  }, [isOpen]);
+
+  // Debounced pokepaste preview
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    if (!pokepaste || !pokepasteService.isValidPokepasteUrl(pokepaste)) {
+      setPreviewNames(null);
+      return;
+    }
+
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const names = await pokepasteService.getPokemonNames(pokepaste, 6);
+        setPreviewNames(names);
+      } catch {
+        setPreviewNames(null);
+      }
+    }, 600);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [pokepaste]);
+
+  const isValidUrl = pokepaste === "" || pokepasteService.isValidPokepasteUrl(pokepaste);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !pokepaste.trim() || !pokepasteService.isValidPokepasteUrl(pokepaste)) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      await teamApi.create({
+        name: name.trim(),
+        pokepaste: pokepaste.trim(),
+        regulation: regulation || undefined,
+        showdownUsernames: showdownUsernames.length > 0 ? showdownUsernames : undefined,
+      });
+      onCreated();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create team");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const canSubmit = name.trim() && pokepaste.trim() && pokepasteService.isValidPokepasteUrl(pokepaste) && !submitting;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} className="max-w-lg p-6 sm:p-8">
+      <h2 className="mb-6 text-xl font-semibold text-gray-800 dark:text-white/90">
+        New Team
+      </h2>
+
+      <form onSubmit={handleSubmit} className="space-y-5">
+        {/* Team Name */}
+        <div>
+          <Label htmlFor="team-name">Team Name</Label>
+          <input
+            id="team-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="My Team"
+            className="h-11 w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 text-sm shadow-theme-xs placeholder:text-gray-400 focus:border-brand-300 focus:outline-hidden focus:ring-3 focus:ring-brand-500/10 dark:border-gray-700 dark:bg-white/[0.03] dark:text-white/90 dark:placeholder:text-white/30 dark:focus:border-brand-800"
+          />
+        </div>
+
+        {/* Pokepaste URL */}
+        <div>
+          <Label htmlFor="pokepaste-url">Pokepaste URL</Label>
+          <input
+            id="pokepaste-url"
+            type="text"
+            value={pokepaste}
+            onChange={(e) => setPokepaste(e.target.value)}
+            placeholder="https://pokepast.es/..."
+            className={`h-11 w-full rounded-lg border bg-transparent px-4 py-2.5 text-sm shadow-theme-xs placeholder:text-gray-400 focus:outline-hidden focus:ring-3 dark:bg-white/[0.03] dark:text-white/90 dark:placeholder:text-white/30 ${
+              !isValidUrl
+                ? "border-red-400 focus:border-red-400 focus:ring-red-500/10 dark:border-red-500"
+                : "border-gray-300 focus:border-brand-300 focus:ring-brand-500/10 dark:border-gray-700 dark:focus:border-brand-800"
+            }`}
+          />
+          {!isValidUrl && (
+            <p className="mt-1 text-xs text-red-500">Enter a valid pokepast.es or pokebin.com URL</p>
+          )}
+          {previewNames && previewNames.length > 0 && (
+            <div className="mt-3">
+              <PokemonTeam pokemonNames={previewNames} size="sm" />
+            </div>
+          )}
+        </div>
+
+        {/* Regulation */}
+        <div>
+          <Label htmlFor="regulation">Regulation</Label>
+          <select
+            id="regulation"
+            value={regulation}
+            onChange={(e) => setRegulation(e.target.value)}
+            className={`h-11 w-full appearance-none rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 pr-11 text-sm shadow-theme-xs focus:border-brand-300 focus:outline-hidden focus:ring-3 focus:ring-brand-500/10 dark:border-gray-700 dark:bg-gray-900 dark:focus:border-brand-800 ${
+              regulation ? "text-gray-800 dark:text-white/90" : "text-gray-400 dark:text-gray-400"
+            }`}
+          >
+            <option value="">Select regulation (optional)</option>
+            {REGULATIONS.map((reg) => (
+              <option key={reg} value={reg} className="text-gray-700 dark:bg-gray-900 dark:text-gray-400">
+                {shortRegulation(reg)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Showdown Usernames */}
+        <div>
+          <Label>Showdown Usernames</Label>
+          <TagInput
+            tags={showdownUsernames}
+            onTagsChange={setShowdownUsernames}
+            placeholder="Type a username and press Enter..."
+          />
+        </div>
+
+        {/* Error */}
+        {error && (
+          <p className="text-sm text-red-500">{error}</p>
+        )}
+
+        {/* Submit */}
+        <div className="flex justify-end gap-3 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-medium text-white hover:bg-brand-600 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {submitting ? "Creating..." : "Create Team"}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default NewTeamModal;

--- a/frontend-rewrite/src/components/pokemon/PokemonSprite.tsx
+++ b/frontend-rewrite/src/components/pokemon/PokemonSprite.tsx
@@ -1,0 +1,90 @@
+import React, { useState, useEffect } from "react";
+import * as pokemonService from "../../services/pokemonService";
+
+interface PokemonSpriteProps {
+  name: string;
+  size?: "sm" | "md" | "lg";
+  showTooltip?: boolean;
+  className?: string;
+}
+
+const SIZE_MAP = {
+  sm: 32,
+  md: 48,
+  lg: 64,
+} as const;
+
+const PokemonSpriteInner: React.FC<PokemonSpriteProps> = ({
+  name,
+  size = "md",
+  showTooltip = true,
+  className = "",
+}) => {
+  const [spriteUrl, setSpriteUrl] = useState<string | null>(null);
+  const [displayName, setDisplayName] = useState(name);
+  const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
+
+  const px = SIZE_MAP[size];
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setStatus("loading");
+      try {
+        const data = await pokemonService.getPokemon(name);
+        if (cancelled) return;
+        setSpriteUrl(data.sprite || null);
+        setDisplayName(data.name);
+        setStatus(data.sprite ? "loaded" : "error");
+      } catch {
+        if (!cancelled) setStatus("error");
+      }
+    };
+
+    load();
+    return () => { cancelled = true; };
+  }, [name]);
+
+  if (status === "loading") {
+    return (
+      <div
+        className={`animate-pulse rounded-full bg-gray-200 dark:bg-gray-700 ${className}`}
+        style={{ width: px, height: px }}
+      />
+    );
+  }
+
+  if (status === "error" || !spriteUrl) {
+    const initial = displayName.charAt(0).toUpperCase();
+    return (
+      <div
+        className={`flex items-center justify-center rounded-full bg-gray-300 text-gray-600 font-semibold dark:bg-gray-600 dark:text-gray-300 ${className}`}
+        style={{ width: px, height: px, fontSize: px * 0.4 }}
+        title={showTooltip ? displayName : undefined}
+      >
+        {initial}
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={spriteUrl}
+      alt={displayName}
+      title={showTooltip ? displayName : undefined}
+      width={px}
+      height={px}
+      className={`object-contain ${className}`}
+      onError={() => setStatus("error")}
+    />
+  );
+};
+
+const PokemonSprite = React.memo(PokemonSpriteInner, (prev, next) => {
+  return prev.name === next.name && prev.size === next.size && prev.showTooltip === next.showTooltip && prev.className === next.className;
+});
+
+PokemonSprite.displayName = "PokemonSprite";
+
+export default PokemonSprite;

--- a/frontend-rewrite/src/components/pokemon/PokemonTeam.tsx
+++ b/frontend-rewrite/src/components/pokemon/PokemonTeam.tsx
@@ -1,0 +1,82 @@
+import React, { useState, useEffect } from "react";
+import PokemonSprite from "./PokemonSprite";
+import * as pokepasteService from "../../services/pokepasteService";
+
+interface PokemonTeamProps {
+  pokemonNames?: string[];
+  pokepasteUrl?: string;
+  size?: "sm" | "md" | "lg";
+}
+
+const TEAM_SIZE = 6;
+
+const SIZE_MAP = {
+  sm: 32,
+  md: 48,
+  lg: 64,
+} as const;
+
+const PokemonTeam: React.FC<PokemonTeamProps> = ({
+  pokemonNames,
+  pokepasteUrl,
+  size = "md",
+}) => {
+  const [resolvedNames, setResolvedNames] = useState<string[]>(pokemonNames || []);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (pokemonNames) {
+      setResolvedNames(pokemonNames);
+      return;
+    }
+
+    if (!pokepasteUrl) {
+      setResolvedNames([]);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    pokepasteService.getPokemonNames(pokepasteUrl, 6).then((names) => {
+      if (!cancelled) {
+        setResolvedNames(names);
+        setLoading(false);
+      }
+    }).catch(() => {
+      if (!cancelled) {
+        setResolvedNames([]);
+        setLoading(false);
+      }
+    });
+
+    return () => { cancelled = true; };
+  }, [pokemonNames, pokepasteUrl]);
+
+  const px = SIZE_MAP[size];
+  const slots = Array.from({ length: TEAM_SIZE }, (_, i) => resolvedNames[i] || null);
+
+  return (
+    <div className="flex flex-row items-center gap-1">
+      {slots.map((name, i) =>
+        loading ? (
+          <div
+            key={i}
+            className="animate-pulse rounded-full bg-gray-200 dark:bg-gray-700"
+            style={{ width: px, height: px }}
+          />
+        ) : name ? (
+          <PokemonSprite key={`${name}-${i}`} name={name} size={size} />
+        ) : (
+          <div
+            key={i}
+            className="rounded-full border-2 border-dashed border-gray-300 dark:border-gray-600"
+            style={{ width: px, height: px }}
+          />
+        )
+      )}
+    </div>
+  );
+};
+
+export default PokemonTeam;

--- a/frontend-rewrite/src/components/ui/modal/index.tsx
+++ b/frontend-rewrite/src/components/ui/modal/index.tsx
@@ -51,13 +51,13 @@ export const Modal: React.FC<ModalProps> = ({
 
   const contentClasses = isFullscreen
     ? "w-full h-full"
-    : "relative w-full rounded-3xl bg-white  dark:bg-gray-900";
+    : "relative w-full rounded-3xl border border-gray-200 bg-white shadow-xl dark:border-gray-700 dark:bg-gray-900";
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center overflow-y-auto modal z-99999">
+    <div className="fixed inset-0 flex items-center justify-center overflow-y-auto modal z-999999">
       {!isFullscreen && (
         <div
-          className="fixed inset-0 h-full w-full bg-gray-400/50 backdrop-blur-[32px]"
+          className="fixed inset-0 h-full w-full bg-black/40"
           onClick={onClose}
         ></div>
       )}

--- a/frontend-rewrite/src/hooks/useTeams.ts
+++ b/frontend-rewrite/src/hooks/useTeams.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect, useCallback } from "react";
+import { teamApi } from "../services/api/teamApi";
+import type { Team } from "../types";
+
+export function useTeams() {
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      setTeams(await teamApi.getAll());
+    } catch (err) {
+      console.error("Failed to load teams:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { teams, loading, refresh };
+}
+
+export default useTeams;

--- a/frontend-rewrite/src/pages/Dashboard/HomePage.tsx
+++ b/frontend-rewrite/src/pages/Dashboard/HomePage.tsx
@@ -1,22 +1,267 @@
+import { useState, useMemo } from "react";
+import { Link } from "react-router";
+import { Plus, Download } from "lucide-react";
 import PageMeta from "../../components/common/PageMeta";
+import PokemonTeam from "../../components/pokemon/PokemonTeam";
+import SearchInput from "../../components/form/SearchInput";
+import RegulationFilter from "../../components/form/RegulationFilter";
+import NewTeamModal from "../../components/modals/NewTeamModal";
+import ImportTeamModal from "../../components/modals/ImportTeamModal";
+import { useTeams } from "../../hooks/useTeams";
+import { useMultipleTeamStats } from "../../hooks/useTeamStats";
+import useTeamPokemon from "../../hooks/useTeamPokemon";
+import { formatTimeAgo } from "../../utils/timeUtils";
+import type { Team } from "../../types";
+
+function shortRegulation(reg: string): string {
+  const match = reg.match(/Regulation\s+([A-Z])$/);
+  return match ? `Reg ${match[1]}` : reg;
+}
 
 export default function HomePage() {
+  const { teams, loading, refresh } = useTeams();
+  const teamIds = useMemo(() => teams.map((t) => t.id), [teams]);
+  const { teamStats, overallStats, loading: statsLoading } = useMultipleTeamStats(teamIds);
+  const { teamPokemon, loading: pokemonLoading } = useTeamPokemon(teams);
+
+  const [search, setSearch] = useState("");
+  const [regulationFilter, setRegulationFilter] = useState("");
+  const [showNewTeam, setShowNewTeam] = useState(false);
+  const [showImport, setShowImport] = useState(false);
+
+  const regulations = useMemo(() => {
+    const regs = new Set(teams.map((t) => t.regulation).filter(Boolean));
+    return Array.from(regs).sort();
+  }, [teams]);
+
+  const filteredTeams = useMemo(() => {
+    return teams.filter((team) => {
+      if (regulationFilter && team.regulation !== regulationFilter) return false;
+      if (search && !team.name.toLowerCase().includes(search.toLowerCase())) return false;
+      return true;
+    });
+  }, [teams, regulationFilter, search]);
+
   return (
     <div>
       <PageMeta
         title="VS Recorder | Dashboard"
         description="Pokemon VGC Replay Analysis Dashboard"
       />
+
       <div className="min-h-screen rounded-2xl border border-gray-200 bg-white px-5 py-7 dark:border-gray-800 dark:bg-white/[0.03] xl:px-10 xl:py-12">
-        <div className="mx-auto w-full max-w-[630px] text-center">
-          <h3 className="mb-4 font-semibold text-gray-800 text-theme-xl dark:text-white/90 sm:text-2xl">
-            Welcome to VS Recorder
-          </h3>
-          <p className="text-sm text-gray-500 dark:text-gray-400 sm:text-base">
-            Dashboard coming soon. Use the sidebar to navigate your teams and replays.
-          </p>
+        {/* Header */}
+        <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <h2 className="text-xl font-semibold text-gray-800 dark:text-white/90 sm:text-2xl">
+            Your Teams
+          </h2>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setShowNewTeam(true)}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-medium text-white hover:bg-brand-600"
+            >
+              <Plus className="h-4 w-4" />
+              New Team
+            </button>
+            <button
+              onClick={() => setShowImport(true)}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+            >
+              <Download className="h-4 w-4" />
+              Import
+            </button>
+          </div>
         </div>
+
+        {/* Stats Bar */}
+        {!loading && teams.length > 0 && (
+          <div className="mb-6 flex flex-wrap gap-4 rounded-lg border border-gray-200 bg-gray-50 px-5 py-3.5 dark:border-gray-700 dark:bg-gray-800/50">
+            <div className="text-sm text-gray-600 dark:text-gray-400">
+              <span className="font-semibold text-gray-800 dark:text-white/90">{teams.length}</span>{" "}
+              {teams.length === 1 ? "team" : "teams"}
+            </div>
+            {!statsLoading && overallStats.totalGames > 0 && (
+              <>
+                <div className="text-sm text-gray-400 dark:text-gray-600">|</div>
+                <div className="text-sm text-gray-600 dark:text-gray-400">
+                  <span className="font-semibold text-emerald-600 dark:text-emerald-400">{overallStats.totalWins}W</span>
+                  {" / "}
+                  <span className="font-semibold text-red-500 dark:text-red-400">{overallStats.totalLosses}L</span>
+                  {" / "}
+                  <span className="font-semibold text-gray-800 dark:text-white/90">{overallStats.overallWinRate}%</span>
+                  {" win rate"}
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Filters */}
+        {!loading && teams.length > 0 && (
+          <div className="mb-6 flex flex-col gap-3 sm:flex-row">
+            <div className="w-full sm:w-48">
+              <RegulationFilter
+                value={regulationFilter}
+                onChange={setRegulationFilter}
+                regulations={regulations}
+              />
+            </div>
+            <div className="flex-1">
+              <SearchInput
+                value={search}
+                onChange={setSearch}
+                placeholder="Search teams..."
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Loading State */}
+        {loading && (
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {[1, 2, 3].map((i) => (
+              <div
+                key={i}
+                className="animate-pulse rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-gray-900"
+              >
+                <div className="mb-3 h-5 w-2/3 rounded bg-gray-200 dark:bg-gray-700" />
+                <div className="mb-4 flex gap-1">
+                  {[1, 2, 3, 4, 5, 6].map((j) => (
+                    <div key={j} className="h-8 w-8 rounded-full bg-gray-200 dark:bg-gray-700" />
+                  ))}
+                </div>
+                <div className="h-4 w-1/2 rounded bg-gray-200 dark:bg-gray-700" />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Empty State */}
+        {!loading && teams.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-20 text-center">
+            <div className="mb-4 rounded-full bg-gray-100 p-4 dark:bg-gray-800">
+              <Plus className="h-8 w-8 text-gray-400" />
+            </div>
+            <h3 className="mb-2 text-lg font-semibold text-gray-800 dark:text-white/90">
+              No teams yet
+            </h3>
+            <p className="mb-6 max-w-sm text-sm text-gray-500 dark:text-gray-400">
+              Create your first team to start tracking your replays and analyzing your performance.
+            </p>
+            <button
+              onClick={() => setShowNewTeam(true)}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-medium text-white hover:bg-brand-600"
+            >
+              <Plus className="h-4 w-4" />
+              Create Team
+            </button>
+          </div>
+        )}
+
+        {/* No Filter Results */}
+        {!loading && teams.length > 0 && filteredTeams.length === 0 && (
+          <div className="py-12 text-center">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              No teams match your filters.
+            </p>
+          </div>
+        )}
+
+        {/* Team Grid */}
+        {!loading && filteredTeams.length > 0 && (
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            {filteredTeams.map((team) => (
+              <TeamCard
+                key={team.id}
+                team={team}
+                pokemonNames={teamPokemon[team.id]}
+                pokemonLoading={pokemonLoading}
+                stats={teamStats[team.id]}
+                statsLoading={statsLoading}
+              />
+            ))}
+          </div>
+        )}
       </div>
+
+      {/* Modals */}
+      <NewTeamModal
+        isOpen={showNewTeam}
+        onClose={() => setShowNewTeam(false)}
+        onCreated={refresh}
+      />
+      <ImportTeamModal
+        isOpen={showImport}
+        onClose={() => setShowImport(false)}
+        onImported={refresh}
+      />
     </div>
+  );
+}
+
+interface TeamCardProps {
+  team: Team;
+  pokemonNames?: string[];
+  pokemonLoading: boolean;
+  stats?: {
+    wins: number;
+    losses: number;
+    total: number;
+    winRate: number;
+  };
+  statsLoading: boolean;
+}
+
+function TeamCard({ team, pokemonNames, pokemonLoading, stats, statsLoading }: TeamCardProps) {
+  return (
+    <Link
+      to={`/team/${team.id}/replays`}
+      className="group block rounded-xl border border-gray-200 bg-white p-5 transition-all hover:border-brand-300 hover:shadow-md dark:border-gray-800 dark:bg-gray-900 dark:hover:border-brand-800"
+    >
+      {/* Team Name & Regulation */}
+      <div className="mb-3 flex items-start justify-between gap-2">
+        <h3 className="font-semibold text-gray-800 group-hover:text-brand-600 dark:text-white/90 dark:group-hover:text-brand-400">
+          {team.name}
+        </h3>
+        {team.regulation && (
+          <span className="shrink-0 rounded-full bg-brand-50 px-2.5 py-0.5 text-xs font-medium text-brand-700 dark:bg-brand-500/10 dark:text-brand-400">
+            {shortRegulation(team.regulation)}
+          </span>
+        )}
+      </div>
+
+      {/* Pokemon Sprites */}
+      <div className="mb-4">
+        {pokemonLoading ? (
+          <div className="flex gap-1">
+            {[1, 2, 3, 4, 5, 6].map((i) => (
+              <div key={i} className="h-8 w-8 animate-pulse rounded-full bg-gray-200 dark:bg-gray-700" />
+            ))}
+          </div>
+        ) : (
+          <PokemonTeam pokemonNames={pokemonNames || []} size="sm" />
+        )}
+      </div>
+
+      {/* Stats & Time */}
+      <div className="flex items-center justify-between text-sm">
+        {statsLoading ? (
+          <div className="h-4 w-24 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+        ) : stats && stats.total > 0 ? (
+          <div className="text-gray-600 dark:text-gray-400">
+            <span className="font-medium text-emerald-600 dark:text-emerald-400">{stats.wins}W</span>
+            {" / "}
+            <span className="font-medium text-red-500 dark:text-red-400">{stats.losses}L</span>
+            {" / "}
+            <span className="font-medium text-gray-800 dark:text-white/90">{stats.winRate}%</span>
+          </div>
+        ) : (
+          <span className="text-gray-400 dark:text-gray-500">No games</span>
+        )}
+        <span className="text-xs text-gray-400 dark:text-gray-500">
+          {formatTimeAgo(team.updatedAt)}
+        </span>
+      </div>
+    </Link>
   );
 }


### PR DESCRIPTION
## Summary
- **Home Page dashboard**: Team card grid with Pokemon sprites, W/L/WR% stats, regulation badges, search + regulation filters, skeleton loading, and empty state
- **New Team / Import / Edit / Export modals**: Full CRUD modals with pokepaste preview, tag input for usernames, share code import with element counts, JSON paste/file import, and export with options & share code generation
- **Sidebar improvements**: Removed collapsible menu toggle (always expanded), added Edit Team + Export Team actions with dividers, cleaned up UserDropdown (no avatar icon)
- **Modal fixes**: z-index above header, dim backdrop instead of blur, dark mode border

## New files (10)
| File | Purpose |
|---|---|
| `components/pokemon/PokemonSprite.tsx` | Memo-wrapped sprite with loading/error fallback |
| `components/pokemon/PokemonTeam.tsx` | 6-slot team display |
| `components/form/SearchInput.tsx` | Search input with icon |
| `components/form/TagInput.tsx` | Inline tag input (Enter/Backspace) |
| `components/form/RegulationFilter.tsx` | Regulation select dropdown |
| `components/modals/NewTeamModal.tsx` | Create team form |
| `components/modals/ImportTeamModal.tsx` | Import via share code or JSON |
| `components/modals/EditTeamModal.tsx` | Edit team form |
| `components/modals/ExportTeamModal.tsx` | Export with options & share code |
| `hooks/useTeams.ts` | Team list fetching hook |

## Modified files (4)
- `pages/Dashboard/HomePage.tsx` — Full dashboard replacing placeholder
- `layout/AppSidebar.tsx` — Always-expanded nav, Edit/Export actions, dividers
- `components/ui/modal/index.tsx` — z-index fix, dim backdrop, border
- `components/header/UserDropdown.tsx` — Removed avatar circle

## Test plan
- [ ] `npx tsc --noEmit` passes (verified)
- [ ] `npx vite build` succeeds (verified)
- [ ] Sign in → HomePage shows team cards or empty state
- [ ] New Team modal → create → card appears with sprites
- [ ] Import modal → share code preview shows counts → import works
- [ ] Import modal → JSON tab → paste/file → validate → import works
- [ ] Edit Team from sidebar → updates team name in sidebar
- [ ] Export Team from sidebar → options → generate share code
- [ ] Filters: regulation dropdown + search narrow the grid
- [ ] Dark mode: all components respect theme
- [ ] Mobile: cards single column, modals responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)