### PR TITLE
Add Pokemon notes, matchup planner, and team member sync (Phase 6)

### DIFF
--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/TeamMemberController.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/TeamMemberController.java
@@ -106,6 +106,30 @@ public class TeamMemberController {
     }
 
     /**
+     * Sync team members from pokepaste
+     * POST /api/team-members/sync?teamId={teamId}
+     */
+    @PostMapping("/sync")
+    public ResponseEntity<TeamMemberDTO.SyncResponse> syncTeamMembers(
+            @RequestParam Long teamId,
+            Authentication authentication) {
+
+        Long userId = getCurrentUserId(authentication);
+        verifyTeamOwnership(teamId, userId);
+
+        TeamService.SyncResult result = teamService.syncTeamMembersFromPokepaste(teamId, userId);
+
+        TeamMemberDTO.SyncResponse response = new TeamMemberDTO.SyncResponse(
+                teamMemberMapper.toResponseList(result.members()),
+                result.kept(),
+                result.added(),
+                result.removed()
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
      * Delete a team member
      * DELETE /api/team-members/{id}
      */

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/dto/TeamMemberDTO.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/dto/TeamMemberDTO.java
@@ -50,4 +50,14 @@ public class TeamMemberDTO {
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
     }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SyncResponse {
+        private List<Response> members;
+        private List<String> kept;
+        private List<String> added;
+        private List<String> removed;
+    }
 }

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/TeamService.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/TeamService.java
@@ -1,17 +1,21 @@
 package com.yeskatronics.vs_recorder_backend.services;
 
+import com.yeskatronics.vs_recorder_backend.dto.PokepasteDTO;
 import com.yeskatronics.vs_recorder_backend.entities.Replay;
 import com.yeskatronics.vs_recorder_backend.entities.Team;
+import com.yeskatronics.vs_recorder_backend.entities.TeamMember;
 import com.yeskatronics.vs_recorder_backend.entities.User;
+import com.yeskatronics.vs_recorder_backend.repositories.TeamMemberRepository;
 import com.yeskatronics.vs_recorder_backend.repositories.TeamRepository;
 import com.yeskatronics.vs_recorder_backend.repositories.UserRepository;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Service class for Team entity business logic.
@@ -24,8 +28,11 @@ import java.util.Optional;
 public class TeamService {
 
     private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
     private final UserRepository userRepository;
     private final ReplayService replayService;
+    private final PokepasteService pokepasteService;
+    private final EntityManager entityManager;
 
     /**
      * Create a new team for a user
@@ -46,7 +53,38 @@ public class TeamService {
         Team savedTeam = teamRepository.save(team);
         log.info("Team created successfully with ID: {}", savedTeam.getId());
 
+        // Auto-create team members from pokepaste (best-effort)
+        if (savedTeam.getPokepaste() != null && !savedTeam.getPokepaste().isEmpty()) {
+            createTeamMembersFromPokepaste(savedTeam);
+        }
+
         return savedTeam;
+    }
+
+    /**
+     * Parse the team's pokepaste and create TeamMember entities (slots 1-6).
+     * Best-effort: if parsing fails, the team is still usable — members can be
+     * created later when the user visits the Pokemon Notes page.
+     */
+    private void createTeamMembersFromPokepaste(Team team) {
+        try {
+            PokepasteDTO.PasteData pasteData = pokepasteService.fetchPasteData(team.getPokepaste());
+            List<String> speciesNames = pokepasteService.extractSpeciesNames(pasteData);
+
+            for (int i = 0; i < speciesNames.size() && i < 6; i++) {
+                TeamMember member = new TeamMember();
+                member.setTeam(team);
+                member.setPokemonName(speciesNames.get(i));
+                member.setSlot(i + 1);
+                member.setNotes("");
+                teamMemberRepository.save(member);
+            }
+
+            log.info("Auto-created {} team members for team ID: {}", speciesNames.size(), team.getId());
+        } catch (Exception e) {
+            log.warn("Failed to auto-create team members from pokepaste for team ID: {} - {}",
+                    team.getId(), e.getMessage());
+        }
     }
 
     /**
@@ -259,6 +297,102 @@ public class TeamService {
     }
 
     /**
+     * Sync team members from the team's pokepaste URL.
+     * Performs a smart merge: keeps existing members that match, adds new ones, removes stale ones.
+     *
+     * @param teamId the team ID
+     * @param userId the user ID (for ownership verification)
+     * @return SyncResult with the updated member list and change details
+     */
+    public SyncResult syncTeamMembersFromPokepaste(Long teamId, Long userId) {
+        log.info("Syncing team members from pokepaste for team ID: {} user ID: {}", teamId, userId);
+
+        Team team = teamRepository.findByIdAndUserId(teamId, userId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Team not found with ID: " + teamId + " for user: " + userId));
+
+        if (team.getPokepaste() == null || team.getPokepaste().isEmpty()) {
+            throw new IllegalArgumentException("Team has no pokepaste URL");
+        }
+
+        // Parse pokepaste
+        PokepasteDTO.PasteData pasteData = pokepasteService.fetchPasteData(team.getPokepaste());
+        List<String> newNames = pokepasteService.extractSpeciesNames(pasteData);
+
+        // Get existing members
+        List<TeamMember> existingMembers = teamMemberRepository.findByTeamIdOrderBySlotAsc(teamId);
+
+        // Build a map of lowercase name -> existing member for matching
+        Map<String, TeamMember> existingByName = new LinkedHashMap<>();
+        for (TeamMember member : existingMembers) {
+            existingByName.put(member.getPokemonName().toLowerCase(), member);
+        }
+
+        List<String> kept = new ArrayList<>();
+        List<String> added = new ArrayList<>();
+        List<String> removed = new ArrayList<>();
+
+        // Track which existing members are matched
+        Set<String> matchedKeys = new HashSet<>();
+        // Map new slot -> kept member
+        Map<Integer, TeamMember> keptBySlot = new LinkedHashMap<>();
+
+        for (int i = 0; i < newNames.size() && i < 6; i++) {
+            String newName = newNames.get(i);
+            String key = newName.toLowerCase();
+
+            if (existingByName.containsKey(key) && !matchedKeys.contains(key)) {
+                TeamMember member = existingByName.get(key);
+                matchedKeys.add(key);
+                kept.add(newName);
+                keptBySlot.put(i + 1, member);
+            } else {
+                added.add(newName);
+            }
+        }
+
+        // 1. Delete removed members first to free up slots
+        for (Map.Entry<String, TeamMember> entry : existingByName.entrySet()) {
+            if (!matchedKeys.contains(entry.getKey())) {
+                removed.add(entry.getValue().getPokemonName());
+                teamMemberRepository.delete(entry.getValue());
+            }
+        }
+        entityManager.flush();
+
+        // 2. Move kept members to temporary slots (slot + 100) to avoid unique constraint conflicts
+        for (Map.Entry<Integer, TeamMember> entry : keptBySlot.entrySet()) {
+            entry.getValue().setSlot(entry.getKey() + 100);
+            teamMemberRepository.save(entry.getValue());
+        }
+        entityManager.flush();
+
+        // 3. Assign final slots to kept members and create new members
+        List<TeamMember> resultMembers = new ArrayList<>();
+        for (int i = 0; i < newNames.size() && i < 6; i++) {
+            String newName = newNames.get(i);
+            int slot = i + 1;
+
+            if (keptBySlot.containsKey(slot)) {
+                TeamMember member = keptBySlot.get(slot);
+                member.setSlot(slot);
+                member.setPokemonName(newName); // normalize casing
+                resultMembers.add(teamMemberRepository.save(member));
+            } else {
+                TeamMember member = new TeamMember();
+                member.setTeam(team);
+                member.setPokemonName(newName);
+                member.setSlot(slot);
+                member.setNotes("");
+                resultMembers.add(teamMemberRepository.save(member));
+            }
+        }
+
+        log.info("Sync complete for team {}: kept={}, added={}, removed={}", teamId, kept, added, removed);
+        return new SyncResult(resultMembers, kept, added, removed);
+    }
+
+    /**
      * Inner class to hold team statistics
      */
     public record TeamStats(
@@ -267,5 +401,12 @@ public class TeamService {
             int wins,
             int losses,
             double winRate
+    ) {}
+
+    public record SyncResult(
+            List<TeamMember> members,
+            List<String> kept,
+            List<String> added,
+            List<String> removed
     ) {}
 }

--- a/frontend-rewrite/src/components/form/PokemonDropdown.tsx
+++ b/frontend-rewrite/src/components/form/PokemonDropdown.tsx
@@ -1,0 +1,133 @@
+import React, { useState, useEffect, useRef } from "react";
+import { ChevronDown } from "lucide-react";
+import PokemonSprite from "../pokemon/PokemonSprite";
+import { getDisplayName } from "../../utils/pokemonNameUtils";
+
+interface PokemonDropdownProps {
+  options: string[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  showSprite?: boolean;
+}
+
+const PokemonDropdown: React.FC<PokemonDropdownProps> = ({
+  options = [],
+  value = "",
+  onChange,
+  placeholder = "Select Pokemon",
+  disabled = false,
+  showSprite = true,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState("");
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const filteredOptions = options.filter((option) =>
+    option.toLowerCase().includes(searchTerm.toLowerCase()),
+  );
+
+  const handleSelect = (option: string) => {
+    onChange(option);
+    setIsOpen(false);
+    setSearchTerm("");
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+        setSearchTerm("");
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [isOpen]);
+
+  return (
+    <div ref={dropdownRef} className="relative">
+      <button
+        type="button"
+        onClick={() => !disabled && setIsOpen(!isOpen)}
+        disabled={disabled}
+        className={`flex w-full items-center gap-2 rounded-lg border px-3 py-2 text-left text-sm transition-colors ${
+          disabled
+            ? "cursor-not-allowed opacity-50"
+            : "cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800"
+        } ${
+          value
+            ? "text-gray-800 dark:text-white/90"
+            : "text-gray-400 dark:text-gray-500"
+        } border-gray-300 bg-white focus:border-brand-300 focus:outline-none dark:border-gray-700 dark:bg-gray-900`}
+      >
+        {showSprite && value && (
+          <div className="flex-shrink-0">
+            <PokemonSprite name={value} size="sm" />
+          </div>
+        )}
+        <span className="flex-1 truncate">
+          {value ? getDisplayName(value) : placeholder}
+        </span>
+        <ChevronDown
+          className={`h-4 w-4 text-gray-400 transition-transform ${isOpen ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {isOpen && (
+        <div className="absolute z-50 mt-1 flex max-h-64 w-full flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-900">
+          {options.length > 5 && (
+            <div className="border-b border-gray-200 p-2 dark:border-gray-700">
+              <input
+                type="text"
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                placeholder="Search Pokemon..."
+                className="w-full rounded border border-gray-300 bg-transparent px-2 py-1 text-sm text-gray-800 placeholder-gray-400 focus:border-brand-300 focus:outline-none dark:border-gray-600 dark:text-white/90 dark:placeholder-gray-500"
+                autoFocus
+              />
+            </div>
+          )}
+
+          <div className="max-h-52 overflow-y-auto">
+            {filteredOptions.length === 0 ? (
+              <div className="px-3 py-2 text-center text-sm text-gray-400">
+                No Pokemon found
+              </div>
+            ) : (
+              filteredOptions.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  onClick={() => handleSelect(option)}
+                  className={`flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 ${
+                    value === option
+                      ? "bg-brand-50 text-brand-700 dark:bg-brand-500/10 dark:text-brand-400"
+                      : "text-gray-800 dark:text-white/90"
+                  }`}
+                >
+                  {showSprite && (
+                    <div className="flex-shrink-0">
+                      <PokemonSprite name={option} size="sm" />
+                    </div>
+                  )}
+                  <span className="text-sm">{getDisplayName(option)}</span>
+                  {value === option && (
+                    <span className="ml-auto text-brand-500 dark:text-brand-400">
+                      &#10003;
+                    </span>
+                  )}
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PokemonDropdown;

--- a/frontend-rewrite/src/components/modals/AddOpponentTeamModal.tsx
+++ b/frontend-rewrite/src/components/modals/AddOpponentTeamModal.tsx
@@ -1,0 +1,175 @@
+import React, { useState } from "react";
+import { Link as LinkIcon, AlertCircle } from "lucide-react";
+import { Modal } from "../ui/modal";
+import * as pokepasteService from "../../services/pokepasteService";
+
+const COLOR_CHOICES = [
+  { key: "blue", bg: "bg-blue-500" },
+  { key: "red", bg: "bg-red-500" },
+  { key: "green", bg: "bg-green-500" },
+  { key: "yellow", bg: "bg-yellow-500" },
+  { key: "purple", bg: "bg-purple-500" },
+  { key: "pink", bg: "bg-pink-500" },
+  { key: "orange", bg: "bg-orange-500" },
+  { key: "teal", bg: "bg-teal-500" },
+  { key: "gray", bg: "bg-gray-500" },
+];
+
+interface AddOpponentTeamModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: { pokepaste: string; notes?: string; color?: string }) => Promise<void>;
+}
+
+const AddOpponentTeamModal: React.FC<AddOpponentTeamModalProps> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+}) => {
+  const [formData, setFormData] = useState({
+    pokepaste: "",
+    notes: "",
+    color: "blue",
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleInputChange = (field: string, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    if (error) setError("");
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!formData.pokepaste.trim()) {
+      setError("Pokepaste or Pokebin URL is required");
+      return;
+    }
+
+    if (!pokepasteService.isValidPokepasteUrl(formData.pokepaste.trim())) {
+      setError(
+        "Please enter a valid Pokepaste or Pokebin URL (e.g., https://pokepast.es/abc123 or https://pokebin.com/abc123)",
+      );
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError("");
+
+      await onSubmit({
+        pokepaste: formData.pokepaste.trim(),
+        notes: formData.notes.trim() || "",
+        color: formData.color,
+      });
+
+      setFormData({ pokepaste: "", notes: "", color: "blue" });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add matchup team. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} className="max-w-md">
+      <div className="p-6">
+        <h2 className="mb-6 text-xl font-semibold text-gray-800 dark:text-white/90">
+          Add Matchup Team
+        </h2>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <div className="flex items-center gap-2 rounded-lg border border-red-300 bg-red-50 p-3 dark:border-red-500/50 dark:bg-red-900/20">
+              <AlertCircle className="h-4 w-4 flex-shrink-0 text-red-500 dark:text-red-400" />
+              <span className="text-sm text-red-700 dark:text-red-300">{error}</span>
+            </div>
+          )}
+
+          {/* Paste URL */}
+          <div>
+            <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              <LinkIcon className="mr-1 inline h-4 w-4" />
+              Pokepaste / Pokebin URL *
+            </label>
+            <input
+              type="url"
+              value={formData.pokepaste}
+              onChange={(e) => handleInputChange("pokepaste", e.target.value)}
+              placeholder="https://pokepast.es/... or https://pokebin.com/..."
+              className="w-full rounded-lg border border-gray-300 bg-transparent px-3 py-2 text-sm text-gray-800 placeholder-gray-400 focus:border-brand-300 focus:outline-none focus:ring-3 focus:ring-brand-500/10 dark:border-gray-700 dark:text-white/90 dark:placeholder-gray-500"
+              disabled={loading}
+              required
+            />
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              Link to the matchup team on Pokepaste or Pokebin
+            </p>
+          </div>
+
+          {/* Notes */}
+          <div>
+            <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Notes
+            </label>
+            <textarea
+              value={formData.notes}
+              onChange={(e) => handleInputChange("notes", e.target.value)}
+              placeholder="Add player name, team notes, or playstyle observations..."
+              className="w-full rounded-lg border border-gray-300 bg-transparent px-3 py-2 text-sm text-gray-800 placeholder-gray-400 focus:border-brand-300 focus:outline-none focus:ring-3 focus:ring-brand-500/10 dark:border-gray-700 dark:text-white/90 dark:placeholder-gray-500"
+              rows={4}
+              disabled={loading}
+            />
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              Tip: Start with the player's name for easy identification
+            </p>
+          </div>
+
+          {/* Card Color */}
+          <div>
+            <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Card Color
+            </label>
+            <div className="flex gap-2">
+              {COLOR_CHOICES.map(({ key, bg }) => (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => handleInputChange("color", key)}
+                  className={`h-6 w-6 rounded ${bg} transition-transform hover:scale-110 ${
+                    formData.color === key
+                      ? "ring-2 ring-white ring-offset-1 ring-offset-white dark:ring-offset-gray-900"
+                      : ""
+                  }`}
+                  title={key}
+                  disabled={loading}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Action Buttons */}
+          <div className="flex gap-3 pt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+              disabled={loading}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="flex-1 rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-600 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={loading}
+            >
+              {loading ? "Adding..." : "Add Team"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </Modal>
+  );
+};
+
+export default AddOpponentTeamModal;

--- a/frontend-rewrite/src/components/team/OpponentTeamCard.tsx
+++ b/frontend-rewrite/src/components/team/OpponentTeamCard.tsx
@@ -1,0 +1,769 @@
+import React, { useState, useEffect } from "react";
+import {
+  Plus,
+  Trash2,
+  Edit3,
+  Save,
+  X as XIcon,
+  ExternalLink,
+} from "lucide-react";
+import PokemonTeam from "../pokemon/PokemonTeam";
+import PokemonSprite from "../pokemon/PokemonSprite";
+import PokemonDropdown from "../form/PokemonDropdown";
+import ConfirmationModal from "../modals/ConfirmationModal";
+import * as pokepasteService from "../../services/pokepasteService";
+import type { Composition } from "../../types";
+
+const COLOR_OPTIONS: Record<string, { border: string; bg: string }> = {
+  blue: { border: "border-l-blue-500", bg: "bg-blue-500" },
+  red: { border: "border-l-red-500", bg: "bg-red-500" },
+  green: { border: "border-l-green-500", bg: "bg-green-500" },
+  yellow: { border: "border-l-yellow-500", bg: "bg-yellow-500" },
+  purple: { border: "border-l-purple-500", bg: "bg-purple-500" },
+  pink: { border: "border-l-pink-500", bg: "bg-pink-500" },
+  orange: { border: "border-l-orange-500", bg: "bg-orange-500" },
+  teal: { border: "border-l-teal-500", bg: "bg-teal-500" },
+  gray: { border: "border-l-gray-500", bg: "bg-gray-500" },
+};
+
+export interface OpponentTeam {
+  id: number;
+  teamId: number;
+  gamePlanId: number;
+  pokepaste: string;
+  notes: string;
+  color: string;
+  compositions: Composition[];
+  createdAt: string;
+}
+
+interface OpponentTeamCardProps {
+  opponentTeam: OpponentTeam;
+  myTeamPokemon: string[];
+  onUpdateNotes: (
+    id: number,
+    updates: { pokepaste?: string; notes?: string; color?: string },
+  ) => Promise<void>;
+  onAddComposition: (id: number, composition: Composition) => Promise<unknown>;
+  onUpdateComposition: (
+    id: number,
+    index: number,
+    composition: Composition,
+  ) => Promise<unknown>;
+  onDeleteComposition: (id: number, index: number) => Promise<unknown>;
+  onDeleteTeam: (id: number) => Promise<unknown>;
+}
+
+const OpponentTeamCard: React.FC<OpponentTeamCardProps> = ({
+  opponentTeam,
+  myTeamPokemon = [],
+  onUpdateNotes,
+  onAddComposition,
+  onUpdateComposition,
+  onDeleteComposition,
+  onDeleteTeam,
+}) => {
+  const [isEditingNotes, setIsEditingNotes] = useState(false);
+  const [editedNotes, setEditedNotes] = useState(opponentTeam.notes || "");
+  const [editedPokepaste, setEditedPokepaste] = useState(
+    opponentTeam.pokepaste || "",
+  );
+  const [pasteTitle, setPasteTitle] = useState<string | null>(null);
+  const [loadingTitle, setLoadingTitle] = useState(false);
+  const [showDeleteTeamModal, setShowDeleteTeamModal] = useState(false);
+  const [showDeletePlanModal, setShowDeletePlanModal] = useState(false);
+  const [deletingPlanIndex, setDeletingPlanIndex] = useState<number | null>(
+    null,
+  );
+  const [isAddingPlan, setIsAddingPlan] = useState(false);
+
+  const teamColor = COLOR_OPTIONS[opponentTeam.color] || COLOR_OPTIONS.blue;
+
+  useEffect(() => {
+    const fetchTitle = async () => {
+      if (!opponentTeam.pokepaste) {
+        setPasteTitle(null);
+        return;
+      }
+
+      setLoadingTitle(true);
+      try {
+        const parsed = await pokepasteService.fetchAndParse(
+          opponentTeam.pokepaste,
+        );
+        const firstMon = parsed[0];
+        setPasteTitle(firstMon?.name || null);
+      } catch {
+        setPasteTitle(null);
+      } finally {
+        setLoadingTitle(false);
+      }
+    };
+
+    fetchTitle();
+  }, [opponentTeam.pokepaste]);
+
+  const handleSaveNotes = async () => {
+    try {
+      await onUpdateNotes(opponentTeam.id, {
+        notes: editedNotes,
+        pokepaste: editedPokepaste,
+      });
+      setIsEditingNotes(false);
+    } catch (error) {
+      console.error("Failed to save notes:", error);
+    }
+  };
+
+  const handleCancelEditNotes = () => {
+    setEditedNotes(opponentTeam.notes || "");
+    setEditedPokepaste(opponentTeam.pokepaste || "");
+    setIsEditingNotes(false);
+  };
+
+  const handleDeletePlanClick = (index: number) => {
+    setDeletingPlanIndex(index);
+    setShowDeletePlanModal(true);
+  };
+
+  const handleConfirmDeletePlan = async () => {
+    if (deletingPlanIndex === null) return;
+    try {
+      await onDeleteComposition(opponentTeam.id, deletingPlanIndex);
+      setShowDeletePlanModal(false);
+      setDeletingPlanIndex(null);
+    } catch (error) {
+      console.error("Failed to delete plan:", error);
+    }
+  };
+
+  const handleConfirmDeleteTeam = async () => {
+    try {
+      await onDeleteTeam(opponentTeam.id);
+      setShowDeleteTeamModal(false);
+    } catch (error) {
+      console.error("Failed to delete team:", error);
+    }
+  };
+
+  const compositions = opponentTeam.compositions || [];
+
+  return (
+    <div
+      className={`rounded-lg border border-l-4 border-gray-200 dark:border-gray-700 ${teamColor.border}`}
+    >
+      {/* Header */}
+      <div className="rounded-t-lg border-b border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-white/[0.02]">
+        <div className="flex items-start gap-4">
+          {/* Opponent Team Sprites */}
+          <div className="w-fit flex-shrink-0">
+            <div className="mb-2 flex max-w-[280px] items-center gap-2">
+              <h3
+                className="truncate text-sm font-semibold text-gray-800 dark:text-white/90"
+                title={pasteTitle || "Matchup Team"}
+              >
+                {loadingTitle
+                  ? "Loading..."
+                  : pasteTitle || "Matchup Team"}
+              </h3>
+              {opponentTeam.pokepaste && (
+                <a
+                  href={opponentTeam.pokepaste}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex-shrink-0 text-gray-400 transition-colors hover:text-brand-500"
+                  title="View Pokepaste"
+                >
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+              )}
+            </div>
+            {opponentTeam.pokepaste && (
+              <PokemonTeam pokepasteUrl={opponentTeam.pokepaste} size="md" />
+            )}
+          </div>
+
+          {/* Notes */}
+          <div className="min-w-0 flex-1">
+            <div className="mb-2 flex items-center justify-between">
+              <h4 className="text-sm font-semibold text-gray-800 dark:text-white/90">
+                Notes
+              </h4>
+              {!isEditingNotes && (
+                <button
+                  onClick={() => setIsEditingNotes(true)}
+                  className="flex items-center gap-1 text-xs text-brand-500 hover:text-brand-600 dark:text-brand-400 dark:hover:text-brand-300"
+                >
+                  <Edit3 className="h-3 w-3" />
+                  Edit
+                </button>
+              )}
+            </div>
+            {isEditingNotes ? (
+              <div className="space-y-2">
+                <div>
+                  <label className="mb-1 block text-xs text-gray-500 dark:text-gray-400">
+                    Pokepaste URL
+                  </label>
+                  <input
+                    type="text"
+                    value={editedPokepaste}
+                    onChange={(e) => setEditedPokepaste(e.target.value)}
+                    className="w-full rounded-lg border border-gray-300 bg-transparent px-3 py-2 text-sm text-gray-800 placeholder-gray-400 focus:border-brand-300 focus:outline-none dark:border-gray-700 dark:text-white/90 dark:placeholder-gray-500"
+                    placeholder="https://pokepast.es/..."
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs text-gray-500 dark:text-gray-400">
+                    Notes
+                  </label>
+                  <textarea
+                    value={editedNotes}
+                    onChange={(e) => setEditedNotes(e.target.value)}
+                    className="w-full rounded-lg border border-gray-300 bg-transparent px-3 py-2 text-sm text-gray-800 placeholder-gray-400 focus:border-brand-300 focus:outline-none dark:border-gray-700 dark:text-white/90 dark:placeholder-gray-500"
+                    rows={2}
+                    placeholder="Add notes about this matchup..."
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs text-gray-500 dark:text-gray-400">
+                    Card Color
+                  </label>
+                  <div className="flex gap-1.5">
+                    {Object.entries(COLOR_OPTIONS).map(([key, val]) => (
+                      <button
+                        key={key}
+                        type="button"
+                        onClick={() =>
+                          onUpdateNotes(opponentTeam.id, { color: key })
+                        }
+                        className={`h-5 w-5 rounded ${val.bg} transition-transform hover:scale-110 ${
+                          (opponentTeam.color || "blue") === key
+                            ? "ring-2 ring-white ring-offset-1 ring-offset-white dark:ring-offset-gray-900"
+                            : ""
+                        }`}
+                        title={key}
+                      />
+                    ))}
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleSaveNotes}
+                    className="flex items-center gap-1 rounded bg-brand-500 px-3 py-1 text-xs text-white transition-colors hover:bg-brand-600"
+                  >
+                    <Save className="h-3 w-3" />
+                    Save
+                  </button>
+                  <button
+                    onClick={handleCancelEditNotes}
+                    className="flex items-center gap-1 rounded border border-gray-300 px-3 py-1 text-xs text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+                  >
+                    <XIcon className="h-3 w-3" />
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <p className="whitespace-pre-wrap text-sm text-gray-500 dark:text-gray-400">
+                {opponentTeam.notes || "No notes. Click Edit to add."}
+              </p>
+            )}
+          </div>
+
+          {/* Delete Team Button */}
+          <button
+            onClick={() => setShowDeleteTeamModal(true)}
+            className="flex-shrink-0 rounded p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-500/10 dark:hover:text-red-400"
+            title="Delete matchup team"
+          >
+            <Trash2 className="h-3 w-3" />
+          </button>
+        </div>
+      </div>
+
+      {/* Strategy Plans Section */}
+      <div className="p-4">
+        <div className="mb-3 flex items-center justify-between">
+          <h4 className="text-sm font-semibold text-gray-800 dark:text-white/90">
+            Strategy Plans ({compositions.length})
+          </h4>
+          {!isAddingPlan && (
+            <button
+              onClick={() => setIsAddingPlan(true)}
+              className="rounded p-1.5 text-gray-400 transition-colors hover:bg-brand-50 hover:text-brand-500 dark:hover:bg-brand-500/10 dark:hover:text-brand-400"
+              title="Add strategy plan"
+            >
+              <Plus className="h-3 w-3" />
+            </button>
+          )}
+        </div>
+
+        <div className="space-y-3">
+          {isAddingPlan && (
+            <AddPlanRow
+              myTeamPokemon={myTeamPokemon}
+              onSave={async (composition) => {
+                await onAddComposition(opponentTeam.id, composition);
+                setIsAddingPlan(false);
+              }}
+              onCancel={() => setIsAddingPlan(false)}
+            />
+          )}
+
+          {compositions.map((composition, index) => (
+            <PlanRow
+              key={index}
+              composition={composition}
+              index={index}
+              myTeamPokemon={myTeamPokemon}
+              onUpdate={(updated) =>
+                onUpdateComposition(opponentTeam.id, index, updated)
+              }
+              onDelete={() => handleDeletePlanClick(index)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Delete Plan Modal */}
+      <ConfirmationModal
+        isOpen={showDeletePlanModal}
+        title="Delete Strategy Plan"
+        message="Are you sure you want to delete this strategy plan? This action cannot be undone."
+        onConfirm={handleConfirmDeletePlan}
+        onCancel={() => {
+          setShowDeletePlanModal(false);
+          setDeletingPlanIndex(null);
+        }}
+        confirmText="Delete Plan"
+        variant="danger"
+      />
+
+      {/* Delete Team Modal */}
+      <ConfirmationModal
+        isOpen={showDeleteTeamModal}
+        title="Delete Matchup Team"
+        message={
+          <div>
+            <p className="mb-2">
+              Are you sure you want to delete this matchup team?
+            </p>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              This will delete {compositions.length} strategy{" "}
+              {compositions.length === 1 ? "plan" : "plans"} associated with
+              this team.
+            </p>
+            <p className="mt-2 text-sm font-medium text-red-500 dark:text-red-400">
+              This action cannot be undone.
+            </p>
+          </div>
+        }
+        onConfirm={handleConfirmDeleteTeam}
+        onCancel={() => setShowDeleteTeamModal(false)}
+        confirmText="Delete Team"
+        variant="danger"
+      />
+    </div>
+  );
+};
+
+/* ---------- PlanRow ---------- */
+
+interface PlanRowProps {
+  composition: Composition;
+  index: number;
+  myTeamPokemon: string[];
+  onUpdate: (updated: Composition) => Promise<unknown>;
+  onDelete: () => void;
+}
+
+const PlanRow: React.FC<PlanRowProps> = ({
+  composition,
+  index,
+  myTeamPokemon,
+  onUpdate,
+  onDelete,
+}) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [formData, setFormData] = useState({
+    lead1: composition.lead1 || "",
+    lead2: composition.lead2 || "",
+    back1: composition.back1 || "",
+    back2: composition.back2 || "",
+    notes: composition.notes || "",
+  });
+  const [validationError, setValidationError] = useState("");
+
+  const handleSave = async () => {
+    const { lead1, lead2, back1, back2 } = formData;
+    if (!lead1 || !lead2 || !back1 || !back2) {
+      setValidationError("All 4 Pokemon must be selected");
+      return;
+    }
+
+    if (new Set([lead1, lead2, back1, back2]).size !== 4) {
+      setValidationError("Cannot select the same Pokemon twice");
+      return;
+    }
+
+    try {
+      setValidationError("");
+      await onUpdate(formData);
+      setIsEditing(false);
+    } catch (error) {
+      console.error("Failed to update plan:", error);
+    }
+  };
+
+  const handleCancel = () => {
+    setFormData({
+      lead1: composition.lead1 || "",
+      lead2: composition.lead2 || "",
+      back1: composition.back1 || "",
+      back2: composition.back2 || "",
+      notes: composition.notes || "",
+    });
+    setValidationError("");
+    setIsEditing(false);
+  };
+
+  if (isEditing) {
+    return (
+      <div className="rounded-lg border border-brand-300 bg-brand-50/50 p-3 dark:border-brand-500/40 dark:bg-brand-500/5">
+        {validationError && (
+          <p className="mb-2 text-xs text-red-500 dark:text-red-400">
+            {validationError}
+          </p>
+        )}
+        <div className="grid grid-cols-12 items-stretch gap-2">
+          <div className="col-span-1 pt-2">
+            <span className="text-xs font-semibold text-brand-600 dark:text-brand-400">
+              Plan {index + 1}
+            </span>
+          </div>
+
+          <div className="col-span-4 flex justify-center gap-2">
+            <div className="min-w-0 flex-1">
+              <p className="mb-0.5 text-center text-xs text-brand-600 dark:text-brand-400">
+                Leads
+              </p>
+              <div className="space-y-1">
+                <PokemonDropdown
+                  options={myTeamPokemon}
+                  value={formData.lead1}
+                  onChange={(value) =>
+                    setFormData({ ...formData, lead1: value })
+                  }
+                  placeholder="Lead 1"
+                  showSprite={false}
+                />
+                <PokemonDropdown
+                  options={myTeamPokemon}
+                  value={formData.lead2}
+                  onChange={(value) =>
+                    setFormData({ ...formData, lead2: value })
+                  }
+                  placeholder="Lead 2"
+                  showSprite={false}
+                />
+              </div>
+            </div>
+
+            <div className="min-w-0 flex-1">
+              <p className="mb-0.5 text-center text-xs text-blue-600 dark:text-blue-400">
+                Back
+              </p>
+              <div className="space-y-1">
+                <PokemonDropdown
+                  options={myTeamPokemon}
+                  value={formData.back1}
+                  onChange={(value) =>
+                    setFormData({ ...formData, back1: value })
+                  }
+                  placeholder="Back 1"
+                  showSprite={false}
+                />
+                <PokemonDropdown
+                  options={myTeamPokemon}
+                  value={formData.back2}
+                  onChange={(value) =>
+                    setFormData({ ...formData, back2: value })
+                  }
+                  placeholder="Back 2"
+                  showSprite={false}
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className="col-span-6 flex flex-col">
+            <p className="mb-0.5 text-xs text-gray-500 dark:text-gray-400">
+              Notes
+            </p>
+            <textarea
+              value={formData.notes}
+              onChange={(e) =>
+                setFormData({ ...formData, notes: e.target.value })
+              }
+              placeholder="Strategy notes..."
+              className="w-full flex-1 resize-none rounded border border-gray-300 bg-transparent px-2 py-1.5 text-sm text-gray-800 placeholder-gray-400 focus:border-brand-300 focus:outline-none dark:border-gray-600 dark:text-white/90 dark:placeholder-gray-500"
+            />
+          </div>
+
+          <div className="col-span-1 flex justify-end gap-1 pt-2">
+            <button
+              onClick={handleSave}
+              className="rounded p-1.5 text-gray-400 transition-colors hover:bg-brand-50 hover:text-brand-500 dark:hover:bg-brand-500/10 dark:hover:text-brand-400"
+              title="Save"
+            >
+              <Save className="h-3 w-3" />
+            </button>
+            <button
+              onClick={handleCancel}
+              className="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+              title="Cancel"
+            >
+              <XIcon className="h-3 w-3" />
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-3 transition-colors hover:border-gray-300 dark:border-gray-700 dark:bg-white/[0.02] dark:hover:border-gray-600">
+      <div className="grid grid-cols-12 items-start gap-2">
+        <div className="col-span-1 pt-2">
+          <span className="text-xs font-semibold text-gray-500 dark:text-gray-400">
+            Plan {index + 1}
+          </span>
+        </div>
+
+        <div className="col-span-4 flex justify-center gap-2">
+          <div>
+            <p className="mb-0.5 text-center text-xs text-brand-600 dark:text-brand-400">
+              Leads
+            </p>
+            <div className="rounded-lg border border-brand-200 bg-brand-50/50 p-1 dark:border-brand-400/30 dark:bg-brand-200/10">
+              <div className="flex gap-0.5">
+                <PokemonSprite
+                  name={composition.lead1}
+                  size="md"
+                  showTooltip={true}
+                />
+                <PokemonSprite
+                  name={composition.lead2}
+                  size="md"
+                  showTooltip={true}
+                />
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <p className="mb-0.5 text-center text-xs text-blue-600 dark:text-blue-400">
+              Back
+            </p>
+            <div className="rounded-lg border border-blue-200 bg-blue-50/50 p-1 dark:border-blue-400/30 dark:bg-blue-200/10">
+              <div className="flex gap-0.5">
+                <PokemonSprite
+                  name={composition.back1}
+                  size="md"
+                  showTooltip={true}
+                />
+                <PokemonSprite
+                  name={composition.back2}
+                  size="md"
+                  showTooltip={true}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="col-span-6">
+          <p className="mb-0.5 text-xs text-gray-500 dark:text-gray-400">
+            Notes
+          </p>
+          <div className="rounded-lg bg-gray-50 p-2 dark:bg-white/[0.03]">
+            {composition.notes ? (
+              <p className="break-words whitespace-pre-wrap text-sm text-gray-700 dark:text-gray-300">
+                {composition.notes}
+              </p>
+            ) : (
+              <p className="text-sm italic text-gray-400 dark:text-gray-500">
+                No notes
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="col-span-1 flex justify-end gap-1 pt-2">
+          <button
+            onClick={() => setIsEditing(true)}
+            className="rounded p-1.5 text-gray-400 transition-colors hover:bg-blue-50 hover:text-blue-500 dark:hover:bg-blue-500/10 dark:hover:text-blue-400"
+            title="Edit"
+          >
+            <Edit3 className="h-3 w-3" />
+          </button>
+          <button
+            onClick={onDelete}
+            className="rounded p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-500/10 dark:hover:text-red-400"
+            title="Delete"
+          >
+            <Trash2 className="h-3 w-3" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/* ---------- AddPlanRow ---------- */
+
+interface AddPlanRowProps {
+  myTeamPokemon: string[];
+  onSave: (composition: Composition) => Promise<void>;
+  onCancel: () => void;
+}
+
+const AddPlanRow: React.FC<AddPlanRowProps> = ({
+  myTeamPokemon,
+  onSave,
+  onCancel,
+}) => {
+  const [formData, setFormData] = useState({
+    lead1: "",
+    lead2: "",
+    back1: "",
+    back2: "",
+    notes: "",
+  });
+  const [validationError, setValidationError] = useState("");
+
+  const handleSave = async () => {
+    const { lead1, lead2, back1, back2 } = formData;
+    if (!lead1 || !lead2 || !back1 || !back2) {
+      setValidationError("All 4 Pokemon must be selected");
+      return;
+    }
+
+    if (new Set([lead1, lead2, back1, back2]).size !== 4) {
+      setValidationError("Cannot select the same Pokemon twice");
+      return;
+    }
+
+    try {
+      setValidationError("");
+      await onSave(formData);
+    } catch (error) {
+      console.error("Failed to add plan:", error);
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-brand-300 bg-brand-50/30 p-3 dark:border-brand-500/40 dark:bg-brand-900/20">
+      {validationError && (
+        <p className="mb-2 text-xs text-red-500 dark:text-red-400">
+          {validationError}
+        </p>
+      )}
+      <div className="grid grid-cols-12 items-stretch gap-2">
+        <div className="col-span-1 pt-2">
+          <span className="text-xs font-semibold text-brand-600 dark:text-brand-400">
+            New
+          </span>
+        </div>
+
+        <div className="col-span-4 flex justify-center gap-2">
+          <div className="min-w-0 flex-1">
+            <p className="mb-0.5 text-center text-xs text-brand-600 dark:text-brand-400">
+              Leads
+            </p>
+            <div className="space-y-1">
+              <PokemonDropdown
+                options={myTeamPokemon}
+                value={formData.lead1}
+                onChange={(value) =>
+                  setFormData({ ...formData, lead1: value })
+                }
+                placeholder="Lead 1"
+                showSprite={false}
+              />
+              <PokemonDropdown
+                options={myTeamPokemon}
+                value={formData.lead2}
+                onChange={(value) =>
+                  setFormData({ ...formData, lead2: value })
+                }
+                placeholder="Lead 2"
+                showSprite={false}
+              />
+            </div>
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <p className="mb-0.5 text-center text-xs text-blue-600 dark:text-blue-400">
+              Back
+            </p>
+            <div className="space-y-1">
+              <PokemonDropdown
+                options={myTeamPokemon}
+                value={formData.back1}
+                onChange={(value) =>
+                  setFormData({ ...formData, back1: value })
+                }
+                placeholder="Back 1"
+                showSprite={false}
+              />
+              <PokemonDropdown
+                options={myTeamPokemon}
+                value={formData.back2}
+                onChange={(value) =>
+                  setFormData({ ...formData, back2: value })
+                }
+                placeholder="Back 2"
+                showSprite={false}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="col-span-6 flex flex-col">
+          <p className="mb-0.5 text-xs text-gray-500 dark:text-gray-400">
+            Notes
+          </p>
+          <textarea
+            value={formData.notes}
+            onChange={(e) =>
+              setFormData({ ...formData, notes: e.target.value })
+            }
+            placeholder="Strategy notes..."
+            className="w-full flex-1 resize-none rounded border border-gray-300 bg-transparent px-2 py-1.5 text-sm text-gray-800 placeholder-gray-400 focus:border-brand-300 focus:outline-none dark:border-gray-600 dark:text-white/90 dark:placeholder-gray-500"
+          />
+        </div>
+
+        <div className="col-span-1 flex justify-end gap-1 pt-2">
+          <button
+            onClick={handleSave}
+            className="rounded p-1.5 text-gray-400 transition-colors hover:bg-brand-50 hover:text-brand-500 dark:hover:bg-brand-500/10 dark:hover:text-brand-400"
+            title="Save"
+          >
+            <Save className="h-3 w-3" />
+          </button>
+          <button
+            onClick={onCancel}
+            className="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+            title="Cancel"
+          >
+            <XIcon className="h-3 w-3" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OpponentTeamCard;

--- a/frontend-rewrite/src/components/team/PokemonNoteCard.tsx
+++ b/frontend-rewrite/src/components/team/PokemonNoteCard.tsx
@@ -1,0 +1,202 @@
+import React, { useState } from "react";
+import { Save, MessageSquare, ChevronDown, X } from "lucide-react";
+import PokemonSprite from "../pokemon/PokemonSprite";
+import type { TeamMember } from "../../types";
+
+interface PokemonNoteCardProps {
+  member: TeamMember;
+  isEditingNote: boolean;
+  isSavingNote: boolean;
+  noteText: string;
+  onStartEditingNote: (member: TeamMember) => void;
+  onCancelEditingNote: () => void;
+  onSaveNote: (memberId: number) => void;
+  onNoteTextChange: (text: string) => void;
+  onKeyPress: (e: React.KeyboardEvent, memberId: number) => void;
+  onAddCalc: (memberId: number, calcText: string) => Promise<void>;
+  onRemoveCalc: (memberId: number, index: number) => Promise<void>;
+}
+
+const PokemonNoteCard: React.FC<PokemonNoteCardProps> = ({
+  member,
+  isEditingNote,
+  isSavingNote,
+  noteText,
+  onStartEditingNote,
+  onCancelEditingNote,
+  onSaveNote,
+  onNoteTextChange,
+  onKeyPress,
+  onAddCalc,
+  onRemoveCalc,
+}) => {
+  const [isNoteExpanded, setIsNoteExpanded] = useState(true);
+  const [isCalcsExpanded, setIsCalcsExpanded] = useState(true);
+  const [calcInput, setCalcInput] = useState("");
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-white/[0.02] dark:hover:bg-white/[0.04]">
+      <div className="flex items-center justify-between">
+        <div className="flex flex-1 items-center gap-4">
+          <PokemonSprite name={member.pokemonName} size="lg" showTooltip={false} />
+          <div className="min-w-0 flex-1">
+            <span className="text-sm font-medium text-gray-800 dark:text-white/90">
+              {member.pokemonName}
+            </span>
+            {!member.notes && !isEditingNote && (
+              <p className="mt-0.5 text-xs text-gray-400 dark:text-gray-500">
+                No notes yet
+              </p>
+            )}
+          </div>
+        </div>
+
+        <button
+          onClick={() => onStartEditingNote(member)}
+          disabled={isEditingNote || isSavingNote}
+          className="rounded p-1.5 text-gray-400 transition-colors hover:bg-blue-50 hover:text-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-blue-500/10 dark:hover:text-blue-400"
+          title="Edit notes"
+        >
+          <MessageSquare className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Collapsible Notes */}
+      {member.notes && !isEditingNote && (
+        <button
+          type="button"
+          onClick={() => setIsNoteExpanded(!isNoteExpanded)}
+          className={`group mt-2 flex w-full items-start gap-1.5 rounded-b-md border-t border-gray-200 pt-2 text-left dark:border-gray-700 ${
+            isNoteExpanded ? "bg-gray-50 p-2 dark:bg-white/[0.03]" : ""
+          }`}
+        >
+          <ChevronDown
+            className={`mt-0.5 h-3 w-3 flex-shrink-0 text-gray-400 transition-transform dark:text-gray-500 ${
+              isNoteExpanded ? "rotate-180" : ""
+            }`}
+          />
+          <p
+            className={`text-sm ${
+              isNoteExpanded
+                ? "break-words whitespace-pre-wrap text-gray-700 dark:text-gray-300"
+                : "truncate text-gray-500 dark:text-gray-400"
+            }`}
+          >
+            {member.notes}
+          </p>
+        </button>
+      )}
+
+      {/* Inline Note Editor */}
+      {isEditingNote && (
+        <div className="mt-3 space-y-2 border-t border-gray-200 pt-3 dark:border-gray-700">
+          <textarea
+            value={noteText}
+            onChange={(e) => onNoteTextChange(e.target.value)}
+            onKeyDown={(e) => onKeyPress(e, member.id)}
+            placeholder={`Add notes about ${member.pokemonName}...`}
+            rows={6}
+            className="w-full resize-none rounded border border-gray-300 bg-transparent px-3 py-2 text-base text-gray-800 placeholder-gray-400 focus:border-blue-400 focus:outline-none dark:border-gray-600 dark:text-white/90 dark:placeholder-gray-500"
+            disabled={isSavingNote}
+            autoFocus
+          />
+
+          <div className="flex items-center justify-between">
+            <p className="text-xs text-gray-400 dark:text-gray-500">
+              Ctrl+Enter to save, Escape to cancel
+            </p>
+
+            <div className="flex gap-2">
+              <button
+                onClick={() => onSaveNote(member.id)}
+                disabled={isSavingNote}
+                className="flex items-center gap-1 rounded bg-blue-600 px-3 py-1 text-xs text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isSavingNote ? (
+                  <>
+                    <div className="h-2 w-2 animate-spin rounded-full border border-white border-t-transparent" />
+                    Saving...
+                  </>
+                ) : (
+                  <>
+                    <Save className="h-2 w-2" />
+                    Save
+                  </>
+                )}
+              </button>
+              <button
+                onClick={onCancelEditingNote}
+                disabled={isSavingNote}
+                className="px-3 py-1 text-xs text-gray-500 transition-colors hover:text-gray-700 disabled:opacity-50 dark:text-gray-400 dark:hover:text-gray-200"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Collapsible Calcs Section */}
+      <div className="mt-2 border-t border-gray-200 pt-2 dark:border-gray-700">
+        <button
+          type="button"
+          onClick={() => setIsCalcsExpanded(!isCalcsExpanded)}
+          className="group flex w-full items-center gap-1.5 text-left"
+        >
+          <ChevronDown
+            className={`h-3 w-3 flex-shrink-0 text-gray-400 transition-transform dark:text-gray-500 ${
+              isCalcsExpanded ? "rotate-180" : ""
+            }`}
+          />
+          <span className="text-xs font-medium text-gray-500 transition-colors group-hover:text-gray-700 dark:text-gray-400 dark:group-hover:text-gray-300">
+            Calcs
+          </span>
+          {member.calcs?.length > 0 && (
+            <span className="rounded-full bg-gray-200 px-1.5 text-xs text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+              {member.calcs.length}
+            </span>
+          )}
+        </button>
+
+        {isCalcsExpanded && (
+          <div className="mt-2 space-y-1">
+            {member.calcs?.map((calc, index) => (
+              <div
+                key={index}
+                className="group/calc flex items-start gap-2 rounded border border-gray-200 bg-gray-50 px-2 py-1.5 dark:border-gray-700 dark:bg-white/[0.03]"
+              >
+                <span className="flex-1 break-words text-sm text-gray-700 dark:text-gray-300">
+                  {calc}
+                </span>
+                <button
+                  onClick={() => onRemoveCalc(member.id, index)}
+                  className="flex-shrink-0 p-0.5 text-gray-400 opacity-0 transition-all hover:text-red-500 group-hover/calc:opacity-100 dark:text-gray-500 dark:hover:text-red-400"
+                  title="Remove calc"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </div>
+            ))}
+
+            <input
+              type="text"
+              value={calcInput}
+              onChange={(e) => setCalcInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && calcInput.trim()) {
+                  e.preventDefault();
+                  onAddCalc(member.id, calcInput.trim());
+                  setCalcInput("");
+                }
+              }}
+              placeholder="Paste a calc result and press Enter..."
+              className="w-full rounded border border-gray-200 bg-gray-50 px-2 py-1.5 text-xs text-gray-800 placeholder-gray-400 transition-colors focus:border-brand-300 focus:outline-none dark:border-gray-700 dark:bg-white/[0.03] dark:text-white/90 dark:placeholder-gray-500"
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PokemonNoteCard;

--- a/frontend-rewrite/src/hooks/useOpponentTeams.ts
+++ b/frontend-rewrite/src/hooks/useOpponentTeams.ts
@@ -37,7 +37,7 @@ export const useOpponentTeams = (
     gamePlanId: team.gamePlanId,
     pokepaste: team.pokepaste,
     notes: team.notes || "",
-    color: (team as GamePlanTeam & { color?: string }).color || "blue",
+    color: team.color || "blue",
     compositions: team.compositions || [],
     createdAt: team.createdAt,
   });

--- a/frontend-rewrite/src/hooks/useTeamPokemon.ts
+++ b/frontend-rewrite/src/hooks/useTeamPokemon.ts
@@ -1,8 +1,9 @@
 import { useState, useEffect, useMemo } from "react";
 import * as pokepasteService from "../services/pokepasteService";
-import type { Team } from "../types";
 
-const useTeamPokemon = (teams: Team[]) => {
+type TeamLike = { id: number; pokepaste?: string | null };
+
+const useTeamPokemon = (teams: TeamLike[]) => {
   const [teamPokemon, setTeamPokemon] = useState<Record<number, string[]>>({});
   const [loading, setLoading] = useState(false);
 

--- a/frontend-rewrite/src/pages/Team/MatchupPlannerPage.tsx
+++ b/frontend-rewrite/src/pages/Team/MatchupPlannerPage.tsx
@@ -1,8 +1,255 @@
+import { useState, useEffect, useMemo } from "react";
+import { Plus, Target, AlertTriangle } from "lucide-react";
+import OpponentTeamCard from "../../components/team/OpponentTeamCard";
+import AddOpponentTeamModal from "../../components/modals/AddOpponentTeamModal";
+import TagInput from "../../components/form/TagInput";
+import { useActiveTeam } from "../../context/ActiveTeamContext";
+import { useOpponentTeams } from "../../hooks/useOpponentTeams";
+import useTeamPokemon from "../../hooks/useTeamPokemon";
+import * as pokepasteService from "../../services/pokepasteService";
+import { matchesPokemonTags } from "../../utils/pokemonNameUtils";
+
 export default function MatchupPlannerPage() {
+  const { team } = useActiveTeam();
+  const [myTeamPokemon, setMyTeamPokemon] = useState<string[]>([]);
+  const [parsingPokepaste, setParsingPokepaste] = useState(false);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [showAddTeamModal, setShowAddTeamModal] = useState(false);
+  const [searchTags, setSearchTags] = useState<string[]>([]);
+
+  const {
+    opponentTeams,
+    loading,
+    error,
+    createOpponentTeam,
+    updateOpponentTeam,
+    deleteOpponentTeam,
+    addComposition,
+    updateComposition,
+    deleteComposition,
+    refresh,
+    isEmpty,
+  } = useOpponentTeams(team?.id ?? null);
+
+  const { teamPokemon } = useTeamPokemon(opponentTeams);
+
+  const filteredOpponentTeams = useMemo(() => {
+    if (searchTags.length === 0) return opponentTeams;
+    return opponentTeams.filter((ot) => {
+      const pokemonNames = teamPokemon[ot.id] || [];
+      return matchesPokemonTags(pokemonNames, searchTags);
+    });
+  }, [opponentTeams, searchTags, teamPokemon]);
+
+  useEffect(() => {
+    if (team?.pokepaste) {
+      parseMyTeamPokepaste();
+    } else {
+      setMyTeamPokemon([]);
+      setParseError(null);
+    }
+  }, [team?.pokepaste]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const parseMyTeamPokepaste = async () => {
+    if (!team?.pokepaste) return;
+    try {
+      setParsingPokepaste(true);
+      setParseError(null);
+      const parsed = await pokepasteService.fetchAndParse(team.pokepaste);
+      setMyTeamPokemon(parsed.map((p) => p.name).filter(Boolean));
+    } catch {
+      setParseError(
+        "Failed to parse your team. Make sure your Pokepaste URL is valid.",
+      );
+      setMyTeamPokemon([]);
+    } finally {
+      setParsingPokepaste(false);
+    }
+  };
+
+  const handleAddOpponentTeam = async (data: {
+    pokepaste: string;
+    notes?: string;
+    color?: string;
+  }) => {
+    await createOpponentTeam(data);
+    setShowAddTeamModal(false);
+  };
+
+  const handleUpdateNotes = async (
+    opponentTeamId: number,
+    updates: { pokepaste?: string; notes?: string; color?: string },
+  ) => {
+    await updateOpponentTeam(opponentTeamId, updates);
+  };
+
+  const handleDeleteOpponentTeam = async (opponentTeamId: number) => {
+    await deleteOpponentTeam(opponentTeamId);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-brand-500" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="py-12 text-center">
+        <div className="mb-4 text-red-500 dark:text-red-400">
+          Error loading matchup teams: {error}
+        </div>
+        <button
+          onClick={refresh}
+          className="rounded-lg bg-brand-500 px-4 py-2 text-white transition-colors hover:bg-brand-600"
+        >
+          Try Again
+        </button>
+      </div>
+    );
+  }
+
   return (
-    <div className="rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-800 dark:bg-white/[0.03]">
-      <h3 className="text-xl font-semibold text-gray-800 dark:text-white/90">Matchup Planner</h3>
-      <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">Coming in Phase 4</p>
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="flex items-center gap-2 text-2xl font-bold text-gray-800 dark:text-white/90">
+            <Target className="h-6 w-6 text-brand-500" />
+            Matchup Planning
+          </h2>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Plan strategies for specific matchups
+          </p>
+        </div>
+        <button
+          onClick={() => setShowAddTeamModal(true)}
+          className="flex items-center gap-2 rounded-lg bg-brand-500 px-4 py-2 text-white transition-colors hover:bg-brand-600"
+        >
+          <Plus className="h-4 w-4" />
+          Add Matchup Team
+        </button>
+      </div>
+
+      {/* Warning if team has no pokepaste */}
+      {!team?.pokepaste && (
+        <div className="flex items-start gap-3 rounded-lg border border-yellow-300 bg-yellow-50 p-4 dark:border-yellow-500/50 dark:bg-yellow-900/20">
+          <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0 text-yellow-500" />
+          <div>
+            <p className="font-medium text-yellow-800 dark:text-yellow-200">
+              Your team needs a Pokepaste URL
+            </p>
+            <p className="mt-1 text-sm text-yellow-700 dark:text-yellow-300">
+              Add a Pokepaste URL to your team to be able to create strategy
+              plans. Edit your team to add one.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Warning if pokepaste parsing failed */}
+      {parseError && (
+        <div className="flex items-start gap-3 rounded-lg border border-red-300 bg-red-50 p-4 dark:border-red-500/50 dark:bg-red-900/20">
+          <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0 text-red-500 dark:text-red-400" />
+          <div>
+            <p className="font-medium text-red-800 dark:text-red-200">
+              Failed to load your team
+            </p>
+            <p className="mt-1 text-sm text-red-700 dark:text-red-300">
+              {parseError}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Pokepaste parsing loading */}
+      {parsingPokepaste && (
+        <div className="flex items-center gap-2 rounded-lg border border-blue-300 bg-blue-50 p-3 dark:border-blue-500/50 dark:bg-blue-900/20">
+          <div className="h-4 w-4 animate-spin rounded-full border-b-2 border-blue-500" />
+          <span className="text-sm text-blue-700 dark:text-blue-300">
+            Loading your team...
+          </span>
+        </div>
+      )}
+
+      {/* Tag Filter */}
+      {!isEmpty && !loading && (
+        <div>
+          <TagInput
+            tags={searchTags}
+            onTagsChange={setSearchTags}
+            placeholder="Filter by opponent pokemon..."
+          />
+          {searchTags.length > 0 && (
+            <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+              Showing {filteredOpponentTeams.length} of {opponentTeams.length}{" "}
+              matchup teams
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Empty State */}
+      {isEmpty && !loading && (
+        <div className="rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 py-16 text-center dark:border-gray-600 dark:bg-white/[0.02]">
+          <Target className="mx-auto mb-4 h-16 w-16 text-gray-300 dark:text-gray-600" />
+          <h3 className="mb-2 text-xl font-semibold text-gray-700 dark:text-gray-300">
+            No matchup teams yet
+          </h3>
+          <p className="mx-auto mb-6 max-w-md text-gray-500 dark:text-gray-400">
+            Add matchup teams to plan your strategies. You'll be able to define
+            different compositions and notes for each matchup.
+          </p>
+          <button
+            onClick={() => setShowAddTeamModal(true)}
+            className="mx-auto flex items-center gap-2 rounded-lg bg-brand-500 px-6 py-3 text-white transition-colors hover:bg-brand-600"
+          >
+            <Plus className="h-5 w-5" />
+            Add Your First Matchup Team
+          </button>
+        </div>
+      )}
+
+      {/* Filtered empty */}
+      {!isEmpty && filteredOpponentTeams.length === 0 && searchTags.length > 0 ? (
+        <div className="py-8 text-center">
+          <p className="text-gray-500 dark:text-gray-400">
+            No matchup teams match your filters
+          </p>
+          <button
+            onClick={() => setSearchTags([])}
+            className="mt-2 text-sm text-brand-500 hover:text-brand-600 dark:text-brand-400 dark:hover:text-brand-300"
+          >
+            Clear filters
+          </button>
+        </div>
+      ) : (
+        !isEmpty && (
+          <div className="space-y-6">
+            {filteredOpponentTeams.map((opponentTeam) => (
+              <OpponentTeamCard
+                key={opponentTeam.id}
+                opponentTeam={opponentTeam}
+                myTeamPokemon={myTeamPokemon}
+                onUpdateNotes={handleUpdateNotes}
+                onAddComposition={addComposition}
+                onUpdateComposition={updateComposition}
+                onDeleteComposition={deleteComposition}
+                onDeleteTeam={handleDeleteOpponentTeam}
+              />
+            ))}
+          </div>
+        )
+      )}
+
+      {/* Add Modal */}
+      <AddOpponentTeamModal
+        isOpen={showAddTeamModal}
+        onClose={() => setShowAddTeamModal(false)}
+        onSubmit={handleAddOpponentTeam}
+      />
     </div>
   );
 }

--- a/frontend-rewrite/src/pages/Team/PokemonNotesPage.tsx
+++ b/frontend-rewrite/src/pages/Team/PokemonNotesPage.tsx
@@ -1,8 +1,128 @@
+import { useState } from "react";
+import { FileText } from "lucide-react";
+import PokemonNoteCard from "../../components/team/PokemonNoteCard";
+import { useActiveTeam } from "../../context/ActiveTeamContext";
+import useTeamMembers from "../../hooks/useTeamMembers";
+import type { TeamMember } from "../../types";
+
 export default function PokemonNotesPage() {
+  const { team } = useActiveTeam();
+  const { teamMembers, loading, error, updateMemberNotes, updateMemberCalcs } =
+    useTeamMembers(team?.id ?? null, team?.pokepaste ?? null);
+
+  const [editingNoteId, setEditingNoteId] = useState<number | null>(null);
+  const [noteText, setNoteText] = useState("");
+  const [savingNoteId, setSavingNoteId] = useState<number | null>(null);
+
+  const startEditingNote = (member: TeamMember) => {
+    setEditingNoteId(member.id);
+    setNoteText(member.notes || "");
+  };
+
+  const cancelEditingNote = () => {
+    setEditingNoteId(null);
+    setNoteText("");
+  };
+
+  const saveNote = async (memberId: number) => {
+    try {
+      setSavingNoteId(memberId);
+      await updateMemberNotes(memberId, noteText.trim());
+      setEditingNoteId(null);
+      setNoteText("");
+    } catch (err) {
+      console.error("Error updating note:", err);
+    } finally {
+      setSavingNoteId(null);
+    }
+  };
+
+  const addCalc = async (memberId: number, calcText: string) => {
+    const member = teamMembers.find((m) => m.id === memberId);
+    const currentCalcs = member?.calcs || [];
+    await updateMemberCalcs(memberId, [...currentCalcs, calcText]);
+  };
+
+  const removeCalc = async (memberId: number, index: number) => {
+    const member = teamMembers.find((m) => m.id === memberId);
+    const currentCalcs = member?.calcs || [];
+    await updateMemberCalcs(
+      memberId,
+      currentCalcs.filter((_, i) => i !== index),
+    );
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent, memberId: number) => {
+    if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      saveNote(memberId);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      cancelEditingNote();
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-brand-500" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="py-12 text-center">
+        <p className="text-red-500 dark:text-red-400">
+          Error loading team members: {error}
+        </p>
+      </div>
+    );
+  }
+
+  if (teamMembers.length === 0) {
+    return (
+      <div className="py-12 text-center">
+        <FileText className="mx-auto mb-4 h-16 w-16 text-gray-300 dark:text-gray-600" />
+        <h3 className="mb-2 text-xl font-semibold text-gray-700 dark:text-gray-300">
+          No team members
+        </h3>
+        <p className="text-gray-500 dark:text-gray-400">
+          Add a pokepaste to your team to start adding notes for each Pokemon
+        </p>
+      </div>
+    );
+  }
+
   return (
-    <div className="rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-800 dark:bg-white/[0.03]">
-      <h3 className="text-xl font-semibold text-gray-800 dark:text-white/90">Pokemon Notes</h3>
-      <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">Coming in Phase 4</p>
+    <div>
+      <div className="mb-6">
+        <h3 className="text-xl font-semibold text-gray-800 dark:text-white/90">
+          Pokemon Notes
+        </h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Add notes for each Pokemon on your team
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {teamMembers.map((member) => (
+          <PokemonNoteCard
+            key={member.id}
+            member={member}
+            isEditingNote={editingNoteId === member.id}
+            isSavingNote={savingNoteId === member.id}
+            noteText={noteText}
+            onStartEditingNote={startEditingNote}
+            onCancelEditingNote={cancelEditingNote}
+            onSaveNote={saveNote}
+            onNoteTextChange={setNoteText}
+            onKeyPress={handleKeyPress}
+            onAddCalc={addCalc}
+            onRemoveCalc={removeCalc}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend-rewrite/src/services/api/teamMemberApi.ts
+++ b/frontend-rewrite/src/services/api/teamMemberApi.ts
@@ -1,5 +1,5 @@
 import apiClient from "./client";
-import type { TeamMember } from "../../types";
+import type { TeamMember, TeamMemberSyncResponse } from "../../types";
 
 export const teamMemberApi = {
   getByTeamId: (teamId: number) =>
@@ -13,6 +13,9 @@ export const teamMemberApi = {
 
   delete: (id: number) =>
     apiClient.delete(`/api/team-members/${id}`) as Promise<void>,
+
+  sync: (teamId: number) =>
+    apiClient.post(`/api/team-members/sync?teamId=${teamId}`) as Promise<TeamMemberSyncResponse>,
 };
 
 export default teamMemberApi;

--- a/frontend-rewrite/src/services/pokemonService.ts
+++ b/frontend-rewrite/src/services/pokemonService.ts
@@ -104,7 +104,7 @@ export async function getPokemon(identifier: string | number): Promise<PokemonDa
   // Fallback to static data
   const staticKey = typeof identifier === "string" ? identifier.toLowerCase() : String(identifier);
   if (COMMON_VGC_POKEMON[staticKey]) {
-    const fallbackData = enrichFallbackData(COMMON_VGC_POKEMON[staticKey]);
+    const fallbackData = enrichFallbackData(COMMON_VGC_POKEMON[staticKey], staticKey);
     return fallbackData;
   }
 
@@ -174,9 +174,13 @@ function processPokemonData(apiData: any): PokemonData {
 
 /**
  * Enrich fallback data with sprite info
+ * @param nameKey - normalized name for sprite map lookup (e.g. "ogerpon-hearthflame")
  */
-function enrichFallbackData(fallbackData: { id: number; name: string; types: string[] }): PokemonData {
-  const spriteUrls = generateSpriteUrls(fallbackData.id);
+function enrichFallbackData(
+  fallbackData: { id: number; name: string; types: string[] },
+  nameKey?: string,
+): PokemonData {
+  const spriteUrls = generateSpriteUrls(nameKey || fallbackData.id);
   return {
     ...fallbackData,
     sprite: spriteUrls.normal,

--- a/frontend-rewrite/src/types/gamePlan.ts
+++ b/frontend-rewrite/src/types/gamePlan.ts
@@ -12,6 +12,7 @@ export interface GamePlanTeam {
   pokepaste: string;
   playerName: string;
   notes: string;
+  color?: string;
   compositions: Composition[];
   createdAt: string;
   updatedAt: string;

--- a/frontend-rewrite/src/types/index.ts
+++ b/frontend-rewrite/src/types/index.ts
@@ -5,7 +5,7 @@ export type { Match, MatchStats } from "./match";
 export type { UsageStats, MatchupStats, MatchupEntry, MoveUsage } from "./analytics";
 export type { GamePlan, GamePlanTeam, Composition } from "./gamePlan";
 export type { ExportOptions, ExportResult, ImportResult, RateLimitStatus, ExportSummary } from "./export";
-export type { TeamMember } from "./teamMember";
+export type { TeamMember, TeamMemberSyncResponse } from "./teamMember";
 export type {
   PokemonData,
   PokemonState,

--- a/frontend-rewrite/src/types/teamMember.ts
+++ b/frontend-rewrite/src/types/teamMember.ts
@@ -8,3 +8,10 @@ export interface TeamMember {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface TeamMemberSyncResponse {
+  members: TeamMember[];
+  kept: string[];
+  added: string[];
+  removed: string[];
+}


### PR DESCRIPTION
## Summary
- **PokemonNotesPage**: Extracted `PokemonNoteCard` component with calcs support, auto-backfills team members via sync on first visit
- **MatchupPlannerPage**: Opponent team management with `AddOpponentTeamModal`, `PokemonDropdown`, and `OpponentTeamCard`
- **Backend sync endpoint** (`POST /api/team-members/sync`): Smart merge that preserves notes/calcs for kept Pokemon, deletes removed, creates new — handles `(team_id, slot)` unique constraint via temporary slot reassignment and flush
- **EditTeamModal**: Detects pokepaste roster changes, shows amber warning listing added/removed Pokemon before syncing
- **useTeamMembers**: Adds pokepaste dependency for refetch + auto-backfill for existing teams with no members

## Test plan
- [ ] Edit team, change pokepaste (swap one mon) — warning shows dropped/added names — Cancel returns to form — Confirm saves and syncs
- [ ] Edit team, change pokepaste (same mons, different moves) — no warning, saves normally
- [ ] Edit team, change only name (not pokepaste) — no warning, saves normally
- [ ] Visit Pokemon Notes on an existing team with no members — members auto-created via sync
- [ ] After sync, kept Pokemon retain their notes/calcs
- [ ] Backend: `mvn test` — 107 tests pass, 0 failures
- [ ] Frontend: `tsc --noEmit` and `vite build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)