### PR TITLE
Add Team Page header, replays view, and team management (Phase 4)

### DIFF
--- a/frontend-rewrite/src/components/modals/AddReplayModal.tsx
+++ b/frontend-rewrite/src/components/modals/AddReplayModal.tsx
@@ -1,0 +1,323 @@
+import React, { useState, useEffect } from "react";
+import { Link as LinkIcon, Plus, AlertCircle, FileText } from "lucide-react";
+import { Modal } from "../ui/modal";
+import Label from "../form/Label";
+import * as replayService from "../../services/replayService";
+
+interface AddReplayModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onAdded: () => void;
+  teamId: number;
+}
+
+const REPLAY_URL_PATTERN = /^https?:\/\/replay\.pokemonshowdown\.com\/.+$/;
+
+const AddReplayModal: React.FC<AddReplayModalProps> = ({
+  isOpen,
+  onClose,
+  onAdded,
+  teamId,
+}) => {
+  const [replayUrl, setReplayUrl] = useState("");
+  const [notes, setNotes] = useState("");
+  const [bulkMode, setBulkMode] = useState(false);
+  const [bulkUrls, setBulkUrls] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [progress, setProgress] = useState<{ current: number; total: number } | null>(null);
+
+  // Reset form when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setReplayUrl("");
+      setNotes("");
+      setBulkMode(false);
+      setBulkUrls("");
+      setError("");
+      setProgress(null);
+    }
+  }, [isOpen]);
+
+  const validateReplayUrl = (url: string) => {
+    return REPLAY_URL_PATTERN.test(url.trim());
+  };
+
+  const handleSingleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const trimmedUrl = replayUrl.trim();
+    if (!trimmedUrl) {
+      setError("Please enter a replay URL");
+      return;
+    }
+
+    if (!validateReplayUrl(trimmedUrl)) {
+      setError("Please enter a valid Pokemon Showdown replay URL");
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError("");
+      const cleanUrl = trimmedUrl.split("?")[0];
+      await replayService.createFromUrl(teamId, cleanUrl, notes.trim() || undefined);
+      onAdded();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add replay. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleBulkSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const urls = bulkUrls
+      .split("\n")
+      .map((url) => url.trim())
+      .filter((url) => url);
+
+    if (urls.length === 0) {
+      setError("Please enter at least one replay URL");
+      return;
+    }
+
+    const invalidUrls = urls.filter((url) => !validateReplayUrl(url));
+    if (invalidUrls.length > 0) {
+      setError(
+        `Invalid URLs found: ${invalidUrls.slice(0, 3).join(", ")}${invalidUrls.length > 3 ? "..." : ""}`
+      );
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError("");
+
+      const cleanUrls = urls.map((url) => url.split("?")[0]);
+      const result = await replayService.createManyFromUrls(
+        teamId,
+        cleanUrls,
+        (current, total) => setProgress({ current, total })
+      );
+
+      if (result.failed.length > 0) {
+        setError(
+          `${result.success.length} added, ${result.failed.length} failed: ${result.failed[0].error}`
+        );
+        onAdded();
+      } else {
+        onAdded();
+        onClose();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to import replays. Please try again.");
+    } finally {
+      setLoading(false);
+      setProgress(null);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} className="max-w-lg p-6 sm:p-8">
+      <h2 className="mb-6 text-xl font-semibold text-gray-800 dark:text-white/90">
+        Add Replay
+      </h2>
+
+      {/* Mode Toggle */}
+      <div className="mb-6 flex gap-2">
+        <button
+          type="button"
+          onClick={() => {
+            setBulkMode(false);
+            setError("");
+          }}
+          disabled={loading}
+          className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+            !bulkMode
+              ? "bg-brand-500 text-white"
+              : "border border-gray-300 text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+          }`}
+        >
+          <LinkIcon className="h-4 w-4" />
+          Single Replay
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setBulkMode(true);
+            setError("");
+          }}
+          disabled={loading}
+          className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+            bulkMode
+              ? "bg-brand-500 text-white"
+              : "border border-gray-300 text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+          }`}
+        >
+          <Plus className="h-4 w-4" />
+          Bulk Import
+        </button>
+      </div>
+
+      {!bulkMode ? (
+        <form onSubmit={handleSingleSubmit} className="space-y-5">
+          {/* URL Input */}
+          <div>
+            <Label htmlFor="replay-url">Replay URL</Label>
+            <input
+              id="replay-url"
+              type="url"
+              value={replayUrl}
+              onChange={(e) => {
+                setReplayUrl(e.target.value);
+                setError("");
+              }}
+              placeholder="https://replay.pokemonshowdown.com/..."
+              className="h-11 w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 text-sm shadow-theme-xs placeholder:text-gray-400 focus:border-brand-300 focus:outline-hidden focus:ring-3 focus:ring-brand-500/10 dark:border-gray-700 dark:bg-white/[0.03] dark:text-white/90 dark:placeholder:text-white/30 dark:focus:border-brand-800"
+              disabled={loading}
+            />
+            <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+              Paste the URL from a Pokemon Showdown replay page
+            </p>
+          </div>
+
+          {/* Notes */}
+          <div>
+            <Label htmlFor="replay-notes">Notes (optional)</Label>
+            <textarea
+              id="replay-notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Add any notes about this game..."
+              rows={3}
+              className="w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 text-sm shadow-theme-xs placeholder:text-gray-400 focus:border-brand-300 focus:outline-hidden focus:ring-3 focus:ring-brand-500/10 dark:border-gray-700 dark:bg-white/[0.03] dark:text-white/90 dark:placeholder:text-white/30 dark:focus:border-brand-800"
+              disabled={loading}
+            />
+          </div>
+
+          {/* Error */}
+          {error && (
+            <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-500/20 dark:bg-red-500/10">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-600 dark:text-red-400" />
+              <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={loading}
+              className="rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading || !replayUrl.trim()}
+              className="inline-flex items-center gap-2 rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-medium text-white hover:bg-brand-600 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {loading ? (
+                <>
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                  Adding Replay...
+                </>
+              ) : (
+                <>
+                  <Plus className="h-4 w-4" />
+                  Add Replay
+                </>
+              )}
+            </button>
+          </div>
+        </form>
+      ) : (
+        <form onSubmit={handleBulkSubmit} className="space-y-5">
+          {/* Bulk URLs */}
+          <div>
+            <Label htmlFor="bulk-urls">Replay URLs</Label>
+            <textarea
+              id="bulk-urls"
+              value={bulkUrls}
+              onChange={(e) => {
+                setBulkUrls(e.target.value);
+                setError("");
+              }}
+              placeholder={`https://replay.pokemonshowdown.com/game1\nhttps://replay.pokemonshowdown.com/game2\nhttps://replay.pokemonshowdown.com/game3`}
+              rows={8}
+              className="w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 font-mono text-sm shadow-theme-xs placeholder:text-gray-400 focus:border-brand-300 focus:outline-hidden focus:ring-3 focus:ring-brand-500/10 dark:border-gray-700 dark:bg-white/[0.03] dark:text-white/90 dark:placeholder:text-white/30 dark:focus:border-brand-800"
+              disabled={loading}
+            />
+            <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+              Enter one replay URL per line
+            </p>
+          </div>
+
+          {/* Info Box */}
+          <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-500/20 dark:bg-blue-500/10">
+            <div className="flex items-start gap-2">
+              <FileText className="mt-0.5 h-4 w-4 shrink-0 text-blue-600 dark:text-blue-400" />
+              <div className="text-sm">
+                <p className="font-medium text-blue-700 dark:text-blue-400">Bulk Import</p>
+                <p className="mt-1 text-blue-600 dark:text-gray-300">
+                  This will import multiple replays at once. Each replay will be processed
+                  individually, so if some fail, others may still succeed.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Progress */}
+          {progress && (
+            <div className="text-sm text-gray-600 dark:text-gray-400">
+              Processing {progress.current} of {progress.total}...
+            </div>
+          )}
+
+          {/* Error */}
+          {error && (
+            <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-500/20 dark:bg-red-500/10">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-600 dark:text-red-400" />
+              <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={loading}
+              className="rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading || !bulkUrls.trim()}
+              className="inline-flex items-center gap-2 rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-medium text-white hover:bg-brand-600 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {loading ? (
+                <>
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                  Importing Replays...
+                </>
+              ) : (
+                <>
+                  <Plus className="h-4 w-4" />
+                  Import All
+                </>
+              )}
+            </button>
+          </div>
+        </form>
+      )}
+    </Modal>
+  );
+};
+
+export default AddReplayModal;

--- a/frontend-rewrite/src/components/modals/ConfirmationModal.tsx
+++ b/frontend-rewrite/src/components/modals/ConfirmationModal.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { Modal } from "../ui/modal";
+
+interface ConfirmationModalProps {
+  isOpen: boolean;
+  title?: string;
+  message: React.ReactNode;
+  onConfirm: () => void;
+  onCancel: () => void;
+  loading?: boolean;
+  confirmText?: string;
+  cancelText?: string;
+  variant?: "danger" | "default";
+}
+
+const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
+  isOpen,
+  title = "Confirm Action",
+  message,
+  onConfirm,
+  onCancel,
+  loading = false,
+  confirmText = "Confirm",
+  cancelText = "Cancel",
+  variant = "default",
+}) => {
+  const isDanger = variant === "danger";
+
+  return (
+    <Modal isOpen={isOpen} onClose={onCancel} className="max-w-md p-6 sm:p-8" showCloseButton={false}>
+      {/* Header */}
+      <div className="mb-4 flex items-center gap-3">
+        {isDanger && (
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-red-100 dark:bg-red-500/10">
+            <svg className="h-5 w-5 text-red-600 dark:text-red-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
+              <path d="M12 9v4" />
+              <path d="M12 17h.01" />
+            </svg>
+          </div>
+        )}
+        <h2 className="text-xl font-semibold text-gray-800 dark:text-white/90">
+          {title}
+        </h2>
+      </div>
+
+      {/* Message */}
+      <div className="mb-6 text-sm text-gray-600 dark:text-gray-300">
+        {typeof message === "string" ? <p>{message}</p> : message}
+      </div>
+
+      {/* Actions */}
+      <div className="flex justify-end gap-3">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={loading}
+          className="rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+        >
+          {cancelText}
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={loading}
+          className={`inline-flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50 ${
+            isDanger
+              ? "bg-red-600 hover:bg-red-700"
+              : "bg-brand-500 hover:bg-brand-600"
+          }`}
+        >
+          {loading ? (
+            <>
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+              Processing...
+            </>
+          ) : (
+            confirmText
+          )}
+        </button>
+      </div>
+    </Modal>
+  );
+};
+
+export default ConfirmationModal;

--- a/frontend-rewrite/src/components/team/CompactReplayCard.tsx
+++ b/frontend-rewrite/src/components/team/CompactReplayCard.tsx
@@ -1,0 +1,228 @@
+import React, { useState } from "react";
+import { Trash2, Save, MessageSquare, ExternalLink, ChevronDown } from "lucide-react";
+import PokemonTeam from "../pokemon/PokemonTeam";
+import { getResultDisplay } from "../../utils/resultUtils";
+import { formatTimeAgo } from "../../utils/timeUtils";
+import { getOpponentPokemonFromReplay } from "../../utils/pokemonNameUtils";
+import type { Replay } from "../../types";
+
+interface CompactReplayCardProps {
+  replay: Replay;
+  isDeleting: boolean;
+  isEditingNote: boolean;
+  isSavingNote: boolean;
+  noteText: string;
+  onDelete: (id: number) => void;
+  onStartEditNote: (replay: Replay) => void;
+  onCancelEditNote: () => void;
+  onSaveNote: (id: number) => void;
+  onNoteTextChange: (text: string) => void;
+}
+
+const CompactReplayCard: React.FC<CompactReplayCardProps> = ({
+  replay,
+  isDeleting,
+  isEditingNote,
+  isSavingNote,
+  noteText,
+  onDelete,
+  onStartEditNote,
+  onCancelEditNote,
+  onSaveNote,
+  onNoteTextChange,
+}) => {
+  const [isNoteExpanded, setIsNoteExpanded] = useState(false);
+
+  const resultDisplay = getResultDisplay(replay.result);
+  const opponentTeam = getOpponentPokemonFromReplay(replay);
+
+  const getOpponentDisplay = () => {
+    if (!replay.opponent) return "Unknown opponent";
+    if (replay.opponent.includes(" vs ")) return replay.opponent;
+    return `vs ${replay.opponent}`;
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      onSaveNote(replay.id);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      onCancelEditNote();
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-4 transition-colors hover:bg-gray-50 dark:border-gray-800 dark:bg-white/[0.03] dark:hover:bg-white/[0.05]">
+      <div className="flex items-center justify-between">
+        <div className="flex flex-1 items-center gap-3 min-w-0">
+          {/* Result Badge */}
+          <span
+            className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-bold ${resultDisplay.className}`}
+          >
+            {resultDisplay.text}
+          </span>
+
+          {/* Opponent & Time */}
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span className="truncate text-sm font-medium text-gray-800 dark:text-white/90">
+                {getOpponentDisplay()}
+              </span>
+              <span className="text-gray-300 dark:text-gray-600">&middot;</span>
+              <span className="shrink-0 text-xs text-gray-400 dark:text-gray-500">
+                {formatTimeAgo(replay.createdAt)}
+              </span>
+            </div>
+          </div>
+
+          {/* Opponent Team Sprites */}
+          {opponentTeam.length > 0 && (
+            <div className="hidden items-center gap-1.5 sm:flex">
+              <span className="text-xs text-gray-400 dark:text-gray-500">vs</span>
+              <PokemonTeam pokemonNames={opponentTeam} size="sm" />
+            </div>
+          )}
+
+          {/* View Replay Link */}
+          <a
+            href={replay.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hidden shrink-0 items-center gap-1 rounded-md px-2 py-1 text-xs text-brand-600 transition-colors hover:bg-brand-50 sm:inline-flex dark:text-brand-400 dark:hover:bg-brand-500/10"
+          >
+            <ExternalLink className="h-3 w-3" />
+            View
+          </a>
+        </div>
+
+        {/* Action Buttons */}
+        <div className="ml-3 flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => onStartEditNote(replay)}
+            disabled={isEditingNote || isSavingNote}
+            className="rounded-md p-1.5 text-gray-400 transition-colors hover:bg-blue-50 hover:text-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-blue-500/10 dark:hover:text-blue-400"
+            title="Edit notes"
+          >
+            <MessageSquare className="h-3.5 w-3.5" />
+          </button>
+
+          <button
+            type="button"
+            onClick={() => onDelete(replay.id)}
+            disabled={isDeleting || isEditingNote}
+            className="rounded-md p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-red-500/10 dark:hover:text-red-400"
+            title="Delete replay"
+          >
+            {isDeleting ? (
+              <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-gray-300 border-t-transparent dark:border-gray-600" />
+            ) : (
+              <Trash2 className="h-3.5 w-3.5" />
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Mobile: View Replay link + opponent sprites */}
+      <div className="mt-2 flex items-center justify-between sm:hidden">
+        {opponentTeam.length > 0 && (
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs text-gray-400 dark:text-gray-500">vs</span>
+            <PokemonTeam pokemonNames={opponentTeam} size="sm" />
+          </div>
+        )}
+        <a
+          href={replay.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs text-brand-600 transition-colors hover:bg-brand-50 dark:text-brand-400 dark:hover:bg-brand-500/10"
+        >
+          <ExternalLink className="h-3 w-3" />
+          View Replay
+        </a>
+      </div>
+
+      {/* Collapsible Notes */}
+      {replay.notes && !isEditingNote && (
+        <button
+          type="button"
+          onClick={() => setIsNoteExpanded(!isNoteExpanded)}
+          className={`mt-3 flex w-full items-start gap-1.5 border-t border-gray-100 pt-2 text-left dark:border-gray-800 ${
+            isNoteExpanded ? "rounded-b-lg bg-gray-50 p-2 dark:bg-white/[0.02]" : ""
+          }`}
+        >
+          <ChevronDown
+            className={`mt-0.5 h-3 w-3 shrink-0 text-gray-400 transition-transform dark:text-gray-500 ${
+              isNoteExpanded ? "rotate-180" : ""
+            }`}
+          />
+          <p
+            className={`text-xs ${
+              isNoteExpanded
+                ? "whitespace-pre-wrap break-words text-gray-600 dark:text-gray-300"
+                : "truncate text-gray-400 dark:text-gray-500"
+            }`}
+          >
+            {replay.notes}
+          </p>
+        </button>
+      )}
+
+      {/* Inline Note Editor */}
+      {isEditingNote && (
+        <div className="mt-3 border-t border-gray-100 pt-3 dark:border-gray-800">
+          <div className="space-y-2">
+            <textarea
+              value={noteText}
+              onChange={(e) => onNoteTextChange(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Add notes about this game..."
+              rows={2}
+              className="w-full rounded-lg border border-gray-300 bg-transparent px-3 py-2 text-sm placeholder:text-gray-400 focus:border-brand-300 focus:outline-hidden focus:ring-3 focus:ring-brand-500/10 dark:border-gray-700 dark:bg-white/[0.03] dark:text-white/90 dark:placeholder:text-white/30 dark:focus:border-brand-800"
+              disabled={isSavingNote}
+              autoFocus
+            />
+
+            <div className="flex items-center justify-between">
+              <p className="text-xs text-gray-400 dark:text-gray-500">
+                Ctrl+Enter to save, Escape to cancel
+              </p>
+
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => onSaveNote(replay.id)}
+                  disabled={isSavingNote}
+                  className="inline-flex items-center gap-1 rounded-md bg-brand-500 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-brand-600 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {isSavingNote ? (
+                    <>
+                      <div className="h-2.5 w-2.5 animate-spin rounded-full border border-white border-t-transparent" />
+                      Saving...
+                    </>
+                  ) : (
+                    <>
+                      <Save className="h-2.5 w-2.5" />
+                      Save
+                    </>
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={onCancelEditNote}
+                  disabled={isSavingNote}
+                  className="rounded-md px-3 py-1 text-xs text-gray-500 transition-colors hover:text-gray-700 disabled:opacity-50 dark:text-gray-400 dark:hover:text-gray-200"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CompactReplayCard;

--- a/frontend-rewrite/src/components/team/TeamHeader.tsx
+++ b/frontend-rewrite/src/components/team/TeamHeader.tsx
@@ -1,0 +1,204 @@
+import React, { useState, useEffect } from "react";
+import { Plus, ChevronUp, ChevronDown } from "lucide-react";
+import { useActiveTeam } from "../../context/ActiveTeamContext";
+import { useTeamStats } from "../../hooks/useTeamStats";
+import PokemonTeam from "../pokemon/PokemonTeam";
+import AddReplayModal from "../modals/AddReplayModal";
+import { formatShortDate } from "../../utils/timeUtils";
+
+const STORAGE_KEY = "vs-recorder-team-header-collapsed";
+
+function shortRegulation(reg: string): string {
+  const match = reg.match(/Regulation\s+([A-Z])$/);
+  return match ? `Reg ${match[1]}` : reg;
+}
+
+const TeamHeader: React.FC = () => {
+  const { team, bumpStatsVersion } = useActiveTeam();
+  const {
+    gamesPlayed,
+    wins,
+    losses,
+    winRate,
+    loading: statsLoading,
+    refreshStats,
+  } = useTeamStats(team?.id ?? null);
+
+  const [collapsed, setCollapsed] = useState(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
+
+  const [showAddReplay, setShowAddReplay] = useState(false);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, String(collapsed));
+    } catch {
+      // ignore
+    }
+  }, [collapsed]);
+
+  if (!team) return null;
+
+  const handleReplayAdded = () => {
+    refreshStats();
+    bumpStatsVersion();
+  };
+
+  // Collapsed view
+  if (collapsed) {
+    return (
+      <>
+        <div className="mb-4 rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-white/[0.03]">
+          <div className="flex items-center gap-3">
+            {/* Team name + regulation */}
+            <div className="flex min-w-0 items-center gap-2">
+              <h2 className="truncate text-lg font-semibold text-gray-800 dark:text-white/90">
+                {team.name}
+              </h2>
+              {team.regulation && (
+                <span className="shrink-0 rounded-full bg-brand-50 px-2.5 py-0.5 text-xs font-medium text-brand-700 dark:bg-brand-500/10 dark:text-brand-400">
+                  {shortRegulation(team.regulation)}
+                </span>
+              )}
+            </div>
+
+            {/* Pokemon sprites (small) */}
+            <div className="hidden sm:block">
+              <PokemonTeam pokepasteUrl={team.pokepaste} size="sm" />
+            </div>
+
+            {/* Spacer */}
+            <div className="flex-1" />
+
+            {/* Add Replay button */}
+            <button
+              type="button"
+              onClick={() => setShowAddReplay(true)}
+              className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-brand-500 px-3 py-2 text-sm font-medium text-white hover:bg-brand-600"
+            >
+              <Plus className="h-4 w-4" />
+              <span className="hidden sm:inline">Add Replay</span>
+            </button>
+
+            {/* Expand */}
+            <button
+              type="button"
+              onClick={() => setCollapsed(false)}
+              className="rounded-md p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+              title="Expand header"
+            >
+              <ChevronDown className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+
+        <AddReplayModal
+          isOpen={showAddReplay}
+          onClose={() => setShowAddReplay(false)}
+          onAdded={handleReplayAdded}
+          teamId={team.id}
+        />
+      </>
+    );
+  }
+
+  // Expanded view
+  return (
+    <>
+      <div className="mb-4 rounded-2xl border border-gray-200 bg-white p-5 sm:p-6 dark:border-gray-800 dark:bg-white/[0.03]">
+        {/* Top row: Name + Regulation + Actions */}
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <h2 className="text-xl font-semibold text-gray-800 dark:text-white/90">
+              {team.name}
+            </h2>
+            {team.regulation && (
+              <span className="shrink-0 rounded-full bg-brand-50 px-2.5 py-0.5 text-xs font-medium text-brand-700 dark:bg-brand-500/10 dark:text-brand-400">
+                {shortRegulation(team.regulation)}
+              </span>
+            )}
+          </div>
+
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setShowAddReplay(true)}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-brand-500 px-3 py-2 text-sm font-medium text-white hover:bg-brand-600"
+            >
+              <Plus className="h-4 w-4" />
+              Add Replay
+            </button>
+
+            <button
+              type="button"
+              onClick={() => setCollapsed(true)}
+              className="rounded-md p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+              title="Collapse header"
+            >
+              <ChevronUp className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+
+        {/* Pokemon Team */}
+        <div className="mb-4">
+          <PokemonTeam pokepasteUrl={team.pokepaste} size="md" />
+        </div>
+
+        {/* Quick Stats */}
+        <div className="mb-4 flex flex-wrap items-center gap-4 text-sm">
+          {statsLoading ? (
+            <div className="flex gap-4">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-5 w-16 animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
+              ))}
+            </div>
+          ) : gamesPlayed > 0 ? (
+            <>
+              <div className="text-gray-600 dark:text-gray-400">
+                <span className="font-medium text-gray-800 dark:text-white/90">{gamesPlayed}</span>{" "}
+                games
+              </div>
+              <div className="text-gray-600 dark:text-gray-400">
+                <span className="font-medium text-emerald-600 dark:text-emerald-400">{wins}W</span>
+                {" / "}
+                <span className="font-medium text-red-500 dark:text-red-400">{losses}L</span>
+              </div>
+              <div className="text-gray-600 dark:text-gray-400">
+                <span className="font-semibold text-gray-800 dark:text-white/90">{winRate}%</span>{" "}
+                win rate
+              </div>
+            </>
+          ) : (
+            <span className="text-gray-400 dark:text-gray-500">No games played yet</span>
+          )}
+        </div>
+
+        {/* Details */}
+        <div className="flex flex-wrap gap-x-6 gap-y-1 text-xs text-gray-400 dark:text-gray-500">
+          <span>Created {formatShortDate(team.createdAt)}</span>
+          <span>Updated {formatShortDate(team.updatedAt)}</span>
+          {team.showdownUsernames && team.showdownUsernames.length > 0 && (
+            <span>
+              Showdown: {team.showdownUsernames.join(", ")}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <AddReplayModal
+        isOpen={showAddReplay}
+        onClose={() => setShowAddReplay(false)}
+        onAdded={handleReplayAdded}
+        teamId={team.id}
+      />
+    </>
+  );
+};
+
+export default TeamHeader;

--- a/frontend-rewrite/src/context/ActiveTeamContext.tsx
+++ b/frontend-rewrite/src/context/ActiveTeamContext.tsx
@@ -1,9 +1,11 @@
-import { createContext, useContext, useState } from "react";
+import { createContext, useCallback, useContext, useState } from "react";
 import type { Team } from "../types";
 
 type ActiveTeamContextType = {
   team: Team | null;
   setTeam: (team: Team | null) => void;
+  statsVersion: number;
+  bumpStatsVersion: () => void;
 };
 
 const ActiveTeamContext = createContext<ActiveTeamContextType | undefined>(
@@ -22,9 +24,11 @@ export const ActiveTeamProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const [team, setTeam] = useState<Team | null>(null);
+  const [statsVersion, setStatsVersion] = useState(0);
+  const bumpStatsVersion = useCallback(() => setStatsVersion((v) => v + 1), []);
 
   return (
-    <ActiveTeamContext.Provider value={{ team, setTeam }}>
+    <ActiveTeamContext.Provider value={{ team, setTeam, statsVersion, bumpStatsVersion }}>
       {children}
     </ActiveTeamContext.Provider>
   );

--- a/frontend-rewrite/src/layout/TeamLayout.tsx
+++ b/frontend-rewrite/src/layout/TeamLayout.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Outlet, useParams, Navigate } from "react-router";
 import { useActiveTeam } from "../context/ActiveTeamContext";
 import { teamApi } from "../services/api/teamApi";
+import TeamHeader from "../components/team/TeamHeader";
 
 export default function TeamLayout() {
   const { teamId } = useParams<{ teamId: string }>();
@@ -50,5 +51,10 @@ export default function TeamLayout() {
     );
   }
 
-  return <Outlet />;
+  return (
+    <>
+      <TeamHeader />
+      <Outlet />
+    </>
+  );
 }

--- a/frontend-rewrite/src/pages/Team/ReplaysPage.tsx
+++ b/frontend-rewrite/src/pages/Team/ReplaysPage.tsx
@@ -1,8 +1,201 @@
+import { useState, useMemo, useEffect, useRef } from "react";
+import { Calendar, Copy, Check } from "lucide-react";
+import { useActiveTeam } from "../../context/ActiveTeamContext";
+import { useTeamStats } from "../../hooks/useTeamStats";
+import CompactReplayCard from "../../components/team/CompactReplayCard";
+import TagInput from "../../components/form/TagInput";
+import * as replayService from "../../services/replayService";
+import { matchesPokemonTags, getOpponentPokemonFromReplay } from "../../utils/pokemonNameUtils";
+import type { Replay } from "../../types";
+
 export default function ReplaysPage() {
+  const { team, statsVersion, bumpStatsVersion } = useActiveTeam();
+  const { replays, loading, refreshStats } = useTeamStats(team?.id ?? null);
+
+  // Refresh when another component (e.g. TeamHeader) bumps the version
+  const prevVersion = useRef(statsVersion);
+  useEffect(() => {
+    if (statsVersion !== prevVersion.current) {
+      prevVersion.current = statsVersion;
+      refreshStats();
+    }
+  }, [statsVersion, refreshStats]);
+
+  const [searchTags, setSearchTags] = useState<string[]>([]);
+  const [deletingReplayId, setDeletingReplayId] = useState<number | null>(null);
+  const [editingNoteId, setEditingNoteId] = useState<number | null>(null);
+  const [noteText, setNoteText] = useState("");
+  const [savingNoteId, setSavingNoteId] = useState<number | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const filteredReplays = useMemo(() => {
+    if (searchTags.length === 0) return replays;
+    return replays.filter((replay) =>
+      matchesPokemonTags(getOpponentPokemonFromReplay(replay), searchTags)
+    );
+  }, [replays, searchTags]);
+
+  const handleDeleteReplay = async (replayId: number) => {
+    try {
+      setDeletingReplayId(replayId);
+      await replayService.deleteReplay(replayId);
+      refreshStats();
+      bumpStatsVersion();
+    } catch (error) {
+      console.error("Error deleting replay:", error);
+    } finally {
+      setDeletingReplayId(null);
+    }
+  };
+
+  const startEditingNote = (replay: Replay) => {
+    setEditingNoteId(replay.id);
+    setNoteText(replay.notes || "");
+  };
+
+  const cancelEditingNote = () => {
+    setEditingNoteId(null);
+    setNoteText("");
+  };
+
+  const saveNote = async (replayId: number) => {
+    try {
+      setSavingNoteId(replayId);
+      await replayService.update(replayId, { notes: noteText.trim() });
+      refreshStats();
+      setEditingNoteId(null);
+      setNoteText("");
+    } catch (error) {
+      console.error("Error updating replay note:", error);
+    } finally {
+      setSavingNoteId(null);
+    }
+  };
+
+  const handleCopyAllUrls = async () => {
+    try {
+      const urls = filteredReplays.map((r) => r.url).join("\n");
+      await navigator.clipboard.writeText(urls);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error("Failed to copy replay URLs:", error);
+    }
+  };
+
+  // Loading state
+  if (loading) {
+    return (
+      <div className="rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-800 dark:bg-white/[0.03]">
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="h-16 animate-pulse rounded-xl bg-gray-100 dark:bg-gray-800"
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // Empty state
+  if (replays.length === 0) {
+    return (
+      <div className="rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03]">
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <div className="mb-4 rounded-full bg-gray-100 p-4 dark:bg-gray-800">
+            <Calendar className="h-8 w-8 text-gray-400" />
+          </div>
+          <h3 className="mb-2 text-lg font-semibold text-gray-800 dark:text-white/90">
+            No replays yet
+          </h3>
+          <p className="max-w-sm text-sm text-gray-500 dark:text-gray-400">
+            Add your first replay using the button above to start analyzing your performance.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-800 dark:bg-white/[0.03]">
-      <h3 className="text-xl font-semibold text-gray-800 dark:text-white/90">Replays</h3>
-      <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">Coming in Phase 4</p>
+    <div className="rounded-2xl border border-gray-200 bg-white p-5 sm:p-6 dark:border-gray-800 dark:bg-white/[0.03]">
+      {/* Section header */}
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-800 dark:text-white/90">
+            Replay Collection
+          </h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {searchTags.length > 0
+              ? `${filteredReplays.length} of ${replays.length} replays`
+              : `${replays.length} replays`}
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleCopyAllUrls}
+          disabled={filteredReplays.length === 0}
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+        >
+          {copied ? (
+            <>
+              <Check className="h-4 w-4 text-emerald-500" />
+              <span className="text-emerald-600 dark:text-emerald-400">Copied!</span>
+            </>
+          ) : (
+            <>
+              <Copy className="h-4 w-4" />
+              {searchTags.length > 0 ? "Copy Filtered URLs" : "Copy All URLs"}
+            </>
+          )}
+        </button>
+      </div>
+
+      {/* Tag filter */}
+      <div className="mb-4">
+        <TagInput
+          tags={searchTags}
+          onTagsChange={setSearchTags}
+          placeholder="Filter by opponent Pokemon..."
+        />
+      </div>
+
+      {/* Filter no-results */}
+      {filteredReplays.length === 0 && searchTags.length > 0 ? (
+        <div className="py-8 text-center">
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            No replays match your filters.
+          </p>
+          <button
+            type="button"
+            onClick={() => setSearchTags([])}
+            className="mt-2 text-sm text-brand-600 hover:text-brand-700 dark:text-brand-400 dark:hover:text-brand-300"
+          >
+            Clear filters
+          </button>
+        </div>
+      ) : (
+        /* Replay list */
+        <div className="space-y-2">
+          {filteredReplays.map((replay) => (
+            <CompactReplayCard
+              key={replay.id}
+              replay={replay}
+              isDeleting={deletingReplayId === replay.id}
+              isEditingNote={editingNoteId === replay.id}
+              isSavingNote={savingNoteId === replay.id}
+              noteText={noteText}
+              onDelete={handleDeleteReplay}
+              onStartEditNote={startEditingNote}
+              onCancelEditNote={cancelEditingNote}
+              onSaveNote={saveNote}
+              onNoteTextChange={setNoteText}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **TeamHeader** component with expanded/collapsed states (persisted in localStorage), team name, regulation badge, Pokemon sprites, quick stats, and "Add Replay" button
- **ReplaysPage** with full replay management: tag-based filtering by opponent Pokemon, "Copy All URLs", inline note editing (Ctrl+Enter/Escape), delete with loading states
- **AddReplayModal** with single replay and bulk import modes, URL validation, and progress tracking
- **CompactReplayCard** with result badge, opponent info/sprites, collapsible notes, and action buttons
- **ConfirmationModal** reusable dialog with danger/default variants
- **Delete Team** added to sidebar with confirmation modal, deletes team and redirects home
- **statsVersion** signal in ActiveTeamContext keeps header stats and replay list in sync after mutations

## Files
### Created
| File | Purpose |
|------|---------|
| `src/components/team/TeamHeader.tsx` | Shared team info header |
| `src/components/team/CompactReplayCard.tsx` | Replay list item |
| `src/components/modals/AddReplayModal.tsx` | Add/bulk import replay modal |
| `src/components/modals/ConfirmationModal.tsx` | Reusable confirmation dialog |

### Modified
| File | Change |
|------|--------|
| `src/layout/TeamLayout.tsx` | Render TeamHeader above Outlet |
| `src/pages/Team/ReplaysPage.tsx` | Replace stub with full implementation |
| `src/layout/AppSidebar.tsx` | Add Delete Team sub-item + ConfirmationModal |
| `src/context/ActiveTeamContext.tsx` | Add statsVersion for cross-component refresh |

## Test plan
- [ ] Navigate to a team — verify TeamHeader shows name, regulation badge, Pokemon sprites, and stats
- [ ] Toggle header collapsed/expanded — verify state persists across page refresh
- [ ] Click "Add Replay" — verify modal opens with single/bulk modes
- [ ] Add a replay via Showdown URL — verify it appears in the list immediately
- [ ] Edit replay notes inline (Ctrl+Enter to save, Escape to cancel)
- [ ] Delete a replay — verify loading state and removal from list
- [ ] Filter replays by opponent Pokemon using tag input
- [ ] "Copy All URLs" copies replay URLs to clipboard
- [ ] "Delete Team" in sidebar shows confirmation, deletes team, redirects to home
- [ ] Test dark mode toggle across all new components
- [ ] Test mobile viewport: header stacks, cards go full-width

🤖 Generated with [Claude Code](https://claude.com/claude-code)