### PR TITLE
Fix .gitignore to track frontend-rewrite data files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build/
 # H2
 data/
 !frontend/src/data/
+!frontend-rewrite/src/data/
 
 # Environment files
 .env

--- a/frontend-rewrite/src/data/setdex-gen9.ts
+++ b/frontend-rewrite/src/data/setdex-gen9.ts
@@ -1,0 +1,16112 @@
+export const SETDEX_GEN9 = {
+    "Meowscarada": {
+        "Sash Overgrow": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Overgrow",
+            "tera_type": "Stellar",
+            "item": "Focus Sash",
+            "moves": [
+                "Flower Trick",
+                "Knock Off",
+                "Sucker Punch",
+                "Triple Axel"
+            ]
+        },
+        "Choice Band Protean": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Protean",
+            "tera_type": "Ghost",
+            "item": "Choice Band",
+            "moves": [
+                "Flower Trick",
+                "Knock Off",
+                "Triple Axel",
+                "U-turn"
+            ]
+        },
+    },
+    "Skeledirge": {
+        "Bulky Tera Grass": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Unaware",
+            "tera_type": "Grass",
+            "item": "Leftovers",
+            "moves": [
+                "Torch Song",
+                "Shadow Ball",
+                "Slack Off",
+                "Protect"
+            ]
+        },
+    },
+    "Quaquaval": {
+        "Clear Amulet Set": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Moxie",
+            "item": "Clear Amulet",
+            "moves": [
+                "Aqua Step",
+                "Close Combat",
+                "Ice Spinner",
+                "Flip Turn"
+            ]
+        },
+    },
+    //"Oinkologne": {
+    //    "Don't use this": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 252,
+    //            "at": 0,
+    //            "df": 252,
+    //            "sa": 0,
+    //            "sd": 4,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "Bold",
+    //        "ability": "Lingering Aroma",
+    //        "tera_type": "Fighting",
+    //        "item": "Figy Berry",
+    //        "moves": [
+    //            "Stuff Cheeks",
+    //            "Body Press",
+    //            "Rest",
+    //            "Yawn"
+    //        ]
+    //    },
+    //},
+    //"Oinkologne-F": {
+    //    "Surely, there are better Pokemon": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 252,
+    //            "at": 0,
+    //            "df": 252,
+    //            "sa": 0,
+    //            "sd": 4,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "Bold",
+    //        "ability": "Lingering Aroma",
+    //        "tera_type": "Fire",
+    //        "item": "Leftovers",
+    //        "moves": [
+    //            "Stockpile",
+    //            "Body Press",
+    //            "Protect",
+    //            "Yawn"
+    //        ]
+    //    },
+    //},
+    //"Spidops": {
+    //    "very weak bug": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 252,
+    //            "at": 0,
+    //            "df": 252,
+    //            "sa": 0,
+    //            "sd": 4,
+    //            "sp": 0
+    //        },
+    //        "nature": "Impish",
+    //        "ability": "Insomnia",
+    //        "tera_type": "Water",
+    //        "item": "Focus Sash",
+    //        "moves": [
+    //            "Circle Throw",
+    //            "Counter",
+    //            "Toxic Spikes",
+    //            "Silk Trap"
+    //        ]
+    //    },
+    //},
+    "Lokix": {
+        "Stellar Choice Band": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Tinted Lens",
+            "tera_type": "Stellar",
+            "item": "Choice Band",
+            "moves": [
+                "First Impression",
+                "U-turn",
+                "Sucker Punch",
+                "Knock Off"
+            ]
+        },
+    },
+    "Jumpluff": {
+        "Cloak Tailwind Support": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 60,
+                "sa": 4,
+                "sd": 4,
+                "sp": 196
+            },
+            "ivs": {
+                "at": 0
+            },
+            "nature": "Timid",
+            "ability": "Chlorophyll",
+            "tera_type": "Water",
+            "item": "Covert Cloak",
+            "moves": [
+                "Leaf Storm",
+                "Sleep Powder",
+                "Encore",
+                "Tailwind"
+            ]
+        },
+    },
+    "Talonflame": {
+        "Bulky Tera Ghost Cloak": {
+            "level": 50,
+            "evs": {
+                "hp": 204,
+                "at": 36,
+                "df": 180,
+                "sa": 0,
+                "sd": 4,
+                "sp": 84
+            },
+            "nature": "Jolly",
+            "ability": "Gale Wings",
+            "tera_type": "Ghost",
+            "item": "Covert Cloak",
+            "moves": [
+                "Brave Bird",
+                "Flare Blitz",
+                "Taunt",
+                "Tailwind"
+            ]
+        },
+        "Tera Flying Sharp Beak": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Gale Wings",
+            "tera_type": "Flying",
+            "item": "Sharp Beak",
+            "moves": [
+                "Brave Bird",
+                "Tailwind",
+                "Taunt",
+                "Protect"
+            ]
+        },
+    },
+    "Pawmot": {
+        "Basic Focus Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Natural Cure",
+            "item": "Focus Sash",
+            "moves": [
+                "Fake Out",
+                "Double Shock",
+                "Close Combat",
+                "Revival Blessing"
+            ]
+        },
+    },
+    "Houndoom": {
+        "If you REALLY hate Hisuian Typhlosion": {
+            "level": 50,
+            "evs": {
+                "hp": 84,
+                "at": 0,
+                "df": 4,
+                "sa": 188,
+                "sd": 4,
+                "sp": 228
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "item": "Safety Goggles",
+            "moves": [
+                "Dark Pulse",
+                "Snarl",
+                "Overheat",
+                "Protect"
+            ]
+        },
+    },
+    //"Gumshoos": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Greedent": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Sunflora": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Kricketune": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Vivillon": {
+        "Compound Eyes Hurricane Sleep Powder": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Compound Eyes",
+            "tera_type": "Ghost",
+            "item": "Focus Sash",
+            "moves": [
+                "Hurricane",
+                "Pollen Puff",
+                "Rage Powder",
+                "Sleep Powder"
+            ]
+        },
+        "Friend Guard Tailwind": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Friend Guard",
+            "tera_type": "Ghost",
+            "item": "Focus Sash",
+            "moves": [
+                "Pollen Puff",
+                "Tailwind",
+                "Rage Powder",
+                "Sleep Powder"
+            ]
+        },
+    },
+    //"Vespiquen": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Corviknight": {
+        "Bulk Up Tailwind": {
+            "level": 50,
+            "evs": {
+                "hp": 220,
+                "at": 204,
+                "df": 4,
+                "sa": 0,
+                "sd": 4,
+                "sp": 76
+            },
+            "nature": "Adamant",
+            "ability": "Mirror Armor",
+            "tera_type": "Dragon",
+            "item": "Leftovers",
+            "moves": [
+                "Brave Bird",
+                "Tailwind",
+                "Roost",
+                "Bulk Up"
+            ]
+        },
+        "SoulSur Banded Corv": {
+            "level": 50,
+            "evs": {
+                "hp": 116,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 140
+            },
+            "nature": "Adamant",
+            "ability": "Mirror Armor",
+            "tera_type": "Fire",
+            "item": "Choice Band",
+            "moves": [
+                "Brave Bird",
+                "Tera Blast",
+                "U-turn",
+                "Iron Head"
+            ]
+        },
+    },
+    //"Chansey": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Blissey": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Azumarill": {
+        "Standard Belly Drum": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 12,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "ability": "Huge Power",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Belly Drum",
+                "Aqua Jet",
+                "Play Rough",
+                "Protect"
+            ]
+        },
+        "Assault Vest Set": {
+            "level": 50,
+            "evs": {
+                "hp": 236,
+                "at": 236,
+                "df": 4,
+                "sa": 0,
+                "sd": 12,
+                "sp": 20
+            },
+            "nature": "Adamant",
+            "ability": "Huge Power",
+            "item": "Assault Vest",
+            "moves": [
+                "Aqua Jet",
+                "Play Rough",
+                "Liquidation",
+                "Ice Spinner"
+            ]
+        },
+    },
+    //"Masquerain": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Floatzel": {
+        "Choice Band Rain Sweeper": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Swift Swim",
+            "item": "Choice Band",
+            "moves": [
+                "Wave Crash",
+                "Ice Spinner",
+                "Aqua Jet",
+                "Brick Break"
+            ]
+        },
+    },
+    "Clodsire": {
+        "Haze Toxic Leftovers": {
+            "level": 50,
+            "evs": {
+                "hp": 164,
+                "at": 28,
+                "df": 236,
+                "sa": 0,
+                "sd": 76,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 0
+            },
+            "nature": "Relaxed",
+            "ability": "Water Absorb",
+            "tera_type": "Dark",
+            "item": "Leftovers",
+            "moves": [
+                "Haze",
+                "Toxic",
+                "Recover",
+                "Gunk Shot"
+            ]
+        },
+    },
+    //"Golduck": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Drednaw": {
+        "Tera Grass Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Swift Swim",
+            "tera_type": "Grass",
+            "item": "Life Orb",
+            "moves": [
+                "Liquidation",
+                "Rock Slide",
+                "Tera Blast",
+                "Protect"
+            ]
+        },
+    },
+    //"Wigglytuff": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Gardevoir": {
+        "Trick Choice Scarf": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Trace",
+            "tera_type": "Fairy",
+            "item": "Choice Scarf",
+            "moves": [
+                "Psychic",
+                "Moonblast",
+                "Dazzling Gleam",
+                "Trick"
+            ]
+        },
+        "Ashton's Sitrus Tera Grass": {
+            "level": 50,
+            "evs": {
+                "hp": 180,
+                "at": 0,
+                "df": 212,
+                "sa": 44,
+                "sd": 4,
+                "sp": 68
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Trace",
+            "tera_type": "Grass",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Psychic",
+                "Moonblast",
+                "Protect",
+                "Trick Room"
+            ]
+        },
+    },
+    "Gallade": {
+        "Trick Room Clear Amulet": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 0,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 2,
+            },
+            "nature": "Brave",
+            "ability": "Sharpness",
+            "tera_type": "Fire",
+            "item": "Clear Amulet",
+            "moves": [
+                "Psycho Cut",
+                "Sacred Sword",
+                "Trick Room",
+                "Wide Guard"
+            ]
+        },
+        "Life Orb Max Speed": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Sharpness",
+            "tera_type": "Fighting",
+            "item": "Life Orb",
+            "moves": [
+                "Psycho Cut",
+                "Sacred Sword",
+                "Night Slash",
+                "Protect"
+            ]
+        },
+    },
+    //"Hypno": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Gengar": {
+        "Tera Stellar Focus Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Cursed Body",
+            "tera_type": "Stellar",
+            "item": "Focus Sash",
+            "moves": [
+                "Shadow Ball",
+                "Sludge Bomb",
+                "Icy Wind",
+                "Haze"
+            ]
+        },
+    },
+    "Maushold": {
+        "Bulky Goggles Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 156,
+                "sa": 0,
+                "sd": 100,
+                "sp": 0
+            },
+            "nature": "Impish",
+            "ability": "Friend Guard",
+            "tera_type": "Ghost",
+            "item": "Safety Goggles",
+            "moves": [
+                "Super Fang",
+                "Feint",
+                "Beat Up",
+                "Follow Me"
+            ]
+        },
+        "Wide Lens Technician": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Technician",
+            "item": "Wide Lens",
+            "moves": [
+                "Population Bomb",
+                "Follow Me",
+                "Protect",
+                "Bite"
+            ]
+        },
+    },
+    "Maushold-Four": {
+        "Bulky Goggles Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 156,
+                "sa": 0,
+                "sd": 100,
+                "sp": 0
+            },
+            "nature": "Impish",
+            "ability": "Friend Guard",
+            "tera_type": "Ghost",
+            "item": "Safety Goggles",
+            "moves": [
+                "Super Fang",
+                "Feint",
+                "Beat Up",
+                "Follow Me"
+            ]
+        },
+        "Wide Lens Technician": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Technician",
+            "item": "Wide Lens",
+            "moves": [
+                "Population Bomb",
+                "Follow Me",
+                "Protect",
+                "Bite"
+            ]
+        },
+    },
+    //"Pikachu": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Raichu": {
+        "Basic Focus Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 4,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Timid",
+            "ability": "Lightning Rod",
+            "tera_type": "Flying",
+            "item": "Focus Sash",
+            "moves": [
+                "Fake Out",
+                "Nuzzle",
+                "Volt Switch",
+                "Endeavor"
+            ]
+        },
+    },
+    "Dachsbun": {
+        "Well-Baked Body Press": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 4,
+                "df": 36,
+                "sa": 0,
+                "sd": 188,
+                "sp": 28
+            },
+            "nature": "Impish",
+            "ability": "Well-Baked Body",
+            "tera_type": "Steel",
+            "item": "Leftovers",
+            "moves": [
+                "Body Press",
+                "Snarl",
+                "Play Rough",
+                "Protect"
+            ]
+        },
+    },
+    "Slaking": {
+        "Tera Normal Offense": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "item": "Life Orb",
+            "moves": [
+                "Double-Edge",
+                "High Horsepower",
+                "Play Rough",
+                "Knock Off"
+            ]
+        },
+        //"Tera Ghost Bulk Up": {
+        //    "level": 50,
+        //    "evs": {
+        //        "hp": 4,
+        //        "at": 252,
+        //        "df": 0,
+        //        "sa": 0,
+        //        "sd": 0,
+        //        "sp": 252
+        //    },
+        //    "nature": "Jolly",
+        //    "ability": "Truant",
+        //    "tera_type": "Ghost",
+        //    "item": "Leftovers",
+        //    "moves": [
+        //        "Bulk Up",
+        //        "Drain Punch",
+        //        "Body Slam",
+        //        "Sucker Punch"
+        //    ]
+        //},
+    },
+    "Tsareena": {
+        "Tera Ice Wide Lens": {
+            "level": 50,
+            "evs": {
+                "hp": 52,
+                "at": 236,
+                "df": 4,
+                "sa": 0,
+                "sd": 4,
+                "sp": 212
+            },
+            "nature": "Adamant",
+            "ability": "Queenly Majesty",
+            "tera_type": "Ice",
+            "item": "Wide Lens",
+            "moves": [
+                "Power Whip",
+                "Triple Axel",
+                "Low Kick",
+                "U-turn"
+            ]
+        },
+        //"Tera Rock Assault Vest": {
+        //    "level": 50,
+        //    "evs": {
+        //        "hp": 236,
+        //        "at": 76,
+        //        "df": 116,
+        //        "sa": 0,
+        //        "sd": 4,
+        //        "sp": 76
+        //    },
+        //    "nature": "Adamant",
+        //    "ability": "Queenly Majesty",
+        //    "tera_type": "Rock",
+        //    "item": "Assault Vest",
+        //    "moves": [
+        //        "Trop Kick",
+        //        "High Jump Kick",
+        //        "U-turn",
+        //        "Tera Blast"
+        //    ]
+        //},
+    },
+    "Arboliva": {
+        "Tera Ground Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 0
+            },
+            "nature": "Quiet",
+            "ability": "Seed Sower",
+            "tera_type": "Ground",
+            "item": "Life Orb",
+            "moves": [
+                "Terrain Pulse",
+                "Giga Drain",
+                "Earth Power",
+                "Protect"
+            ]
+        },
+    },
+    //"Sudowoodo": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Lycanroc-Midday": {
+        "Endeavor Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Ghost",
+            "ability": "Sand Rush",
+            "item": "Focus Sash",
+            "moves": [
+                "Rock Slide",
+                "Endeavor",
+                "Accelerock",
+                "Protect"
+            ]
+        },
+    },
+    "Lycanroc-Dusk": {
+        "Tera Dark Choice Band": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Tough Claws",
+            "tera_type": "Dark",
+            "item": "Choice Band",
+            "moves": [
+                "Rock Slide",
+                "Close Combat",
+                "Psychic Fangs",
+                "Sucker Punch"
+            ]
+        },
+    },
+    //"Lycanroc-Midnight": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Coalossal": {
+        "Steam Engine Absorb Bulb": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Steam Engine",
+            "tera_type": "Grass",
+            "item": "Absorb Bulb",
+            "moves": [
+                "Heat Wave",
+                "Tera Blast",
+                "Power Gem",
+                "Protect"
+            ]
+        },
+        "Flash Fire Body Press": {
+            "level": 50,
+            "evs": {
+                "hp": 188,
+                "at": 0,
+                "df": 156,
+                "sa": 0,
+                "sd": 164,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 0,
+            },
+            "nature": "Relaxed",
+            "ability": "Flash Fire",
+            "tera_type": "Grass",
+            "item": "Leftovers",
+            "moves": [
+                "Body Press",
+                "Fire Spin",
+                "Power Gem",
+                "Iron Defense"
+            ]
+        },
+    },
+    //"Luxray": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Staraptor": {
+        "Choice Scarf Lead": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 44,
+                "df": 4,
+                "sa": 0,
+                "sd": 4,
+                "sp": 204
+            },
+            "nature": "Adamant",
+            "ability": "Intimidate",
+            "tera_type": "Ghost",
+            "item": "Choice Scarf",
+            "moves": [
+                "Final Gambit",
+                "Brave Bird",
+                "U-turn",
+                "Close Combat"
+            ]
+        },
+    },
+    "Oricorio-Sensu": {
+        "Tera Ground Focus Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Dancer",
+            "tera_type": "Ground",
+            "item": "Focus Sash",
+            "moves": [
+                "Revelation Dance",
+                "Air Slash",
+                "Quiver Dance",
+                "Protect"
+            ]
+        },
+    },
+    "Oricorio-Pom-Pom": {
+        "Tera Ice Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Dancer",
+            "tera_type": "Ice",
+            "item": "Life Orb",
+            "moves": [
+                "Revelation Dance",
+                "Air Slash",
+                "Quiver Dance",
+                "Protect"
+            ]
+        },
+    },
+    //"Oricorio-Baile": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Oricorio-Pa'u": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Ampharos": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Lilligant": {
+        "Standard Sash Set": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Chlorophyll",
+            "tera_type": "Ghost",
+            "item": "Focus Sash",
+            "moves": [
+                "Leaf Storm",
+                "Sleep Powder",
+                "After You",
+                "Pollen Puff"
+            ]
+        },
+    },
+    "Breloom": {
+        "Standard Sash Set": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Technician",
+            "tera_type": "Ghost",
+            "item": "Focus Sash",
+            "moves": [
+                "Spore",
+                "Mach Punch",
+                "Bullet Seed",
+                "Close Combat"
+            ]
+        },
+    },
+    //"Flapple": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Appletun": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Grumpig": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Squawkabilly": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Misdreavus": {
+        "Floating Dusclops": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 252,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 0
+            },
+            "nature": "Bold",
+            "ability": "Levitate",
+            "tera_type": "Dark",
+            "item": "Eviolite",
+            "moves": [
+                "Night Shade",
+                "Will-O-Wisp",
+                "Trick Room",
+                "Helping Hand"
+            ]
+        },
+    },
+    //"Mismagius": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Hariyama": {
+        "Flame Orb Set": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 252,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 0
+            },
+            "nature": "Brave",
+            "ability": "Guts",
+            "tera_type": "Steel",
+            "item": "Flame Orb",
+            "moves": [
+                "Close Combat",
+                "Knock Off",
+                "Fake Out",
+                "Wide Guard"
+            ]
+        },
+    },
+    //"Crabominable": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Salazzle": {
+        "Basic Focus Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Timid",
+            "ability": "Oblivious",
+            "tera_type": "Stellar",
+            "item": "Focus Sash",
+            "moves": [
+                "Fake Out",
+                "Overheat",
+                "Sludge Bomb",
+                "Encore"
+            ]
+        },
+    },
+    //"Donphan": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Copperajah": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Garchomp": {
+        "Clear Amulet 3 Attacks": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Rough Skin",
+            "tera_type": "Steel",
+            "item": "Clear Amulet",
+            "moves": [
+                "Stomping Tantrum",
+                "Earthquake",
+                "Dragon Claw",
+                "Protect"
+            ]
+        },
+        "Fairy Loaded Dice": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Rough Skin",
+            "tera_type": "Fairy",
+            "item": "Loaded Dice",
+            "moves": [
+                "Stomping Tantrum",
+                "Earthquake",
+                "Scale Shot",
+                "Protect"
+            ]
+        },
+        "Tera Ground Scarf": {
+            "level": 50,
+            "evs": {
+                "hp": 36,
+                "at": 212,
+                "df": 4,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Rough Skin",
+            "tera_type": "Ground",
+            "item": "Choice Scarf",
+            "moves": [
+                "Dragon Claw",
+                "Earthquake",
+                "Rock Slide",
+                "Stomping Tantrum"
+            ]
+        },
+    },
+    "Garganacl": {
+        "Tera Ghost Body Press": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 4,
+                "sa": 0,
+                "sd": 252,
+                "sp": 0
+            },
+            "nature": "Careful",
+            "ability": "Purifying Salt",
+            "tera_type": "Ghost",
+            "item": "Leftovers",
+            "moves": [
+                "Iron Defense",
+                "Body Press",
+                "Salt Cure",
+                "Recover"
+            ]
+        },
+        "MeLuCa's San Diego 1st Tera Poison Support": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 12,
+                "sa": 0,
+                "sd": 252,
+                "sp": 0
+            },
+            "nature": "Careful",
+            "ability": "Purifying Salt",
+            "tera_type": "Poison",
+            "item": "Leftovers",
+            "moves": [
+                "Salt Cure",
+                "Wide Guard",
+                "Protect",
+                "Recover"
+            ]
+        },
+    },
+    "Pelipper": {
+        "Tera Stellar Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Drizzle",
+            "tera_type": "Stellar",
+            "item": "Focus Sash",
+            "moves": [
+                "Hurricane",
+                "Tailwind",
+                "Wide Guard",
+                "Weather Ball"
+            ]
+        },
+        "Slow Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Drizzle",
+            "tera_type": "Grass",
+            "item": "Life Orb",
+            "moves": [
+                "Hurricane",
+                "Weather Ball",
+                "Wide Guard",
+                "Protect"
+            ]
+        },
+        "Max Speed Scarf": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Drizzle",
+            "tera_type": "Ghost",
+            "item": "Choice Scarf",
+            "moves": [
+                "Hurricane",
+                "Muddy Water",
+                "Ice Beam",
+                "Weather Ball"
+            ]
+        },
+        "Bulky Damp Rock": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 76,
+                "sa": 4,
+                "sd": 140,
+                "sp": 36
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "ability": "Drizzle",
+            "tera_type": "Grass",
+            "item": "Damp Rock",
+            "moves": [
+                "Hurricane",
+                "Tailwind",
+                "Wide Guard",
+                "Weather Ball"
+            ]
+        },
+    },
+    "Gyarados": {
+        "Tera Steel Bulky Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 20,
+                "df": 76,
+                "sa": 0,
+                "sd": 156,
+                "sp": 4
+            },
+            "nature": "Careful",
+            "ability": "Intimidate",
+            "tera_type": "Steel",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Waterfall",
+                "Iron Head",
+                "Taunt",
+                "Thunder Wave"
+            ]
+        },
+        "Tera Flying Dragon Dance": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Intimidate",
+            "tera_type": "Flying",
+            "item": "Clear Amulet",
+            "moves": [
+                "Waterfall",
+                "Tera Blast",
+                "Dragon Dance",
+                "Protect"
+            ]
+        },
+    },
+    "Barraskewda": {
+        "Swift Swim Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Swift Swim",
+            "item": "Life Orb",
+            "moves": [
+                "Liquidation",
+                "Close Combat",
+                "Psychic Fangs",
+                "Throat Chop"
+            ]
+        },
+    },
+    //"Basculin": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Swalot": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Persian": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Drifblim": {
+        "Psychic Seed Unburden Support": {
+            "level": 50,
+            "evs": {
+                "hp": 12,
+                "at": 0,
+                "df": 204,
+                "sa": 4,
+                "sd": 92,
+                "sp": 196
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Unburden",
+            "tera_type": "Grass",
+            "item": "Psychic Seed",
+            "moves": [
+                "Shadow Ball",
+                "Will-O-Wisp",
+                "Tailwind",
+                "Strength Sap"
+            ]
+        },
+    },
+    "Florges": {
+        "Tera Fire Leftovers": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 36,
+                "sa": 220,
+                "sd": 0,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Flower Veil",
+            "tera_type": "Fire",
+            "item": "Leftovers",
+            "moves": [
+                "Moonblast",
+                "Tera Blast",
+                "Pollen Puff",
+                "Helping Hand"
+            ]
+        },
+    },
+    "Dugtrio": {
+        "Rajan why": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Arena Trap",
+            "tera_type": "Grass",
+            "item": "Focus Sash",
+            "moves": [
+                "Endeavor",
+                "Stomping Tantrum",
+                "Helping Hand",
+                "Protect"
+            ]
+        },
+    },
+    "Torkoal": {
+        "Tera Fire Charcoal": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 0
+            },
+            "nature": "Quiet",
+            "ability": "Drought",
+            "item": "Charcoal",
+            "moves": [
+                "Eruption",
+                "Heat Wave",
+                "Earth Power",
+                "Protect"
+            ]
+        },
+    },
+    //"Camerupt": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Bronzong": {
+        "Body Press Trick Room": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 156,
+                "sa": 0,
+                "sd": 108,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 0
+            },
+            "nature": "Sassy",
+            "ability": "Levitate",
+            "tera_type": "Electric",
+            "item": "Leftovers",
+            "moves": [
+                "Heavy Slam",
+                "Body Press",
+                "Iron Defense",
+                "Trick Room"
+            ]
+        },
+    },
+    //"Haxorus": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Annihilape": {
+        "Choice Scarf Final Gambit": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 4,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Defiant",
+            "item": "Choice Scarf",
+            "moves": [
+                "Final Gambit",
+                "Close Combat",
+                "U-turn",
+                "Shadow Claw"
+            ]
+        },
+        "Bulk Up Leftovers": {
+            "level": 50,
+            "evs": {
+                "hp": 180,
+                "at": 36,
+                "df": 108,
+                "sa": 0,
+                "sd": 172,
+                "sp": 12
+            },
+            "nature": "Adamant",
+            "ability": "Defiant",
+            "tera_type": "Fire",
+            "item": "Leftovers",
+            "moves": [
+                "Rage Fist",
+                "Drain Punch",
+                "Bulk Up",
+                "Protect"
+            ]
+        },
+        "Speedy Coaching Offense": {
+            "level": 50,
+            "evs": {
+                "hp": 180,
+                "at": 52,
+                "df": 12,
+                "sa": 0,
+                "sd": 12,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Defiant",
+            "item": "Safety Goggles",
+            "moves": [
+                "Final Gambit",
+                "Close Combat",
+                "Rage Fist",
+                "Coaching"
+            ]
+        },
+    },
+    //"Medicham": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Riolu": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Lucario": {
+        "Tera Stellar Sash Offense": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Stellar",
+            "item": "Focus Sash",
+            "moves": [
+                "Close Combat",
+                "Meteor Mash",
+                "Extreme Speed",
+                "Detect"
+            ]
+        },
+    },
+    "Armarouge": {
+        "Life Orb Trick Room": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Flash Fire",
+            "tera_type": "Grass",
+            "item": "Life Orb",
+            "moves": [
+                "Expanding Force",
+                "Armor Cannon",
+                "Trick Room",
+                "Wide Guard"
+            ]
+        },
+        "Weak Armor WP": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Weak Armor",
+            "tera_type": "Psychic",
+            "item": "Weakness Policy",
+            "moves": [
+                "Expanding Force",
+                "Armor Cannon",
+                "Heat Wave",
+                "Endure"
+            ]
+        },
+        "Porengan's Stellar Meteor Beam": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Weak Armor",
+            "tera_type": "Stellar",
+            "item": "Power Herb",
+            "moves": [
+                "Expanding Force",
+                "Armor Cannon",
+                "Meteor Beam",
+                "Endure"
+            ]
+        },
+    },
+    "Ceruledge": {
+        "Bulk Up Clear Amulet": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "ability": "Flash Fire",
+            "tera_type": "Grass",
+            "item": "Clear Amulet",
+            "moves": [
+                "Bitter Blade",
+                "Shadow Sneak",
+                "Bulk Up",
+                "Protect"
+            ]
+        },
+    },
+    //"Whiscash": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Bellibolt": {
+        "Bruneaux's Reg F Sitrus": {
+            "level": 50,
+            "evs": {
+                "hp": 236,
+                "at": 4,
+                "df": 204,
+                "sa": 52,
+                "sd": 12,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 0
+            },
+            "nature": "Quiet",
+            "ability": "Electromorphosis",
+            "tera_type": "Fairy",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Parabolic Charge",
+                "Thunderbolt",
+                "Muddy Water",
+                "Sucker Punch"
+            ]
+        },
+        "WP Electromorphosis": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 12,
+                "sa": 252,
+                "sd": 0,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 0
+            },
+            "nature": "Quiet",
+            "ability": "Electromorphosis",
+            "item": "Weakness Policy",
+            "moves": [
+                "Parabolic Charge",
+                "Thunderbolt",
+                "Discharge",
+                "Protect"
+            ]
+        },
+    },
+    "Goodra": {
+        "Tera Water Assault Vest": {
+            "level": 50,
+            "evs": {
+                "hp": 204,
+                "at": 0,
+                "df": 36,
+                "sa": 236,
+                "sd": 28,
+                "sp": 4
+            },
+            "nature": "Modest",
+            "ability": "Sap Sipper",
+            "tera_type": "Water",
+            "item": "Assault Vest",
+            "moves": [
+                "Draco Meteor",
+                "Muddy Water",
+                "Acid Spray",
+                "Flamethrower"
+            ]
+        },
+    },
+    "Toxicroak": {
+        "Bulky Assault Vest": {
+            "level": 50,
+            "evs": {
+                "hp": 204,
+                "at": 108,
+                "df": 100,
+                "sa": 0,
+                "sd": 92,
+                "sp": 4
+            },
+            "nature": "Adamant",
+            "tera_type": "Fire",
+            "item": "Assault Vest",
+            "moves": [
+                "Gunk Shot",
+                "Close Combat",
+                "Sucker Punch",
+                "Fake Out"
+            ]
+        },
+    },
+    "Kilowattrel": {
+        "Tailwind Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Competitive",
+            "tera_type": "Ghost",
+            "item": "Focus Sash",
+            "moves": [
+                "Thunderbolt",
+                "Air Slash",
+                "Tailwind",
+                "Protect"
+            ]
+        },
+    },
+    "Vaporeon": {
+        "Hard Dondozo Check": {
+            "level": 50,
+            "evs": {
+                "hp": 148,
+                "at": 0,
+                "df": 252,
+                "sa": 4,
+                "sd": 100,
+                "sp": 4
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Water Absorb",
+            "tera_type": "Fairy",
+            "item": "Leftovers",
+            "moves": [
+                "Muddy Water",
+                "Ice Beam",
+                "Haze",
+                "Recover"
+            ]
+        },
+    },
+    //"Jolteon": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Flareon": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Espeon": {
+        "Specs Psyspam": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "item": "Choice Specs",
+            "moves": [
+                "Expanding Force",
+                "Psychic",
+                "Dazzling Gleam",
+                "Power Gem"
+            ]
+        },
+    },
+    "Umbreon": {
+        "Tera Water Support": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 228,
+                "sa": 0,
+                "sd": 36,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Calm",
+            "ability": "Inner Focus",
+            "tera_type": "Water",
+            "item": "Leftovers",
+            "moves": [
+                "Foul Play",
+                "Snarl",
+                "Taunt",
+                "Yawn"
+            ]
+        },
+    },
+    //"Leafeon": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Glaceon": {
+        "Specs Snow Blizzard Spam": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Snow Cloak",
+            "tera_type": "Water",
+            "item": "Choice Specs",
+            "moves": [
+                "Blizzard",
+                "Freeze-Dry",
+                "Tera Blast",
+                "Shadow Ball"
+            ]
+        },
+    },
+    "Sylveon": {
+        "Tera Water Choice Specs": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "nature": "Modest",
+            "ability": "Pixilate",
+            "tera_type": "Water",
+            "item": "Choice Specs",
+            "moves": [
+                "Hyper Voice",
+                "Tera Blast",
+                "Quick Attack",
+                "Hyper Beam"
+            ]
+        },
+        "Tera Fire Throat Spray": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "nature": "Modest",
+            "ability": "Pixilate",
+            "tera_type": "Fire",
+            "item": "Throat Spray",
+            "moves": [
+                "Hyper Voice",
+                "Tera Blast",
+                "Quick Attack",
+                "Protect"
+            ]
+        },
+    },
+    "Dudunsparce": {
+        "Rattled WP Tera Psychic": {
+            "level": 50,
+            "evs": {
+                "hp": 140,
+                "at": 0,
+                "df": 0,
+                "sa": 164,
+                "sd": 0,
+                "sp": 204
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Rattled",
+            "tera_type": "Psychic",
+            "item": "Weakness Policy",
+            "moves": [
+                "Boomburst",
+                "Stored Power",
+                "Baton Pass",
+                "Roost"
+            ]
+        },
+    },
+    "Dudunsparce-Three-Segment": {
+        "Rattled WP Tera Psychic": {
+            "level": 50,
+            "evs": {
+                "hp": 140,
+                "at": 0,
+                "df": 0,
+                "sa": 164,
+                "sd": 0,
+                "sp": 204
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Rattled",
+            "tera_type": "Psychic",
+            "item": "Weakness Policy",
+            "moves": [
+                "Boomburst",
+                "Stored Power",
+                "Baton Pass",
+                "Roost"
+            ]
+        },
+    },
+    //"Sawsbuck": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Farigiraf": {
+        "ceree's 24 Worlds 1st Tera Water Electric Seed": {
+            "level": 50,
+            "evs": {
+                "hp": 204,
+                "at": 0,
+                "df": 164,
+                "sa": 4,
+                "sd": 108,
+                "sp": 28
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "ability": "Armor Tail",
+            "tera_type": "Water",
+            "item": "Electric Seed",
+            "moves": [
+                "Foul Play",
+                "Psychic Noise",
+                "Helping Hand",
+                "Trick Room"
+            ]
+        },
+        "zee's NAIC T16 Twin Beam Electric Seed": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 52,
+                "sa": 84,
+                "sd": 116,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 22,
+            },
+            "nature": "Modest",
+            "ability": "Armor Tail",
+            "tera_type": "Ground",
+            "item": "Electric Seed",
+            "moves": [
+                "Foul Play",
+                "Twin Beam",
+                "Helping Hand",
+                "Trick Room"
+            ]
+        },
+        "Bulky Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 252,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "ability": "Armor Tail",
+            "tera_type": "Fairy",
+            "item": "Rocky Helmet",
+            "moves": [
+                "Dazzling Gleam",
+                "Psychic Noise",
+                "Helping Hand",
+                "Trick Room"
+            ]
+        },
+        "Throat Spray Offensive": {
+            "level": 50,
+            "evs": {
+                "hp": 108,
+                "at": 0,
+                "df": 44,
+                "sa": 156,
+                "sd": 196,
+                "sp": 4
+            },
+            "ivs": {
+                "at": 0
+            },
+            "nature": "Modest",
+            "ability": "Armor Tail",
+            "tera_type": "Fairy",
+            "item": "Throat Spray",
+            "moves": [
+                "Hyper Voice",
+                "Psychic",
+                "Dazzling Gleam",
+                "Trick Room"
+            ]
+        },
+    },
+    //"Muk": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Mabosstiff": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Toxtricity": {
+        "Tera Normal Specs": {
+            "level": 50,
+            "evs": {
+                "hp": 36,
+                "at": 0,
+                "df": 4,
+                "sa": 204,
+                "sd": 12,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Punk Rock",
+            "tera_type": "Normal",
+            "item": "Choice Specs",
+            "moves": [
+                "Overdrive",
+                "Sludge Bomb",
+                "Boomburst",
+                "Volt Switch"
+            ]
+        },
+    },
+    //"Dedenne": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Pachirisu": {
+        "Miraidon Wall": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 4,
+                "df": 148,
+                "sa": 0,
+                "sd": 4,
+                "sp": 100
+            },
+            "nature": "Jolly",
+            "ability": "Volt Absorb",
+            "tera_type": "Fairy",
+            "item": "Rocky Helmet",
+            "moves": [
+                "Super Fang",
+                "Nuzzle",
+                "Follow Me",
+                "Helping Hand"
+            ]
+        },
+    },
+    "Grafaiai": {
+        "Doodle Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Timid",
+            "ability": "Prankster",
+            "tera_type": "Ghost",
+            "item": "Focus Sash",
+            "moves": [
+                "Doodle",
+                "Parting Shot",
+                "Super Fang",
+                "Taunt"
+            ]
+        },
+    },
+    //"Stantler": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Amoonguss": {
+        "Standard Sitrus Berry": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 156,
+                "sa": 0,
+                "sd": 108,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "ability": "Regenerator",
+            "tera_type": "Water",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Sludge Bomb",
+                "Pollen Puff",
+                "Spore",
+                "Rage Powder"
+            ]
+        },
+    },
+    //"Electrode": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Magnezone": {
+        "Tera Flying Specs Analytic": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Analytic",
+            "tera_type": "Flying",
+            "item": "Choice Specs",
+            "moves": [
+                "Thunderbolt",
+                "Flash Cannon",
+                "Tera Blast",
+                "Volt Switch"
+            ]
+        },
+    },
+    "Ditto": {
+        "Min Speed Scarf": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 252,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 0
+            },
+            "nature": "Relaxed",
+            "ability": "Imposter",
+            "tera_type": "Ghost",
+            "item": "Choice Scarf",
+            "moves": [
+                "Transform"
+            ]
+        },
+    },
+    "Arcanine": {
+        "Tera Water Goggles": {
+            "level": 50,
+            "evs": {
+                "hp": 236,
+                "at": 68,
+                "df": 4,
+                "sa": 0,
+                "sd": 4,
+                "sp": 196
+            },
+            "nature": "Jolly",
+            "ability": "Intimidate",
+            "tera_type": "Water",
+            "item": "Safety Goggles",
+            "moves": [
+                "Flare Blitz",
+                "Extreme Speed",
+                "Will-O-Wisp",
+                "Protect"
+            ]
+        },
+        "Tera Grass Bulky Sitrus": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 52,
+                "df": 100,
+                "sa": 0,
+                "sd": 76,
+                "sp": 36
+            },
+            "nature": "Careful",
+            "ability": "Intimidate",
+            "tera_type": "Grass",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Flare Blitz",
+                "Extreme Speed",
+                "Snarl",
+                "Protect"
+            ]
+        },
+        "Tera Normal Band": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Intimidate",
+            "tera_type": "Normal",
+            "item": "Choice Band",
+            "moves": [
+                "Flare Blitz",
+                "Extreme Speed",
+                "Close Combat",
+                "Crunch"
+            ]
+        },
+        "Chuppa's & D'Angelo's San Diego 1st AV": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 236,
+                "df": 4,
+                "sa": 0,
+                "sd": 12,
+                "sp": 4
+            },
+            "nature": "Adamant",
+            "ability": "Intimidate",
+            "tera_type": "Fairy",
+            "item": "Assault Vest",
+            "moves": [
+                "Flare Blitz",
+                "Extreme Speed",
+                "Play Rough",
+                "Snarl"
+            ]
+        },
+    },
+    //"Ursaring": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Zangoose": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Seviper": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Altaria": {
+        "agano_pokemon's 24 Worlds Day 2 GravSing": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 92,
+                "sa": 4,
+                "sd": 36,
+                "sp": 124
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Calm",
+            "ability": "Cloud Nine",
+            "tera_type": "Water",
+            "item": "Mental Herb",
+            "moves": [
+                "Hurricane",
+                "Tailwind",
+                "Sing",
+                "Roost"
+            ]
+        },
+    },
+    //"Gogoat": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Tauros-Paldea-Combat": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Tauros-Paldea-Blaze": {
+        "Will-O-Wisp Support": {
+            "level": 50,
+            "evs": {
+                "hp": 220,
+                "at": 20,
+                "df": 44,
+                "sa": 0,
+                "sd": 108,
+                "sp": 116
+            },
+            "nature": "Impish",
+            "ability": "Intimidate",
+            "tera_type": "Grass",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Close Combat",
+                "Flare Blitz",
+                "Will-O-Wisp",
+                "Protect"
+            ]
+        },
+    },
+    "Tauros-Paldea-Aqua": {
+        "Tera Water Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Intimidate",
+            "tera_type": "Water",
+            "item": "Life Orb",
+            "moves": [
+                "Wave Crash",
+                "Close Combat",
+                "Aqua Jet",
+                "Protect"
+            ]
+        },
+        "Assault Vest Anger Point": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Anger Point",
+            "tera_type": "Ground",
+            "item": "Assault Vest",
+            "moves": [
+                "Raging Bull",
+                "Close Combat",
+                "Aqua Jet",
+                "Earthquake"
+            ]
+        },
+        "Tera Grass Mirror Herb": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Intimidate",
+            "tera_type": "Grass",
+            "item": "Mirror Herb",
+            "moves": [
+                "Raging Bull",
+                "Close Combat",
+                "Aqua Jet",
+                "Protect"
+            ]
+        },
+    },
+    //"Pyroar": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Skuntank": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Zoroark": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Weavile": {
+        "4 Attacks Focus Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Pressure",
+            "tera_type": "Ice",
+            "item": "Focus Sash",
+            "moves": [
+                "Fake Out",
+                "Triple Axel",
+                "Knock Off",
+                "Upper Hand"
+            ]
+        },
+    },
+    "Murkrow": {
+        "Eviolite Bulk": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 116,
+                "sa": 0,
+                "sd": 140,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Calm",
+            "ability": "Prankster",
+            "tera_type": "Ghost",
+            "item": "Eviolite",
+            "moves": [
+                "Foul Play",
+                "Tailwind",
+                "Taunt",
+                "Haze"
+            ]
+        },
+        "Sash Brave Bird": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Prankster",
+            "tera_type": "Ghost",
+            "item": "Focus Sash",
+            "moves": [
+                "Brave Bird",
+                "Tailwind",
+                "Protect",
+                "Haze"
+            ]
+        },
+    },
+    //"Honchkrow": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Gothitelle": {
+        "Shadow Tag TR Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 100,
+                "sa": 0,
+                "sd": 156,
+                "sp": 0
+            },
+            "nature": "Calm",
+            "ability": "Shadow Tag",
+            "tera_type": "Water",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Psychic",
+                "Fake Out",
+                "Trick Room",
+                "Helping Hand"
+            ]
+        },
+    },
+    //"Polteageist": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Mimikyu": {
+        "Trick Room Safety Goggles": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 164,
+                "df": 44,
+                "sa": 0,
+                "sd": 36,
+                "sp": 12
+            },
+            "nature": "Adamant",
+            "ability": "Disguise",
+            "tera_type": "Fairy",
+            "item": "Safety Goggles",
+            "moves": [
+                "Play Rough",
+                "Shadow Sneak",
+                "Trick Room",
+                "Will-O-Wisp"
+            ]
+        },
+        "Tera Ghost Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Disguise",
+            "tera_type": "Ghost",
+            "item": "Life Orb",
+            "moves": [
+                "Play Rough",
+                "Shadow Sneak",
+                "Shadow Claw",
+                "Protect"
+            ]
+        },
+    },
+    "Klefki": {
+        "Screens Speed Control": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 76,
+                "sa": 0,
+                "sd": 180,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Calm",
+            "ability": "Prankster",
+            "tera_type": "Ghost",
+            "item": "Light Clay",
+            "moves": [
+                "Dazzling Gleam",
+                "Reflect",
+                "Light Screen",
+                "Thunder Wave"
+            ]
+        },
+    },
+    "Indeedee": {
+        "Tera Psychic Scarf": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Psychic Surge",
+            "tera_type": "Psychic",
+            "item": "Choice Scarf",
+            "moves": [
+                "Expanding Force",
+                "Tera Blast",
+                "Trick",
+                "Dazzling Gleam"
+            ]
+        },
+        "Sash Imprison Trick Room": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Psychic Surge",
+            "tera_type": "Fighting",
+            "item": "Focus Sash",
+            "moves": [
+                "Expanding Force",
+                "Tera Blast",
+                "Trick Room",
+                "Imprison"
+            ]
+        },
+    },
+    "Indeedee-F": {
+        "Trick Room Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 252,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "ability": "Psychic Surge",
+            "tera_type": "Fairy",
+            "item": "Psychic Seed",
+            "moves": [
+                "Dazzling Gleam",
+                "Follow Me",
+                "Helping Hand",
+                "Trick Room"
+            ]
+        },
+    },
+    "Brambleghast": {
+        "Post-DLC Offense": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Wind Rider",
+            "tera_type": "Ghost",
+            "item": "Focus Sash",
+            "moves": [
+                "Power Whip",
+                "Shadow Sneak",
+                "Poltergeist",
+                "Seed Bomb"
+            ]
+        },
+        "Emilio Forbes' 23 Worlds T16 Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Wind Rider",
+            "tera_type": "Ghost",
+            "item": "Focus Sash",
+            "moves": [
+                "Power Whip",
+                "Shadow Sneak",
+                "Tera Blast",
+                "Strength Sap"
+            ]
+        },
+    },
+    "Toedscruel": {
+        "Defensive Trick Room": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 252,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "ability": "Mycelium Might",
+            "tera_type": "Water",
+            "item": "Occa Berry",
+            "moves": [
+                "Earth Power",
+                "Spore",
+                "Rage Powder",
+                "Trick Room"
+            ]
+        },
+    },
+    //"Tropius": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Lurantis": {
+        "TR Sitrus": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 0
+            },
+            "nature": "Brave",
+            "ability": "Contrary",
+            "tera_type": "Poison",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Superpower",
+                "Knock Off",
+                "Leaf Blade",
+                "Petal Blizzard"
+            ]
+        },
+    },
+    //"Klawf": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Scovillain": {
+        "Offensive Chlorophyll": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Chlorophyll",
+            "item": "Focus Sash",
+            "moves": [
+                "Flamethrower",
+                "Energy Ball",
+                "Pollen Puff",
+                "Spicy Extract"
+            ]
+        },
+    },
+    //"Cacturne": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Rabsca": {
+        "Leppa Revival Blessing": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 164,
+                "sa": 0,
+                "sd": 92,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 0
+            },
+            "nature": "Sassy",
+            "ability": "Telepathy",
+            "tera_type": "Dark",
+            "item": "Leppa Berry",
+            "moves": [
+                "Bug Buzz",
+                "Trick Room",
+                "Revival Blessing",
+                "Recover"
+            ]
+        },
+    },
+    //"Venomoth": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Forretress": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Scyther": {
+        "The Flamigo that beats only other Flamigo": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Technician",
+            "tera_type": "Ghost",
+            "item": "Focus Sash",
+            "moves": [
+                "Dual Wingbeat",
+                "Close Combat",
+                "Feint",
+                "Thief"
+            ]
+        },
+    },
+    "Scizor": {
+        "Tera Steel Swords Dance": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "ability": "Technician",
+            "tera_type": "Steel",
+            "item": "Clear Amulet",
+            "moves": [
+                "Bullet Punch",
+                "Close Combat",
+                "Swords Dance",
+                "Protect"
+            ]
+        },
+        "Tera Steel Choice Band": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "ability": "Technician",
+            "tera_type": "Steel",
+            "item": "Choice Band",
+            "moves": [
+                "Bullet Punch",
+                "Close Combat",
+                "Bug Bite",
+                "U-turn"
+            ]
+        },
+    },
+    //"Heracross": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Espathra": {
+        "Life Orb Speed Boost": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Speed Boost",
+            "tera_type": "Fairy",
+            "item": "Life Orb",
+            "moves": [
+                "Lumina Crash",
+                "Dazzling Gleam",
+                "Expanding Force",
+                "Protect"
+            ]
+        },
+        "Sash Hypnosis": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Speed Boost",
+            "tera_type": "Fairy",
+            "item": "Focus Sash",
+            "moves": [
+                "Lumina Crash",
+                "Dazzling Gleam",
+                "Hypnosis",
+                "Protect"
+            ]
+        },
+    },
+    "Hippowdon": {
+        "Stall Chipper": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 4,
+                "sa": 0,
+                "sd": 252,
+                "sp": 0
+            },
+            "nature": "Impish",
+            "tera_type": "Steel",
+            "item": "Rocky Helmet",
+            "moves": [
+                "Sand Tomb",
+                "Body Press",
+                "Slack Off",
+                "Yawn"
+            ]
+        },
+    },
+    "Krookodile": {
+        "Tera Poison Amulet Offense": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Poison",
+            "item": "Clear Amulet",
+            "moves": [
+                "Knock Off",
+                "High Horsepower",
+                "Earthquake",
+                "Gunk Shot"
+            ]
+        },
+    },
+    //"Sandaconda": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Mudsdale": {
+        "Stamina Assault Vest": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 196,
+                "df": 0,
+                "sa": 0,
+                "sd": 60,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 0
+            },
+            "nature": "Brave",
+            "ability": "Stamina",
+            "item": "Assault Vest",
+            "moves": [
+                "High Horsepower",
+                "Body Press",
+                "Rock Slide",
+                "Heavy Slam"
+            ]
+        },
+    },
+    "Volcarona": {
+        "Leftovers Quiver Dance": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 60,
+                "sa": 36,
+                "sd": 4,
+                "sp": 156
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Flame Body",
+            "tera_type": "Grass",
+            "item": "Leftovers",
+            "moves": [
+                "Fiery Dance",
+                "Giga Drain",
+                "Heat Wave",
+                "Quiver Dance"
+            ]
+        },
+        "Sitrus Berry Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 212,
+                "sa": 4,
+                "sd": 36,
+                "sp": 4
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Calm",
+            "ability": "Flame Body",
+            "tera_type": "Grass",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Struggle Bug",
+                "Overheat",
+                "Tailwind",
+                "Rage Powder"
+            ]
+        },
+    },
+    "Salamence": {
+        "Bulky Rocky Helmet": {
+            "level": 50,
+            "evs": {
+                "hp": 236,
+                "at": 0,
+                "df": 172,
+                "sa": 4,
+                "sd": 12,
+                "sp": 84
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Intimidate",
+            "tera_type": "Poison",
+            "item": "Rocky Helmet",
+            "moves": [
+                "Draco Meteor",
+                "Air Slash",
+                "Tailwind",
+                "Roost"
+            ]
+        },
+        "Special LO Tailwind": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Intimidate",
+            "tera_type": "Steel",
+            "item": "Life Orb",
+            "moves": [
+                "Draco Meteor",
+                "Heat Wave",
+                "Tailwind",
+                "Hurricane"
+            ]
+        },
+        "Tera Steel Dragon Dance": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Intimidate",
+            "tera_type": "Steel",
+            "item": "Clear Amulet",
+            "moves": [
+                "Dragon Claw",
+                "Dual Wingbeat",
+                "Iron Head",
+                "Dragon Dance"
+            ]
+        },
+    },
+    "Tinkaton": {
+        "Assault Vest Own Tempo": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "ability": "Own Tempo",
+            "tera_type": "Steel",
+            "item": "Assault Vest",
+            "moves": [
+                "Fake Out",
+                "Gigaton Hammer",
+                "Play Rough",
+                "Knock Off"
+            ]
+        },
+    },
+    "Hatterene": {
+        "Tera Fire Trick Room": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 0,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 0
+            },
+            "nature": "Quiet",
+            "ability": "Magic Bounce",
+            "tera_type": "Fire",
+            "item": "Life Orb",
+            "moves": [
+                "Expanding Force",
+                "Dazzling Gleam",
+                "Mystical Fire",
+                "Trick Room"
+            ]
+        },
+    },
+    "Grimmsnarl": {
+        "Screens Light Clay": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 4,
+                "df": 124,
+                "sa": 0,
+                "sd": 116,
+                "sp": 12
+            },
+            "nature": "Careful",
+            "ability": "Prankster",
+            "tera_type": "Ghost",
+            "item": "Light Clay",
+            "moves": [
+                "Spirit Break",
+                "Reflect",
+                "Light Screen",
+                "Foul Play"
+            ]
+        },
+    },
+    //"Wugtrio": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Bombirdier": {
+        "Tera Rock Assault Vest": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 4
+            },
+            "nature": "Adamant",
+            "ability": "Rocky Payload",
+            "item": "Assault Vest",
+            "tera_type": "Rock",
+            "moves": [
+                "Rock Slide",
+                "Brave Bird",
+                "Knock Off",
+                "Sucker Punch"
+            ]
+        },
+    },
+    "Palafin": {
+        "Mystic Water Haze": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 4
+            },
+            "nature": "Adamant",
+            "ability": "Zero to Hero",
+            "item": "Mystic Water",
+            "moves": [
+                "Jet Punch",
+                "Wave Crash",
+                "Haze",
+                "Protect"
+            ]
+        },
+        "Choice Band Max Speed": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Zero to Hero",
+            "item": "Choice Band",
+            "moves": [
+                "Flip Turn",
+                "Jet Punch",
+                "Ice Punch",
+                "Close Combat"
+            ]
+        },
+    },
+    //"Revavroom": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Cyclizar": {
+        "Shed Tail Support": {
+            "level": 50,
+            "evs": {
+                "hp": 116,
+                "at": 4,
+                "df": 68,
+                "sa": 0,
+                "sd": 140,
+                "sp": 180
+            },
+            "nature": "Jolly",
+            "ability": "Regenerator",
+            "tera_type": "Dark",
+            "item": "Leftovers",
+            "moves": [
+                "Knock Off",
+                "Taunt",
+                "Shed Tail",
+                "Protect"
+            ]
+        },
+    },
+    "Orthworm": {
+        "Body Press Shed Tail": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 36,
+                "sa": 0,
+                "sd": 228,
+                "sp": 0
+            },
+            "nature": "Careful",
+            "ability": "Earth Eater",
+            "tera_type": "Fire",
+            "item": "Leftovers",
+            "moves": [
+                "Body Press",
+                "Heavy Slam",
+                "Shed Tail",
+                "Iron Defense"
+            ]
+        },
+    },
+    "Sableye": {
+        "Quash Will-O-Wisp": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 116,
+                "sa": 0,
+                "sd": 140,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "ability": "Prankster",
+            "tera_type": "Poison",
+            "item": "Roseli Berry",
+            "moves": [
+                "Foul Play",
+                "Fake Out",
+                "Quash",
+                "Will-O-Wisp"
+            ]
+        },
+    },
+    //"Banette": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Falinks": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Hawlucha": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Spiritomb": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Noivern": {
+        "Tera Normal Boomburst": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0
+            },
+            "nature": "Timid",
+            "ability": "Frisk",
+            "tera_type": "Normal",
+            "item": "Focus Sash",
+            "moves": [
+                "Boomburst",
+                "Draco Meteor",
+                "Heat Wave",
+                "Tailwind"
+            ]
+        },
+    },
+    "Dragapult": {
+        "Adamant Banded Tera Dragon": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Clear Body",
+            "item": "Choice Band",
+            "moves": [
+                "Dragon Darts",
+                "Outrage",
+                "Phantom Force",
+                "U-turn"
+            ]
+        },
+        "PokeAlex's 23 NAIC 1st Banded Tera Steel": {
+            "level": 50,
+            "evs": {
+                "hp": 12,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 28,
+                "sp": 212
+            },
+            "nature": "Jolly",
+            "ability": "Clear Body",
+            "tera_type": "Steel",
+            "item": "Choice Band",
+            "moves": [
+                "Dragon Darts",
+                "Tera Blast",
+                "Phantom Force",
+                "U-turn"
+            ]
+        },
+        "Choice Specs Tera Steel": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Clear Body",
+            "tera_type": "Steel",
+            "item": "Choice Specs",
+            "moves": [
+                "Draco Meteor",
+                "Shadow Ball",
+                "Flamethrower",
+                "Tera Blast"
+            ]
+        },
+    },
+    "Glimmora": {
+        "Standard Meteor Beam": {
+            "level": 50,
+            "evs": {
+                "hp": 20,
+                "at": 0,
+                "df": 36,
+                "sa": 156,
+                "sd": 44,
+                "sp": 252
+            },
+            "nature": "Timid",
+            "ability": "Toxic Debris",
+            "tera_type": "Grass",
+            "item": "Power Herb",
+            "moves": [
+                "Meteor Beam",
+                "Sludge Bomb",
+                "Earth Power",
+                "Mortal Spin"
+            ]
+        },
+        "Tera Grass Assault Vest": {
+            "level": 50,
+            "evs": {
+                "hp": 212,
+                "at": 0,
+                "df": 4,
+                "sa": 156,
+                "sd": 124,
+                "sp": 12
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Toxic Debris",
+            "tera_type": "Grass",
+            "item": "Assault Vest",
+            "moves": [
+                "Power Gem",
+                "Sludge Bomb",
+                "Earth Power",
+                "Energy Ball"
+            ]
+        },
+        "Emilio's Specs Tera Grass": {
+            "level": 50,
+            "evs": {
+                "hp": 20,
+                "at": 0,
+                "df": 0,
+                "sa": 236,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Toxic Debris",
+            "tera_type": "Grass",
+            "item": "Choice Specs",
+            "moves": [
+                "Power Gem",
+                "Sludge Bomb",
+                "Earth Power",
+                "Sludge Wave"
+            ]
+        },
+    },
+    //"Rotom": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Rotom-Wash": {
+        "Bulky Sitrus Set": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 100,
+                "sa": 44,
+                "sd": 76,
+                "sp": 36
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "ability": "Levitate",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Thunderbolt",
+                "Hydro Pump",
+                "Will-O-Wisp",
+                "Protect"
+            ]
+        },
+    },
+    "Rotom-Heat": {
+        "Basic Choice Specs": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Levitate",
+            "item": "Choice Specs",
+            "moves": [
+                "Thunderbolt",
+                "Overheat",
+                "Volt Switch",
+                "Trick"
+            ]
+        },
+    },
+    "Rotom-Mow": {
+        "Sitrus DisQuake": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 4,
+                "sa": 92,
+                "sd": 44,
+                "sp": 116
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Levitate",
+            "tera_type": "Electric",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Discharge",
+                "Leaf Storm",
+                "Will-O-Wisp",
+                "Protect"
+            ]
+        },
+    },
+    //"Rotom-Frost": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Rotom-Fan": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Houndstone": {
+        "Sand Rush Choice Band": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Sand Rush",
+            "tera_type": "Fighting",
+            "item": "Choice Band",
+            "moves": [
+                "Last Respects",
+                "Body Press",
+                "Play Rough",
+                "Trick"
+            ]
+        },
+    },
+    "Oranguru": {
+        "Safety Goggles Trick Room": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 108,
+                "sa": 0,
+                "sd": 156,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 0
+            },
+            "nature": "Sassy",
+            "tera_type": "Dark",
+            "ability": "Inner Focus",
+            "item": "Safety Goggles",
+            "moves": [
+                "Foul Play",
+                "Trick Room",
+                "Instruct",
+                "Protect"
+            ]
+        },
+    },
+    //"Passimian": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Komala": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Tyranitar": {
+        "Tera Flying AV": {
+            "level": 50,
+            "evs": {
+                "hp": 196,
+                "at": 140,
+                "df": 12,
+                "sa": 0,
+                "sd": 28,
+                "sp": 132
+            },
+            "nature": "Adamant",
+            "ability": "Sand Stream",
+            "tera_type": "Flying",
+            "item": "Assault Vest",
+            "moves": [
+                "Rock Slide",
+                "Knock Off",
+                "Low Kick",
+                "Tera Blast"
+            ]
+        },
+        "EternalSnowman's Sacramento 1st Psychic AV": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 4,
+                "sp": 244
+            },
+            "nature": "Adamant",
+            "ability": "Sand Stream",
+            "tera_type": "Psychic",
+            "item": "Assault Vest",
+            "moves": [
+                "Rock Slide",
+                "Knock Off",
+                "Low Kick",
+                "Tera Blast"
+            ]
+        },
+        "Tera Grass AV Lentar": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 4,
+                "sa": 0,
+                "sd": 252,
+                "sp": 0
+            },
+            "nature": "Careful",
+            "ability": "Sand Stream",
+            "tera_type": "Grass",
+            "item": "Assault Vest",
+            "moves": [
+                "Rock Slide",
+                "Knock Off",
+                "Low Kick",
+                "Tera Blast"
+            ]
+        },
+        "Dragon Dance Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Sand Stream",
+            "tera_type": "Ghost",
+            "item": "Life Orb",
+            "moves": [
+                "Rock Slide",
+                "Crunch",
+                "Dragon Dance",
+                "Protect"
+            ]
+        },
+    },
+    "Stonjourner": {
+        "WACKA's Orlando T16 Rock": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "item": "Focus Sash",
+            "moves": [
+                "Rock Slide",
+                "Low Kick",
+                "Wide Guard",
+                "Protect"
+            ]
+        },
+    },
+    //"Eiscue": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Pincurchin": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Palossand": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Slowbro": {
+        "Trick Room Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 252,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 0
+            },
+            "nature": "Relaxed",
+            "ability": "Oblivious",
+            "tera_type": "Fire",
+            "item": "Leftovers",
+            "moves": [
+                "Scald",
+                "Psychic",
+                "Body Press",
+                "Trick Room"
+            ]
+        },
+    },
+    "Slowking": {
+        "Basic Trick Room": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 108,
+                "sa": 108,
+                "sd": 36,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 0
+            },
+            "nature": "Quiet",
+            "ability": "Regenerator",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Psychic",
+                "Hydro Pump",
+                "Trick Room",
+                "Helping Hand"
+            ]
+        },
+    },
+    "Gastrodon": {
+        "Tera Fire Leftovers": {
+            "level": 50,
+            "evs": {
+                "hp": 116,
+                "at": 0,
+                "df": 252,
+                "sa": 0,
+                "sd": 140,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "ability": "Storm Drain",
+            "tera_type": "Fire",
+            "item": "Leftovers",
+            "moves": [
+                "Earth Power",
+                "Muddy Water",
+                "Ice Beam",
+                "Protect"
+            ]
+        },
+    },
+    "Cloyster": {
+        "You sure? Ok, Skill Link Shell Smash": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "tera_type": "Grass",
+            "item": "Focus Sash",
+            "moves": [
+                "Icicle Spear",
+                "Rock Blast",
+                "Ice Shard",
+                "Shell Smash"
+            ]
+        },
+    },
+    //"Qwilfish": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Luvdisc": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Lumineon": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Bruxish": {
+        "TR Setter + Attacker": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 0
+            },
+            "nature": "Brave",
+            "ability": "Dazzling",
+            "tera_type": "Grass",
+            "item": "Focus Sash",
+            "moves": [
+                "Wave Crash",
+                "Psychic Fangs",
+                "Aqua Jet",
+                "Trick Room"
+            ]
+        },
+    },
+    //"Alomomola": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Dragalge": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Clawitzer": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Eelektross": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Toxapex": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Flamigo": {
+        "Costar Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Costar",
+            "item": "Life Orb",
+            "moves": [
+                "Close Combat",
+                "Brave Bird",
+                "Throat Chop",
+                "Detect"
+            ]
+        },
+        "Stellar Scrappy Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Scrappy",
+            "tera_type": "Stellar",
+            "item": "Focus Sash",
+            "moves": [
+                "Close Combat",
+                "Brave Bird",
+                "Throat Chop",
+                "Wide Guard"
+            ]
+        },
+    },
+    "Dragonite": {
+        "Tera Steel Loaded Dice": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Multiscale",
+            "tera_type": "Steel",
+            "item": "Loaded Dice",
+            "moves": [
+                "Extreme Speed",
+                "Scale Shot",
+                "Iron Head",
+                "Ice Spinner"
+            ]
+        },
+        "Tera Normal Choice Band": {
+            "level": 50,
+            "evs": {
+                "hp": 236,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 20
+            },
+            "nature": "Adamant",
+            "ability": "Inner Focus",
+            "tera_type": "Normal",
+            "item": "Choice Band",
+            "moves": [
+                "Extreme Speed",
+                "Outrage",
+                "Stomping Tantrum",
+                "Aerial Ace"
+            ]
+        },
+        "Tera Flying Assault Vest": {
+            "level": 50,
+            "evs": {
+                "hp": 212,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 4,
+                "sp": 36
+            },
+            "nature": "Adamant",
+            "ability": "Multiscale",
+            "tera_type": "Flying",
+            "item": "Assault Vest",
+            "moves": [
+                "Extreme Speed",
+                "Tera Blast",
+                "Stomping Tantrum",
+                "Low Kick"
+            ]
+        },
+        "Tera Normal Assault Vest": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 4
+            },
+            "nature": "Adamant",
+            "ability": "Inner Focus",
+            "tera_type": "Normal",
+            "item": "Assault Vest",
+            "moves": [
+                "Extreme Speed",
+                "Aerial Ace",
+                "Stomping Tantrum",
+                "Thunder Punch"
+            ]
+        },
+    },
+    //"Frosmoth": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Abomasnow": {
+        "Sash Aurora Veil": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 220,
+                "sd": 0,
+                "sp": 36
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Snow Warning",
+            "tera_type": "Water",
+            "item": "Focus Sash",
+            "moves": [
+                "Blizzard",
+                "Leaf Storm",
+                "Aurora Veil",
+                "Earth Power"
+            ]
+        },
+    },
+    //"Delibird": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Beartic": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Glalie": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Froslass": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Cryogonal": {
+        "1.5% usage in December 2022 in 1760+ how": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Fairy",
+            "item": "Focus Sash",
+            "moves": [
+                "Freeze-Dry",
+                "Icy Wind",
+                "Haze",
+                "Protect"
+            ]
+        },
+    },
+    "Cetitan": {
+        "Basic Belly Drum": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 20,
+                "sa": 0,
+                "sd": 84,
+                "sp": 148
+            },
+            "nature": "Adamant",
+            "ability": "Slush Rush",
+            "tera_type": "Water",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Belly Drum",
+                "Ice Spinner",
+                "Ice Shard",
+                "Liquidation"
+            ]
+        },
+        "Assault Vest Tera Water": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 20,
+                "sa": 0,
+                "sd": 116,
+                "sp": 116
+            },
+            "nature": "Adamant",
+            "ability": "Slush Rush",
+            "tera_type": "Water",
+            "item": "Assault Vest",
+            "moves": [
+                "Ice Spinner",
+                "Liquidation",
+                "Superpower",
+                "Earthquake"
+            ]
+        },
+    },
+    "Avalugg": {
+        "Physically Defensive Body Press": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 4,
+                "df": 252,
+                "sa": 0,
+                "sd": 0,
+                "sp": 0
+            },
+            "nature": "Impish",
+            "ability": "Sturdy",
+            "tera_type": "Water",
+            "item": "Figy Berry",
+            "moves": [
+                "Body Press",
+                "Ice Spinner",
+                "Wide Guard",
+                "Recover"
+            ]
+        },
+    },
+    "Braviary": {
+        "Psychic Seed Acrobatics": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "tera_type": "Steel",
+            "item": "Psychic Seed",
+            "moves": [
+                "Acrobatics",
+                "Close Combat",
+                "Brave Bird",
+                "Tailwind"
+            ]
+        },
+    },
+    //"Bisharp": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Kingambit": {
+        "Black Glasses SUGGESTION BY ASHTONCOXGAZ": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "ability": "Defiant",
+            "tera_type": "Dark",
+            "item": "Black Glasses",
+            "moves": [
+                "Kowtow Cleave",
+                "Sucker Punch",
+                "Iron Head",
+                "Assurance"
+            ]
+        },
+        "Assault Vest Tera Fire": {
+            "level": 50,
+            "evs": {
+                "hp": 188,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 60,
+                "sp": 4
+            },
+            "nature": "Adamant",
+            "ability": "Defiant",
+            "tera_type": "Fire",
+            "item": "Assault Vest",
+            "moves": [
+                "Kowtow Cleave",
+                "Iron Head",
+                "Sucker Punch",
+                "Low Kick"
+            ]
+        },
+    },
+    "Hydreigon": {
+        "Tera Fire Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Levitate",
+            "tera_type": "Fire",
+            "item": "Life Orb",
+            "moves": [
+                "Dark Pulse",
+                "Draco Meteor",
+                "Heat Wave",
+                "Tailwind"
+            ]
+        },
+        "Tera Steel Assault Vest": {
+            "level": 50,
+            "evs": {
+                "hp": 188,
+                "at": 0,
+                "df": 20,
+                "sa": 116,
+                "sd": 12,
+                "sp": 172
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Levitate",
+            "tera_type": "Steel",
+            "item": "Assault Vest",
+            "moves": [
+                "Dark Pulse",
+                "Draco Meteor",
+                "Snarl",
+                "Flash Cannon"
+            ]
+        },
+    },
+    //"Veluza": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Dondozo": {
+        "Tera Grass Oblivious": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 100,
+                "df": 4,
+                "sa": 0,
+                "sd": 172,
+                "sp": 228
+            },
+            "nature": "Adamant",
+            "ability": "Oblivious",
+            "tera_type": "Grass",
+            "item": "Leftovers",
+            "moves": [
+                "Tera Blast",
+                "Earthquake",
+                "Wave Crash",
+                "Order Up"
+            ]
+        },
+        "45mice's 24 Worlds T16 Defense Body Press": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 4,
+                "df": 196,
+                "sa": 0,
+                "sd": 148,
+                "sp": 156
+            },
+            "nature": "Impish",
+            "ability": "Unaware",
+            "tera_type": "Grass",
+            "item": "Leftovers",
+            "moves": [
+                "Body Press",
+                "Wave Crash",
+                "Order Up",
+                "Protect"
+            ]
+        },
+        "Kenji Yabata's 23 Worlds Cut (No Tatsu)": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 4,
+                "df": 4,
+                "sa": 0,
+                "sd": 252,
+                "sp": 4
+            },
+            "nature": "Careful",
+            "ability": "Unaware",
+            "item": "Leftovers",
+            "moves": [
+                "Wave Crash",
+                "Fissure",
+                "Curse",
+                "Protect"
+            ]
+        },
+        "Mixed Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 4,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Hasty",
+            "ability": "Unaware",
+            "item": "Life Orb",
+            "moves": [
+                "Surf",
+                "Wave Crash",
+                "Sleep Talk",
+                "Protect"
+            ]
+        },
+        "Tera Steel Bulky": {
+            "level": 50,
+            "evs": {
+                "hp": 116,
+                "at": 156,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 236
+            },
+            "nature": "Adamant",
+            "ability": "Unaware",
+            "tera_type": "Steel",
+            "item": "Chesto Berry",
+            "moves": [
+                "Earthquake",
+                "Wave Crash",
+                "Rest",
+                "Protect"
+            ]
+        },
+    },
+    "Tatsugiri": {
+        "Standard Choice Scarf": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Commander",
+            "tera_type": "Steel",
+            "item": "Choice Scarf",
+            "moves": [
+                "Muddy Water",
+                "Draco Meteor",
+                "Icy Wind",
+                "Dragon Pulse"
+            ]
+        },
+        "Standard Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Commander",
+            "tera_type": "Water",
+            "item": "Focus Sash",
+            "moves": [
+                "Muddy Water",
+                "Draco Meteor",
+                "Taunt",
+                "Protect"
+            ]
+        },
+    },
+    "Great Tusk": {
+        "Standard Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "item": "Focus Sash",
+            "moves": [
+                "Headlong Rush",
+                "Close Combat",
+                "Earthquake",
+                "Ice Spinner"
+            ]
+        },
+        "Standard Choice Scarf": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "item": "Choice Scarf",
+            "tera_type": "Steel",
+            "moves": [
+                "Earthquake",
+                "Close Combat",
+                "Headlong Rush",
+                "Rock Slide"
+            ]
+        },
+    },
+    "Scream Tail": {
+        "Speed Booster Encore Disable": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 68,
+                "sa": 0,
+                "sd": 0,
+                "sp": 196
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "item": "Booster Energy",
+            "tera_type": "Normal",
+            "moves": [
+                "Dazzling Gleam",
+                "Disable",
+                "Encore",
+                "Thunder Wave"
+            ]
+        },
+        "Wolfe's Orlando 1st Perish Trap": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 60,
+                "df": 60,
+                "sa": 0,
+                "sd": 36,
+                "sp": 100
+            },
+            "nature": "Jolly",
+            "item": "Booster Energy",
+            "tera_type": "Steel",
+            "moves": [
+                "Play Rough",
+                "Disable",
+                "Protect",
+                "Perish Song"
+            ]
+        },
+        "Sitrus Disruption": {
+            "level": 50,
+            "evs": {
+                "hp": 212,
+                "at": 0,
+                "df": 164,
+                "sa": 0,
+                "sd": 132,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "item": "Sitrus Berry",
+            "tera_type": "Steel",
+            "moves": [
+                "Dazzling Gleam",
+                "Disable",
+                "Encore",
+                "Trick Room"
+            ]
+        },
+    },
+    "Brute Bonnet": {
+        "Offensive Support": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 252,
+                "sa": 0,
+                "sd": 12,
+                "sp": 0
+            },
+            "nature": "Impish",
+            "item": "Sitrus Berry",
+            "tera_type": "Fairy",
+            "moves": [
+                "Seed Bomb",
+                "Sucker Punch",
+                "Spore",
+                "Rage Powder"
+            ]
+        },
+        "Loaded Dice Tera Poison": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 20,
+                "df": 20,
+                "sa": 0,
+                "sd": 220,
+                "sp": 4
+            },
+            "nature": "Adamant",
+            "item": "Loaded Dice",
+            "tera_type": "Poison",
+            "moves": [
+                "Bullet Seed",
+                "Crunch",
+                "Spore",
+                "Rage Powder"
+            ]
+        },
+        "Ashton's Orlando 2nd Speedy Sitrus": {
+            "level": 50,
+            "evs": {
+                "hp": 180,
+                "at": 12,
+                "df": 12,
+                "sa": 0,
+                "sd": 68,
+                "sp": 236
+            },
+            "nature": "Adamant",
+            "item": "Sitrus Berry",
+            "tera_type": "Water",
+            "moves": [
+                "Pollen Puff",
+                "Crunch",
+                "Spore",
+                "Protect"
+            ]
+        },
+    },
+    "Flutter Mane": {
+        "Bulky Speed Booster Energy": {
+            "level": 50,
+            "evs": {
+                "hp": 212,
+                "at": 0,
+                "df": 132,
+                "sa": 36,
+                "sd": 4,
+                "sp": 124
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "item": "Booster Energy",
+            "tera_type": "Fairy",
+            "moves": [
+                "Shadow Ball",
+                "Moonblast",
+                "Dazzling Gleam",
+                "Icy Wind"
+            ]
+        },
+        "Bulky SpAtk Booster Energy": {
+            "level": 50,
+            "evs": {
+                "hp": 220,
+                "at": 0,
+                "df": 132,
+                "sa": 36,
+                "sd": 4,
+                "sp": 116
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "item": "Booster Energy",
+            "tera_type": "Fairy",
+            "moves": [
+                "Shadow Ball",
+                "Moonblast",
+                "Dazzling Gleam",
+                "Icy Wind"
+            ]
+        },
+        "Tera Stellar Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "item": "Focus Sash",
+            "tera_type": "Stellar",
+            "moves": [
+                "Shadow Ball",
+                "Moonblast",
+                "Dazzling Gleam",
+                "Thunderbolt"
+            ]
+        },
+        "Timid Choice Specs": {
+            "level": 50,
+            "evs": {
+                "hp": 100,
+                "at": 0,
+                "df": 60,
+                "sa": 220,
+                "sd": 4,
+                "sp": 124
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "item": "Choice Specs",
+            "tera_type": "Fairy",
+            "moves": [
+                "Shadow Ball",
+                "Moonblast",
+                "Dazzling Gleam",
+                "Power Gem"
+            ]
+        },
+    },
+    "Slither Wing": {
+        "Tera Fire Booster Energy": {
+            "level": 50,
+            "evs": {
+                "hp": 20,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 4,
+                "sp": 228
+            },
+            "nature": "Adamant",
+            "item": "Booster Energy",
+            "tera_type": "Fire",
+            "moves": [
+                "Leech Life",
+                "Close Combat",
+                "Flame Charge",
+                "Protect"
+            ]
+        },
+    },
+    "Sandy Shocks": {
+        "Basic Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "item": "Life Orb",
+            "tera_type": "Electric",
+            "moves": [
+                "Volt Switch",
+                "Earth Power",
+                "Thunderbolt",
+                "Protect"
+            ]
+        },
+        "Tera Ice Specs": {
+            "level": 50,
+            "evs": {
+                "hp": 36,
+                "at": 0,
+                "df": 4,
+                "sa": 204,
+                "sd": 12,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "item": "Choice Specs",
+            "tera_type": "Ice",
+            "moves": [
+                "Volt Switch",
+                "Earth Power",
+                "Thunderbolt",
+                "Tera Blast"
+            ]
+        },
+    },
+    "Iron Treads": {
+        "Tera Ghost Life Orb with Miraidon": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "item": "Life Orb",
+            "tera_type": "Ghost",
+            "moves": [
+                "High Horsepower",
+                "Iron Head",
+                "Steel Roller",
+                "Knock Off"
+            ]
+        },
+        "Tera Flying Assault Vest": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 172,
+                "df": 0,
+                "sa": 0,
+                "sd": 84,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "item": "Assault Vest",
+            "tera_type": "Flying",
+            "moves": [
+                "Iron Head",
+                "Stomping Tantrum",
+                "Ice Spinner",
+                "Tera Blast"
+            ]
+        },
+    },
+    "Iron Bundle": {
+        "Fast Booster Energy": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "item": "Booster Energy",
+            "tera_type": "Ice",
+            "moves": [
+                "Freeze-Dry",
+                "Hydro Pump",
+                "Icy Wind",
+                "Protect"
+            ]
+        },
+        "Bulky Speed Booster": {
+            "level": 50,
+            "evs": {
+                "hp": 44,
+                "at": 0,
+                "df": 4,
+                "sa": 228,
+                "sd": 204,
+                "sp": 28
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "item": "Booster Energy",
+            "tera_type": "Ghost",
+            "moves": [
+                "Freeze-Dry",
+                "Hydro Pump",
+                "Icy Wind",
+                "Encore"
+            ]
+        },
+        "Snow Choice Specs": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "item": "Choice Specs",
+            "tera_type": "Ice",
+            "moves": [
+                "Freeze-Dry",
+                "Hydro Pump",
+                "Icy Wind",
+                "Blizzard"
+            ]
+        },
+    },
+    "Iron Hands": {
+        "ceree's 24 Worlds 1st Bug AV": {
+            "level": 50,
+            "evs": {
+                "hp": 76,
+                "at": 180,
+                "df": 12,
+                "sa": 0,
+                "sd": 236,
+                "sp": 0
+            },
+            "nature": "Brave",
+            "item": "Assault Vest",
+            "tera_type": "Bug",
+            "moves": [
+                "Drain Punch",
+                "Wild Charge",
+                "Fake Out",
+                "Low Kick"
+            ]
+        },
+        "Tera Water Assault Vest": {
+            "level": 50,
+            "evs": {
+                "hp": 76,
+                "at": 156,
+                "df": 12,
+                "sa": 0,
+                "sd": 252,
+                "sp": 12
+            },
+            "nature": "Adamant",
+            "item": "Assault Vest",
+            "tera_type": "Water",
+            "moves": [
+                "Drain Punch",
+                "Wild Charge",
+                "Fake Out",
+                "Heavy Slam"
+            ]
+        },
+        "Tera Fire Swords Dance": {
+            "level": 50,
+            "evs": {
+                "hp": 84,
+                "at": 124,
+                "df": 36,
+                "sa": 0,
+                "sd": 252,
+                "sp": 12
+            },
+            "nature": "Adamant",
+            "item": "Sitrus Berry",
+            "tera_type": "Fire",
+            "moves": [
+                "Drain Punch",
+                "Thunder Punch",
+                "Fake Out",
+                "Swords Dance"
+            ]
+        },
+    },
+    "Iron Jugulis": {
+        "Tera Water Rain Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 36,
+                "sa": 4,
+                "sd": 148,
+                "sp": 68
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "item": "Booster Energy",
+            "tera_type": "Water",
+            "moves": [
+                "Snarl",
+                "Hurricane",
+                "Tailwind",
+                "Protect"
+            ]
+        },
+        "Tera Poison Tailwind Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 84,
+                "sa": 36,
+                "sd": 44,
+                "sp": 92
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "item": "Booster Energy",
+            "tera_type": "Poison",
+            "moves": [
+                "Snarl",
+                "Air Slash",
+                "Tailwind",
+                "Protect"
+            ]
+        },
+        "Life Orb Tera Ground": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "item": "Life Orb",
+            "tera_type": "Ground",
+            "moves": [
+                "Dark Pulse",
+                "Hurricane",
+                "Earth Power",
+                "Tailwind"
+            ]
+        },
+    },
+    "Iron Moth": {
+        "Speed-Boosting Booster Energy": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 116,
+                "sa": 132,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "item": "Booster Energy",
+            "tera_type": "Grass",
+            "moves": [
+                "Heat Wave",
+                "Acid Spray",
+                "Energy Ball",
+                "Protect"
+            ]
+        },
+        "SpAtk-Boosting Booster Energy": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "item": "Booster Energy",
+            "tera_type": "Grass",
+            "moves": [
+                "Overheat",
+                "Sludge Wave",
+                "Energy Ball",
+                "Protect"
+            ]
+        },
+    },
+    "Iron Thorns": {
+        "Tera Flying Booster Energy": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "item": "Booster Energy",
+            "tera_type": "Flying",
+            "moves": [
+                "Rock Slide",
+                "Wild Charge",
+                "Tera Blast",
+                "Protect"
+            ]
+        },
+    },
+    "Baxcalibur": {
+        "Standard Clear Amulet": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 196,
+                "df": 4,
+                "sa": 0,
+                "sd": 4,
+                "sp": 60
+            },
+            "nature": "Adamant",
+            "ability": "Thermal Exchange",
+            "tera_type": "Poison",
+            "item": "Clear Amulet",
+            "moves": [
+                "Icicle Crash",
+                "Glaive Rush",
+                "Ice Shard",
+                "Protect"
+            ]
+        },
+        "Fast Scale Shot Loaded Dice": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Ice Body",
+            "tera_type": "Poison",
+            "item": "Loaded Dice",
+            "moves": [
+                "Icicle Spear",
+                "Scale Shot",
+                "Ice Shard",
+                "Swords Dance"
+            ]
+        },
+        "Tera Ground Assault Vest": {
+            "level": 50,
+            "evs": {
+                "hp": 228,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 28
+            },
+            "nature": "Adamant",
+            "ability": "Thermal Exchange",
+            "tera_type": "Ground",
+            "item": "Assault Vest",
+            "moves": [
+                "Glaive Rush",
+                "Ice Shard",
+                "Icicle Crash",
+                "Earthquake"
+            ]
+        },
+        "MeLuCa's San Diego 1st Icicle Spear": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 196,
+                "df": 4,
+                "sa": 0,
+                "sd": 4,
+                "sp": 52
+            },
+            "nature": "Adamant",
+            "ability": "Thermal Exchange",
+            "tera_type": "Water",
+            "item": "Loaded Dice",
+            "moves": [
+                "Glaive Rush",
+                "Ice Shard",
+                "Icicle Spear",
+                "Protect"
+            ]
+        },
+    },
+    "Gholdengo": {
+        "Nasty Plot Leftovers": {
+            "level": 50,
+            "evs": {
+                "hp": 132,
+                "at": 0,
+                "df": 4,
+                "sa": 116,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Good as Gold",
+            "tera_type": "Dragon",
+            "item": "Leftovers",
+            "moves": [
+                "Make It Rain",
+                "Shadow Ball",
+                "Thunderbolt",
+                "Nasty Plot"
+            ]
+        },
+        "Choice Specs Tera Steel": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Good as Gold",
+            "tera_type": "Steel",
+            "item": "Choice Specs",
+            "moves": [
+                "Make It Rain",
+                "Shadow Ball",
+                "Power Gem",
+                "Thunderbolt"
+            ]
+        },
+        "Choice Scarf Max Speed": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Good as Gold",
+            "tera_type": "Flying",
+            "item": "Choice Scarf",
+            "moves": [
+                "Make It Rain",
+                "Shadow Ball",
+                "Power Gem",
+                "Thunderbolt"
+            ]
+        },
+        "Toler Webb's Knoxville 1st Metal Coat": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 44,
+                "sa": 84,
+                "sd": 20,
+                "sp": 108
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Good as Gold",
+            "tera_type": "Fairy",
+            "item": "Metal Coat",
+            "moves": [
+                "Make It Rain",
+                "Shadow Ball",
+                "Nasty Plot",
+                "Protect"
+            ]
+        },
+    },
+    "Wo-Chien": {
+        "Shiliang Tang's 24 NAIC T8 Fast Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 44,
+                "sa": 4,
+                "sd": 20,
+                "sp": 188
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "tera_type": "Poison",
+            "item": "Leftovers",
+            "moves": [
+                "Pollen Puff",
+                "Ruination",
+                "Leech Seed",
+                "Protect"
+            ]
+        },
+        "Defensive Leftovers": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 140,
+                "sa": 0,
+                "sd": 116,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Calm",
+            "tera_type": "Poison",
+            "item": "Leftovers",
+            "moves": [
+                "Pollen Puff",
+                "Snarl",
+                "Foul Play",
+                "Giga Drain"
+            ]
+        },
+    },
+    "Chien-Pao": {
+        "Jolly Tera Ghost Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Ghost",
+            "item": "Focus Sash",
+            "moves": [
+                "Sucker Punch",
+                "Icicle Crash",
+                "Lash Out",
+                "Sacred Sword"
+            ]
+        },
+        "Adamant Tera Stellar Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "tera_type": "Stellar",
+            "item": "Focus Sash",
+            "moves": [
+                "Sucker Punch",
+                "Icicle Crash",
+                "Ice Spinner",
+                "Sacred Sword"
+            ]
+        },
+        "Mont's Worlds T4 AV Support": {
+            "level": 50,
+            "evs": {
+                "hp": 36,
+                "at": 100,
+                "df": 4,
+                "sa": 0,
+                "sd": 116,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Poison",
+            "item": "Assault Vest",
+            "moves": [
+                "Ice Spinner",
+                "Sucker Punch",
+                "Ruination",
+                "Icy Wind"
+            ]
+        },
+    },
+    "Ting-Lu": {
+        "Bulky Rocky Helmet": {
+            "level": 50,
+            "evs": {
+                "hp": 228,
+                "at": 4,
+                "df": 36,
+                "sa": 4,
+                "sd": 236,
+                "sp": 0
+            },
+            "nature": "Relaxed",
+            "tera_type": "Fairy",
+            "item": "Rocky Helmet",
+            "moves": [
+                "Ruination",
+                "Sand Tomb",
+                "Snarl",
+                "Stealth Rock"
+            ]
+        },
+        "Offensive Assault Vest": {
+            "level": 50,
+            "evs": {
+                "hp": 100,
+                "at": 156,
+                "df": 0,
+                "sa": 0,
+                "sd": 252,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "tera_type": "Poison",
+            "item": "Assault Vest",
+            "moves": [
+                "Stomping Tantrum",
+                "Payback",
+                "Heavy Slam",
+                "Earthquake"
+            ]
+        },
+        "Offensive Sitrus Berry": {
+            "level": 50,
+            "evs": {
+                "hp": 12,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 244,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "tera_type": "Water",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Stomping Tantrum",
+                "Throat Chop",
+                "Heavy Slam",
+                "Body Press"
+            ]
+        },
+    },
+    "Chi-Yu": {
+        "Tera Ground Choice Scarf": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Ground",
+            "item": "Choice Scarf",
+            "moves": [
+                "Heat Wave",
+                "Tera Blast",
+                "Dark Pulse",
+                "Overheat"
+            ]
+        },
+        "Tera Fire Covert Cloak": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Fire",
+            "item": "Covert Cloak",
+            "moves": [
+                "Heat Wave",
+                "Snarl",
+                "Dark Pulse",
+                "Overheat"
+            ]
+        },
+        "Bold Choice Specs": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 164,
+                "sa": 28,
+                "sd": 4,
+                "sp": 60
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "tera_type": "Fire",
+            "item": "Choice Specs",
+            "moves": [
+                "Heat Wave",
+                "Snarl",
+                "Dark Pulse",
+                "Overheat"
+            ]
+        },
+    },
+    "Roaring Moon": {
+        "Defensive Speed Booster Tailwind": {
+            "level": 50,
+            "evs": {
+                "hp": 164,
+                "at": 68,
+                "df": 108,
+                "sa": 0,
+                "sd": 4,
+                "sp": 164
+            },
+            "nature": "Jolly",
+            "tera_type": "Flying",
+            "item": "Booster Energy",
+            "moves": [
+                "Acrobatics",
+                "Knock Off",
+                "Tailwind",
+                "Breaking Swipe"
+            ]
+        },
+        "More Offensive Speed Booster": {
+            "level": 50,
+            "evs": {
+                "hp": 28,
+                "at": 220,
+                "df": 4,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Flying",
+            "item": "Booster Energy",
+            "moves": [
+                "Acrobatics",
+                "Knock Off",
+                "Tailwind",
+                "Breaking Swipe"
+            ]
+        },
+        "Attack Booster Dragon Dance": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 4,
+                "sp": 4
+            },
+            "nature": "Adamant",
+            "tera_type": "Flying",
+            "item": "Booster Energy",
+            "moves": [
+                "Acrobatics",
+                "Knock Off",
+                "Dragon Dance",
+                "Earthquake"
+            ]
+        },
+    },
+    "Iron Valiant": {
+        "Yuta's 24 Worlds 2nd Booster Support": {
+            "level": 50,
+            "evs": {
+                "hp": 204,
+                "at": 4,
+                "df": 100,
+                "sa": 0,
+                "sd": 28,
+                "sp": 172
+            },
+            "nature": "Jolly",
+            "tera_type": "Ghost",
+            "item": "Booster Energy",
+            "moves": [
+                "Spirit Break",
+                "Coaching",
+                "Encore",
+                "Wide Guard"
+            ]
+        },
+        "Offensive Mixed Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 100,
+                "df": 0,
+                "sa": 156,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Naive",
+            "item": "Focus Sash",
+            "moves": [
+                "Moonblast",
+                "Close Combat",
+                "Shadow Sneak",
+                "Protect"
+            ]
+        },
+    },
+
+    //"Raichu-Alola": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Dugtrio-Alola": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Persian-Alola": {
+        "Fur Coat Sitrus": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Timid",
+            "ability": "Fur Coat",
+            "tera_type": "Poison",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Foul Play",
+                "Fake Out",
+                "Icy Wind",
+                "Parting Shot"
+            ]
+        },
+    },
+    "Muk-Alola": {
+        "Moody Inheritor": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 124,
+                "sa": 0,
+                "sd": 132,
+                "sp": 0
+            },
+            "nature": "Careful",
+            "ability": "Power of Alchemy",
+            "tera_type": "Grass",
+            "item": "Leftovers",
+            "moves": [
+                "Knock Off",
+                "Gunk Shot",
+                "Minimize",
+                "Protect"
+            ]
+        },
+    },
+    "Slowbro-Galar": {
+        "Life Orb Regenerator": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 156,
+                "sd": 100,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 0,
+            },
+            "nature": "Quiet",
+            "ability": "Regenerator",
+            "tera_type": "Water",
+            "item": "Life Orb",
+            "moves": [
+                "Shell Side Arm",
+                "Psychic",
+                "Expanding Force",
+                "Trick Room"
+            ]
+        },
+    },
+    //"Slowking-Galar": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Arcanine-Hisui": {
+        "Tera Normal Choice Band": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Intimidate",
+            "tera_type": "Normal",
+            "item": "Choice Band",
+            "moves": [
+                "Flare Blitz",
+                "Head Smash",
+                "Extreme Speed",
+                "Rock Slide"
+            ]
+        },
+        "Assault Vest Tera Fairy": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "ability": "Intimidate",
+            "tera_type": "Fairy",
+            "item": "Assault Vest",
+            "moves": [
+                "Flare Blitz",
+                "Tera Blast",
+                "Extreme Speed",
+                "Rock Slide"
+            ]
+        },
+    },
+    "Electrode-Hisui": {
+        "Choice Specs Tera Grass": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Soundproof",
+            "tera_type": "Grass",
+            "item": "Choice Specs",
+            "moves": [
+                "Chloroblast",
+                "Thunderbolt",
+                "Giga Drain",
+                "Volt Switch"
+            ]
+        },
+    },
+    //"Qwilfish-Hisui": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Lilligant-Hisui": {
+        "Chlorophyll Sun": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Ghost",
+            "item": "Focus Sash",
+            "moves": [
+                "Solar Blade",
+                "Close Combat",
+                "Ice Spinner",
+                "Leaf Blade"
+            ]
+        },
+    },
+    //"Basculin-White-Striped": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Zoroark-Hisui": {
+        "Tera Fighting Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Fighting",
+            "item": "Focus Sash",
+            "moves": [
+                "Tera Blast",
+                "Shadow Ball",
+                "Nasty Plot",
+                "Protect"
+            ]
+        },
+        "Tera Normal Specs": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "item": "Choice Specs",
+            "moves": [
+                "Hyper Voice",
+                "Shadow Ball",
+                "Flamethrower",
+                "Hyper Beam"
+            ]
+        },
+    },
+    "Braviary-Hisui": {
+        "Tinted Lens Psyspam": {
+            "level": 50,
+            "evs": {
+                "hp": 12,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 4,
+                "sp": 236
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Tinted Lens",
+            "tera_type": "Psychic",
+            "item": "Life Orb",
+            "moves": [
+                "Expanding Force",
+                "Hurricane",
+                "Esper Wing",
+                "Dazzling Gleam"
+            ]
+        },
+    },
+    "Goodra-Hisui": {
+        "Physical Body Press": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 4,
+                "df": 252,
+                "sa": 0,
+                "sd": 0,
+                "sp": 0
+            },
+            "nature": "Careful",
+            "ability": "Sap Sipper",
+            "tera_type": "Water",
+            "item": "Leftovers",
+            "moves": [
+                "Body Press",
+                "Heavy Slam",
+                "Dragon Tail",
+                "Acid Armor"
+            ]
+        },
+    },
+    //"Avalugg-Hisui": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Tauros": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Quagsire": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Perrserker": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Wyrdeer": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Kleavor": {
+        "Scarf Max Speed": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Sharpness",
+            "tera_type": "Grass",
+            "item": "Choice Scarf",
+            "moves": [
+                "Stone Axe",
+                "U-turn",
+                "X-Scissor",
+                "Close Combat"
+            ]
+        },
+    },
+    "Ursaluna": {
+        "Trick Room Guts": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 0,
+            },
+            "nature": "Brave",
+            "tera_type": "Ghost",
+            "item": "Flame Orb",
+            "moves": [
+                "Facade",
+                "Headlong Rush",
+                "Earthquake",
+                "Ice Punch"
+            ]
+        },
+    },
+    "Basculegion": {
+        "Banded Swift Swim": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Swift Swim",
+            "item": "Choice Band",
+            "moves": [
+                "Wave Crash",
+                "Last Respects",
+                "Flip Turn",
+                "Aqua Jet"
+            ]
+        },
+        "Tera Ghost Sash Adaptability": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Adaptability",
+            "tera_type": "Ghost",
+            "item": "Focus Sash",
+            "moves": [
+                "Liquidation",
+                "Last Respects",
+                "Protect",
+                "Aqua Jet"
+            ]
+        },
+        "Scarf Adaptability": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Adaptability",
+            "item": "Choice Scarf",
+            "moves": [
+                "Wave Crash",
+                "Last Respects",
+                "Flip Turn",
+                "Aqua Jet"
+            ]
+        },
+    },
+    "Basculegion-F": {
+        "Swift Swim Choice Specs": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Water",
+            "ability": "Swift Swim",
+            "item": "Choice Specs",
+            "moves": [
+                "Muddy Water",
+                "Shadow Ball",
+                "Ice Beam",
+                "Hydro Pump"
+            ]
+        },
+    },
+    "Sneasler": {
+        "Swords Dance Grassy Seed Acrobatics": {
+            "level": 50,
+            "evs": {
+                "hp": 172,
+                "at": 92,
+                "df": 108,
+                "sa": 0,
+                "sd": 4,
+                "sp": 132
+            },
+            "nature": "Adamant",
+            "tera_type": "Flying",
+            "item": "Grassy Seed",
+            "moves": [
+                "Acrobatics",
+                "Close Combat",
+                "Swords Dance",
+                "Protect"
+            ]
+        },
+        "Tera Dark Unburden Dark Move": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "tera_type": "Dark",
+            "item": "Psychic Seed",
+            "moves": [
+                "Dire Claw",
+                "Close Combat",
+                "Throat Chop",
+                "Lash Out"
+            ]
+        },
+        "Tera Stellar Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Stellar",
+            "ability": "Poison Touch",
+            "item": "Focus Sash",
+            "moves": [
+                "Dire Claw",
+                "Close Combat",
+                "Throat Chop",
+                "Fake Out"
+            ]
+        },
+    },
+    "Overqwil": {
+        "HobbitVGC's 24 NAIC T8 Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "tera_type": "Poison",
+            "item": "Life Orb",
+            "moves": [
+                "Gunk Shot",
+                "Crunch",
+                "Acid Spray",
+                "Protect"
+            ]
+        },
+    },
+    "Carbink": {
+        "Trick Room Body Press": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 252,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 0,
+            },
+            "nature": "Relaxed",
+            "tera_type": "Grass",
+            "item": "Leftovers",
+            "moves": [
+                "Body Press",
+                "Moonblast",
+                "Iron Defense",
+                "Trick Room"
+            ]
+        },
+    },
+    "Charizard": {
+        "Choice Specs Sun": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Solar Power",
+            "tera_type": "Ghost",
+            "item": "Choice Specs",
+            "moves": [
+                "Heat Wave",
+                "Overheat",
+                "Air Slash",
+                "Weather Ball"
+            ]
+        },
+    },
+    "Typhlosion": {
+        "Scarf Eruption": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Flash Fire",
+            "tera_type": "Ground",
+            "item": "Choice Scarf",
+            "moves": [
+                "Heat Wave",
+                "Eruption",
+                "Overheat",
+                "Tera Blast"
+            ]
+        },
+    },
+    //"Samurott": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Chesnaught": {
+        "Belly Drum paired with Rillaboom": {
+            "level": 50,
+            "evs": {
+                "hp": 116,
+                "at": 100,
+                "df": 36,
+                "sa": 0,
+                "sd": 196,
+                "sp": 60
+            },
+            "nature": "Adamant",
+            "tera_type": "Fire",
+            "ability": "Bulletproof",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Grassy Glide",
+                "Drain Punch",
+                "Belly Drum",
+                "Spiky Shield"
+            ]
+        },
+        "Budget(?) Ferrothorn": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 4,
+                "sa": 0,
+                "sd": 252,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Calm",
+            "ability": "Bulletproof",
+            "tera_type": "Steel",
+            "item": "Leftovers",
+            "moves": [
+                "Body Press",
+                "Leech Seed",
+                "Spiky Shield",
+                "Iron Defense"
+            ]
+        },
+    },
+    "Delphox": {
+        "Life Orb Psyspam": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "hp": 29,
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Blaze",
+            "tera_type": "Water",
+            "item": "Life Orb",
+            "moves": [
+                "Heat Wave",
+                "Expanding Force",
+                "Tera Blast",
+                "Protect"
+            ]
+        },
+    },
+    "Greninja": {
+        "Loaded Dice Arch Enabler": {
+            "level": 50,
+            "evs": {
+                "hp": 212,
+                "at": 0,
+                "df": 4,
+                "sa": 4,
+                "sd": 36,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Torrent",
+            "item": "Loaded Dice",
+            "moves": [
+                "Water Shuriken",
+                "Dark Pulse",
+                "Icy Wind",
+                "Haze"
+            ]
+        },
+        "Choice Specs Protean": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Protean",
+            "item": "Choice Specs",
+            "moves": [
+                "Water Shuriken",
+                "Grass Knot",
+                "Dark Pulse",
+                "Ice Beam"
+            ]
+        },
+    },
+    //"Decidueye": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Rillaboom": {
+        "Standard Assault Vest": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 116,
+                "df": 4,
+                "sa": 0,
+                "sd": 124,
+                "sp": 12
+            },
+            "nature": "Adamant",
+            "tera_type": "Fire",
+            "item": "Assault Vest",
+            "moves": [
+                "Fake Out",
+                "Wood Hammer",
+                "High Horsepower",
+                "Grassy Glide"
+            ]
+        },
+        "Max Speed Drum Beating AV": {
+            "level": 50,
+            "evs": {
+                "hp": 140,
+                "at": 84,
+                "df": 4,
+                "sa": 0,
+                "sd": 28,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Fire",
+            "item": "Assault Vest",
+            "moves": [
+                "Fake Out",
+                "Drum Beating",
+                "U-turn",
+                "Grassy Glide"
+            ]
+        },
+        "Miracle Seed Tera Grass": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 0,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "item": "Miracle Seed",
+            "moves": [
+                "Fake Out",
+                "Wood Hammer",
+                "U-turn",
+                "Grassy Glide"
+            ]
+        },
+    },
+    //"Cinderace": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Inteleon": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Typhlosion-Hisui": {
+        "Choice Specs Modest": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Blaze",
+            "item": "Choice Specs",
+            "moves": [
+                "Heat Wave",
+                "Eruption",
+                "Overheat",
+                "Shadow Ball"
+            ]
+        },
+        "Scarf Eruption Timid": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Blaze",
+            "item": "Choice Scarf",
+            "moves": [
+                "Heat Wave",
+                "Eruption",
+                "Flamethrower",
+                "Shadow Ball"
+            ]
+        },
+    },
+    "Samurott-Hisui": {
+        "Tera Ghost AV": {
+            "level": 50,
+            "evs": {
+                "hp": 236,
+                "at": 172,
+                "df": 12,
+                "sa": 0,
+                "sd": 4,
+                "sp": 84
+            },
+            "nature": "Adamant",
+            "ability": "Sharpness",
+            "item": "Assault Vest",
+            "moves": [
+                "Knock Off",
+                "Aqua Cutter",
+                "Sacred Sword",
+                "Sucker Punch"
+            ]
+        },
+        "Bulky Sitrus Attacker": {
+            "level": 50,
+            "evs": {
+                "hp": 196,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 60
+            },
+            "nature": "Adamant",
+            "ability": "Sharpness",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Ceaseless Edge",
+                "Razor Shell",
+                "Sacred Sword",
+                "Aqua Jet"
+            ]
+        },
+    },
+    "Decidueye-Hisui": {
+        "Offensive Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "tera_type": "Poison",
+            "item": "Focus Sash",
+            "moves": [
+                "Leaf Blade",
+                "Triple Arrows",
+                "Sucker Punch",
+                "Knock Off"
+            ]
+        },
+    },
+    "Articuno": {
+        "Patrick Donegan's 23 Worlds Day 2 Snowbelle": {
+            "level": 50,
+            "evs": {
+                "hp": 212,
+                "at": 0,
+                "df": 68,
+                "sa": 124,
+                "sd": 4,
+                "sp": 100
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Snow Cloak",
+            "tera_type": "Poison",
+            "item": "Bright Powder",
+            "moves": [
+                "Freeze-Dry",
+                "Blizzard",
+                "Sheer Cold",
+                "Roost"
+            ]
+        },
+        "Nikhil Reddy's Utrecht 1st Mono Ice Specs": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 44,
+                "sa": 196,
+                "sd": 4,
+                "sp": 12
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Snow Cloak",
+            "item": "Choice Specs",
+            "moves": [
+                "Freeze-Dry",
+                "Blizzard",
+                "Sheer Cold",
+                "Ice Beam"
+            ]
+        },
+    },
+    "Articuno-Galar": {
+        "Jamie Boyt's Gda\u0144sk T16 Tera Ground": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 140,
+                "sa": 44,
+                "sd": 12,
+                "sp": 60
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Competitive",
+            "tera_type": "Ground",
+            "item": "Rocky Helmet",
+            "moves": [
+                "Freezing Glare",
+                "Tera Blast",
+                "Calm Mind",
+                "Recover"
+            ]
+        },
+    },
+    "Zapdos": {
+        "Bold Rocky Helmet": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 236,
+                "sa": 0,
+                "sd": 20,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "ability": "Static",
+            "tera_type": "Fairy",
+            "item": "Rocky Helmet",
+            "moves": [
+                "Thunderbolt",
+                "Hurricane",
+                "Heat Wave",
+                "Volt Switch"
+            ]
+        },
+        "Sitrus Berry Attacker": {
+            "level": 50,
+            "evs": {
+                "hp": 60,
+                "at": 0,
+                "df": 0,
+                "sa": 196,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Static",
+            "tera_type": "Steel",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Thunderbolt",
+                "Hurricane",
+                "Heat Wave",
+                "Tailwind"
+            ]
+        },
+    },
+    "Zapdos-Galar": {
+        "Choice Scarf Tera Flying": {
+            "level": 50,
+            "evs": {
+                "hp": 60,
+                "at": 196,
+                "df": 4,
+                "sa": 0,
+                "sd": 12,
+                "sp": 236
+            },
+            "nature": "Adamant",
+            "tera_type": "Flying",
+            "item": "Choice Scarf",
+            "moves": [
+                "Brave Bird",
+                "Thunderous Kick",
+                "Close Combat",
+                "U-turn"
+            ]
+        },
+    },
+    //"Moltres": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Moltres-Galar": {
+        "Black Glasses Tailwind": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 76,
+                "sa": 12,
+                "sd": 100,
+                "sp": 76
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Calm",
+            "tera_type": "Dark",
+            "item": "Black Glasses",
+            "moves": [
+                "Fiery Wrath",
+                "Foul Play",
+                "Snarl",
+                "Tailwind"
+            ]
+        },
+        "Nasty Plot Sitrus": {
+            "level": 50,
+            "evs": {
+                "hp": 212,
+                "at": 0,
+                "df": 0,
+                "sa": 156,
+                "sd": 0,
+                "sp": 140
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Poison",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Fiery Wrath",
+                "Air Slash",
+                "Hurricane",
+                "Nasty Plot"
+            ]
+        },
+    },
+    //"Uxie": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Mesprit": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Azelf": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Heatran": {
+        "Tera Bug Mixed Zoom Lens": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 4,
+                "df": 108,
+                "sa": 4,
+                "sd": 148,
+                "sp": 0
+            },
+            "nature": "Relaxed",
+            "tera_type": "Bug",
+            "item": "Zoom Lens",
+            "moves": [
+                "Magma Storm",
+                "Heavy Slam",
+                "Will-O-Wisp",
+                "Protect"
+            ]
+        },
+        "Offensive Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 4
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Fairy",
+            "item": "Life Orb",
+            "moves": [
+                "Heat Wave",
+                "Flash Cannon",
+                "Earth Power",
+                "Flamethrower"
+            ]
+        },
+        "Kenji Miura's 23 Worlds T16 Magma Storm": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 20,
+                "sa": 76,
+                "sd": 148,
+                "sp": 20
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Grass",
+            "item": "Leftovers",
+            "moves": [
+                "Magma Storm",
+                "Earth Power",
+                "Tera Blast",
+                "Protect"
+            ]
+        },
+    },
+    "Cresselia": {
+        "Trick Room Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 180,
+                "sa": 0,
+                "sd": 76,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Calm",
+            "tera_type": "Fairy",
+            "item": "Mental Herb",
+            "moves": [
+                "Psychic",
+                "Ice Beam",
+                "Moonblast",
+                "Trick Room"
+            ]
+        },
+    },
+    "Tornadus": {
+        "Offensive Tailwind": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Prankster",
+            "tera_type": "Ghost",
+            "item": "Mental Herb",
+            "moves": [
+                "Bleakwind Storm",
+                "Icy Wind",
+                "Hurricane",
+                "Tailwind"
+            ]
+        },
+        "Mattie Morgan's 23 Worlds T8 Bulky Aguav": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 220,
+                "sa": 4,
+                "sd": 4,
+                "sp": 28
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Prankster",
+            "tera_type": "Steel",
+            "item": "Aguav Berry",
+            "moves": [
+                "Bleakwind Storm",
+                "Taunt",
+                "Rain Dance",
+                "Tailwind"
+            ]
+        },
+        "Thiago Lattanzi's 24 LAIC 2nd Max Defense": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 252,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 28,
+            },
+            "nature": "Bold",
+            "ability": "Prankster",
+            "tera_type": "Dark",
+            "item": "Safety Goggles",
+            "moves": [
+                "Bleakwind Storm",
+                "Protect",
+                "Rain Dance",
+                "Tailwind"
+            ]
+        },
+    },
+    //"Tornadus-Therian": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "tera_type": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Thundurus": {
+        "Bulky Prankster Disruption": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 252,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "ability": "Prankster",
+            "tera_type": "Water",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Thunderbolt",
+                "Wildbolt Storm",
+                "Eerie Impulse",
+                "Thunder Wave"
+            ]
+        },
+    },
+    "Thundurus-Therian": {
+        "Offensive Rain Beneficiary": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Flying",
+            "item": "Life Orb",
+            "moves": [
+                "Wildbolt Storm",
+                "Thunder",
+                "Volt Switch",
+                "Tera Blast"
+            ]
+        },
+    },
+    "Landorus": {
+        "The Tangs' San Antonio 1st/2nd Bulky Water": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 4,
+                "sa": 124,
+                "sd": 4,
+                "sp": 132
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Sheer Force",
+            "tera_type": "Water",
+            "item": "Life Orb",
+            "moves": [
+                "Sandsear Storm",
+                "Earth Power",
+                "Sludge Bomb",
+                "Psychic"
+            ]
+        },
+        "Timid Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Sheer Force",
+            "tera_type": "Poison",
+            "item": "Life Orb",
+            "moves": [
+                "Sandsear Storm",
+                "Earth Power",
+                "Sludge Bomb",
+                "Psychic"
+            ]
+        },
+        "Modest Choice Scarf": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Modest",
+            "ability": "Sheer Force",
+            "tera_type": "Poison",
+            "item": "Choice Scarf",
+            "moves": [
+                "Sandsear Storm",
+                "Earth Power",
+                "Sludge Bomb",
+                "U-turn"
+            ]
+        },
+    },
+    "Landorus-Therian": {
+        "Tera Flying Choice Scarf": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "tera_type": "Flying",
+            "item": "Choice Scarf",
+            "moves": [
+                "Stomping Tantrum",
+                "Tera Blast",
+                "U-turn",
+                "Rock Slide"
+            ]
+        },
+        "Tera Water Assault Vest": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 196,
+                "df": 4,
+                "sa": 0,
+                "sd": 60,
+                "sp": 4
+            },
+            "nature": "Adamant",
+            "tera_type": "Water",
+            "item": "Assault Vest",
+            "moves": [
+                "Earthquake",
+                "Stomping Tantrum",
+                "U-turn",
+                "Rock Slide"
+            ]
+        },
+    },
+    "Enamorus": {
+        "Tera Stellar Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Stellar",
+            "item": "Life Orb",
+            "moves": [
+                "Tera Blast",
+                "Moonblast",
+                "Earth Power",
+                "Sludge Bomb"
+            ]
+        },
+    },
+    "Enamorus-Therian": {
+        "Tera Fairy Choice Specs": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "item": "Choice Specs",
+            "moves": [
+                "Dazzling Gleam",
+                "Moonblast",
+                "Earth Power",
+                "Mystical Fire"
+            ]
+        },
+        "Tera Flying Offense": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Flying",
+            "item": "Pixie Plate",
+            "moves": [
+                "Springtide Storm",
+                "Moonblast",
+                "Earth Power",
+                "Tera Blast"
+            ]
+        },
+    },
+    "Urshifu-Single Strike": {
+        "Offensive Focus Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 236,
+                "df": 0,
+                "sa": 0,
+                "sd": 20,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "tera_type": "Poison",
+            "item": "Focus Sash",
+            "moves": [
+                "Wicked Blow",
+                "Close Combat",
+                "Sucker Punch",
+                "Poison Jab"
+            ]
+        },
+        "Jolly Choice Band": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Dark",
+            "item": "Choice Band",
+            "moves": [
+                "Wicked Blow",
+                "Close Combat",
+                "Sucker Punch",
+                "Poison Jab"
+            ]
+        },
+    },
+    "Urshifu-Rapid Strike": {
+        "Tera Stellar Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "tera_type": "Stellar",
+            "item": "Focus Sash",
+            "moves": [
+                "Surging Strikes",
+                "Close Combat",
+                "Aqua Jet",
+                "U-turn"
+            ]
+        },
+        "Standard Scarf": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "tera_type": "Water",
+            "item": "Choice Scarf",
+            "moves": [
+                "Surging Strikes",
+                "Close Combat",
+                "Aqua Jet",
+                "U-turn"
+            ]
+        },
+        "Basic Mystic Water": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Water",
+            "item": "Mystic Water",
+            "moves": [
+                "Surging Strikes",
+                "Close Combat",
+                "Aqua Jet",
+                "Rock Slide"
+            ]
+        },
+    },
+    "Regieleki": {
+        "Tera Ice Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Ice",
+            "item": "Focus Sash",
+            "moves": [
+                "Thunderbolt",
+                "Electroweb",
+                "Volt Switch",
+                "Tera Blast"
+            ]
+        },
+        "Tera Normal Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "tera_type": "Normal",
+            "item": "Life Orb",
+            "moves": [
+                "Wild Charge",
+                "Explosion",
+                "Electroweb",
+                "Extreme Speed"
+            ]
+        },
+    },
+    "Regidrago": {
+        "Tera Ghost Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Ghost",
+            "item": "Life Orb",
+            "moves": [
+                "Dragon Energy",
+                "Draco Meteor",
+                "Tera Blast",
+                "Earth Power"
+            ]
+        },
+        "Tera Steel Dragon Fang": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 100,
+                "sa": 252,
+                "sd": 12,
+                "sp": 140
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Steel",
+            "item": "Dragon Fang",
+            "moves": [
+                "Dragon Energy",
+                "Draco Meteor",
+                "Dragon Pulse",
+                "Earth Power"
+            ]
+        },
+        "Tera Dragon Choice Scarf": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "item": "Choice Scarf",
+            "moves": [
+                "Dragon Energy",
+                "Draco Meteor",
+                "Dragon Pulse",
+                "Earth Power"
+            ]
+        },
+    },
+    "Glastrier": {
+        "Assault Vest Tera Poison": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 0,
+            },
+            "nature": "Brave",
+            "tera_type": "Poison",
+            "item": "Assault Vest",
+            "moves": [
+                "Icicle Crash",
+                "Heavy Slam",
+                "Close Combat",
+                "Stomping Tantrum"
+            ]
+        },
+    },
+    "Spectrier": {
+        "Offensive Throat Spray": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 12,
+                "sa": 4,
+                "sd": 60,
+                "sp": 188
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Fairy",
+            "item": "Throat Spray",
+            "moves": [
+                "Shadow Ball",
+                "Draining Kiss",
+                "Snarl",
+                "Will-O-Wisp"
+            ]
+        },
+    },
+
+    //Teal Mask DLC
+
+    //"Ariados": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Yanmega": {
+        "Sash Tailwind Offense": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Ghost",
+            "ability": "Speed Boost",
+            "item": "Focus Sash",
+            "moves": [
+                "Bug Buzz",
+                "Air Slash",
+                "Tailwind",
+                "Hypnosis"
+            ]
+        },
+    },
+    //"Mightyena": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Volbeat": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Illumise": {
+        "Tailwind Full Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 188,
+                "sa": 0,
+                "sd": 68,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "ability": "Prankster",
+            "tera_type": "Ghost",
+            "item": "Mental Herb",
+            "moves": [
+                "Infestation",
+                "Tailwind",
+                "Encore",
+                "Fake Tears"
+            ]
+        },
+    },
+    //"Crawdaunt": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Leavanny": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Ribombee": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Arbok": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Victreebel": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Furret": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Dipplin": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Ninetales": {
+        "Eject Pack Support": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Drought",
+            "tera_type": "Grass",
+            "item": "Eject Pack",
+            "moves": [
+                "Overheat",
+                "Scorching Sands",
+                "Roar",
+                "Will-O-Wisp"
+            ]
+        },
+    },
+    //"Poliwrath": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Politoed": {
+        "Bulky Rain Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Drizzle",
+            "tera_type": "Grass",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Muddy Water",
+                "Icy Wind",
+                "Weather Ball",
+                "Helping Hand"
+            ]
+        },
+    },
+    //"Noctowl": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Ambipom": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Mamoswine": {
+        "Offensive Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Oblivious",
+            "tera_type": "Ground",
+            "item": "Focus Sash",
+            "moves": [
+                "Icicle Crash",
+                "High Horsepower",
+                "Ice Shard",
+                "Rock Slide"
+            ]
+        },
+    },
+    "Shiftry": {
+        "Offensive Wind Rider": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "ability": "Wind Rider",
+            "tera_type": "Dark",
+            "item": "Focus Sash",
+            "moves": [
+                "Leaf Blade",
+                "Knock Off",
+                "Sucker Punch",
+                "Fake Out"
+            ]
+        },
+    },
+    //"Trevenant": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Sinistcha": {
+        "Trick Room Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 84,
+                "sa": 4,
+                "sd": 156,
+                "sp": 12
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Calm",
+            "tera_type": "Water",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Matcha Gotcha",
+                "Rage Powder",
+                "Strength Sap",
+                "Trick Room"
+            ]
+        },
+    },
+    //"Golem": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Conkeldurr": {
+        "Min Speed AV": {
+            "level": 50,
+            "evs": {
+                "hp": 116,
+                "at": 164,
+                "df": 0,
+                "sa": 0,
+                "sd": 228,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 0,
+            },
+            "nature": "Brave",
+            "item": "Assault Vest",
+            "moves": [
+                "Drain Punch",
+                "Mach Punch",
+                "Ice Punch",
+                "Knock Off"
+            ]
+        },
+    },
+    //"Morpeko": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Snorlax": {
+        "Leftovers Thick Fat": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 252,
+                "sa": 0,
+                "sd": 0,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "ability": "Thick Fat",
+            "tera_type": "Ghost",
+            "item": "Leftovers",
+            "moves": [
+                "Heavy Slam",
+                "Heat Crash",
+                "High Horsepower",
+                "Double-Edge"
+            ]
+        },
+    },
+    "Ludicolo": {
+        "Stellar Swift Swim": {
+            "level": 50,
+            "evs": {
+                "hp": 12,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 244
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Stellar",
+            "item": "Life Orb",
+            "moves": [
+                "Energy Ball",
+                "Weather Ball",
+                "Muddy Water",
+                "Ice Beam"
+            ]
+        },
+    },
+    //"Probopass": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Vikavolt": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Sandslash": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Gliscor": {
+        "Tera Water Poison Heal": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "tera_type": "Water",
+            "item": "Toxic Orb",
+            "moves": [
+                "High Horsepower",
+                "Dual Wingbeat",
+                "Facade",
+                "Earthquake"
+            ]
+        },
+    },
+    //"Mandibuzz": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Kommo-o": {
+        "Throat Spray Clangorous Soul": {
+            "level": 50,
+            "evs": {
+                "hp": 28,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 4,
+                "sp": 220
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "ability": "Bulletproof",
+            "tera_type": "Fire",
+            "item": "Throat Spray",
+            "moves": [
+                "Clanging Scales",
+                "Flamethrower",
+                "Aura Sphere",
+                "Clangorous Soul"
+            ]
+        },
+        "EternalSnowman's Sacramento 1st Body Press": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 4,
+                "df": 156,
+                "sa": 0,
+                "sd": 92,
+                "sp": 4
+            },
+            "nature": "Impish",
+            "ability": "Bulletproof",
+            "tera_type": "Steel",
+            "item": "Leftovers",
+            "moves": [
+                "Body Press",
+                "Iron Head",
+                "Iron Defense",
+                "Protect"
+            ]
+        },
+    },
+    "Weezing": {
+        "General Disruption": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 4,
+                "sa": 0,
+                "sd": 252,
+                "sp": 0
+            },
+            "nature": "Impish",
+            "ability": "Neutralizing Gas",
+            "tera_type": "Grass",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Gunk Shot",
+                "Pain Split",
+                "Will-O-Wisp",
+                "Taunt"
+            ]
+        },
+    },
+    "Mienshao": {
+        "Tera Steel Offensive Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "ability": "Inner Focus",
+            "tera_type": "Steel",
+            "item": "Focus Sash",
+            "moves": [
+                "Fake Out",
+                "Close Combat",
+                "Triple Axel",
+                "Stone Edge"
+            ]
+        },
+    },
+    "Dusclops": {
+        "Trick Room Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 4,
+                "sa": 0,
+                "sd": 252,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 0,
+            },
+            "nature": "Sassy",
+            "ability": "Pressure",
+            "tera_type": "Dark",
+            "item": "Eviolite",
+            "moves": [
+                "Night Shade",
+                "Pain Split",
+                "Will-O-Wisp",
+                "Trick Room"
+            ]
+        },
+    },
+    //"Dusknoir": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Chimecho": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Magcargo": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Chandelure": {
+        "Tera Grass Bulky Sitrus": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 172,
+                "sa": 4,
+                "sd": 84,
+                "sp": 4
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Flash Fire",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Heat Wave",
+                "Shadow Ball",
+                "Will-O-Wisp",
+                "Trick Room"
+            ]
+        },
+    },
+    "Clefairy": {
+        "Common Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 252,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "ability": "Friend Guard",
+            "tera_type": "Grass",
+            "item": "Eviolite",
+            "moves": [
+                "Icy Wind",
+                "Moonblast",
+                "Follow Me",
+                "Helping Hand"
+            ]
+        },
+    },
+    "Clefable": {
+        "Clefairy but a Dozo Check": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 252,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Calm",
+            "ability": "Unaware",
+            "tera_type": "Steel",
+            "item": "Rocky Helmet",
+            "moves": [
+                "Moonblast",
+                "Follow Me",
+                "Icy Wind",
+                "Protect"
+            ]
+        },
+    },
+    "Milotic": {
+        "Bulky Icy Wind Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 252,
+                "sa": 4,
+                "sd": 0,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "ability": "Competitive",
+            "tera_type": "Grass",
+            "item": "Leftovers",
+            "moves": [
+                "Scald",
+                "Icy Wind",
+                "Ice Beam",
+                "Hydro Pump"
+            ]
+        },
+    },
+    //"Swanna": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Cramorant": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Okidogi": {
+        "Assault Vest Tera Dragon": {
+            "level": 50,
+            "evs": {
+                "hp": 196,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 4,
+                "sp": 52
+            },
+            "nature": "Adamant",
+            "ability": "Guard Dog",
+            "tera_type": "Dragon",
+            "item": "Assault Vest",
+            "moves": [
+                "Gunk Shot",
+                "Drain Punch",
+                "High Horsepower",
+                "Upper Hand"
+            ]
+        },
+        "Bulk Up Leftovers": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "ability": "Guard Dog",
+            "tera_type": "Dark",
+            "item": "Leftovers",
+            "moves": [
+                "Poison Jab",
+                "Drain Punch",
+                "Knock Off",
+                "Bulk Up"
+            ]
+        },
+    },
+    "Munkidori": {
+        "Offensive Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Timid",
+            "item": "Focus Sash",
+            "moves": [
+                "Psychic",
+                "Sludge Bomb",
+                "Sludge Wave",
+                "Fake Out"
+            ]
+        },
+    },
+    "Fezandipiti": {
+        "Special Support": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Water",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Icy Wind",
+                "Acid Spray",
+                "Dazzling Gleam",
+                "Tailwind"
+            ]
+        },
+    },
+    "Ogerpon": {
+        "Shiliang Tang's 24 Worlds T16 Bullet Support": {
+            "level": 50,
+            "evs": {
+                "hp": 76,
+                "at": 156,
+                "df": 44,
+                "sa": 0,
+                "sd": 20,
+                "sp": 212
+            },
+            "nature": "Adamant",
+            "item": "Loaded Dice",
+            "moves": [
+                "Bullet Seed",
+                "Follow Me",
+                "Encore",
+                "Spiky Shield"
+            ]
+        },
+        "Max Speed Sash": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "item": "Focus Sash",
+            "moves": [
+                "Ivy Cudgel",
+                "Stomping Tantrum",
+                "Knock Off",
+                "Superpower"
+            ]
+        },
+    },
+    "Ogerpon-Wellspring": {
+        "Fast Support": {
+            "level": 50,
+            "evs": {
+                "hp": 164,
+                "at": 132,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 212
+            },
+            "nature": "Jolly",
+            "moves": [
+                "Ivy Cudgel",
+                "Horn Leech",
+                "Follow Me",
+                "Spiky Shield"
+            ]
+        },
+        "Bulkier Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 76,
+                "df": 148,
+                "sa": 0,
+                "sd": 28,
+                "sp": 4
+            },
+            "nature": "Adamant",
+            "moves": [
+                "Ivy Cudgel",
+                "Horn Leech",
+                "Wood Hammer",
+                "Spiky Shield"
+            ]
+        },
+    },
+    "Ogerpon-Hearthflame": {
+        "ceree's 24 Worlds 1st Balanced Spread": {
+            "level": 50,
+            "evs": {
+                "hp": 188,
+                "at": 76,
+                "df": 52,
+                "sa": 0,
+                "sd": 4,
+                "sp": 188
+            },
+            "nature": "Adamant",
+            "moves": [
+                "Ivy Cudgel",
+                "Wood Hammer",
+                "Follow Me",
+                "Spiky Shield"
+            ]
+        },
+        "The Tangs' San Antonio 1st/2nd Max Defense": {
+            "level": 50,
+            "evs": {
+                "hp": 220,
+                "at": 12,
+                "df": 252,
+                "sa": 0,
+                "sd": 4,
+                "sp": 20
+            },
+            "nature": "Impish",
+            "moves": [
+                "Ivy Cudgel",
+                "Horn Leech",
+                "Follow Me",
+                "Spiky Shield"
+            ]
+        },
+        "All-Out Offense": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "moves": [
+                "Ivy Cudgel",
+                "Horn Leech",
+                "Wood Hammer",
+                "Stomping Tantrum"
+            ]
+        },
+    },
+    "Ogerpon-Cornerstone": {
+        "No Bulk Support": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "moves": [
+                "Ivy Cudgel",
+                "Horn Leech",
+                "Power Whip",
+                "Follow Me"
+            ]
+        },
+    },
+    "Ninetales-Alola": {
+        "Bulky Light Clay": {
+            "level": 50,
+            "evs": {
+                "hp": 220,
+                "at": 0,
+                "df": 20,
+                "sa": 4,
+                "sd": 60,
+                "sp": 204
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Water",
+            "item": "Light Clay",
+            "moves": [
+                "Aurora Veil",
+                "Blizzard",
+                "Moonblast",
+                "Freeze-Dry"
+            ]
+        },
+        "Agati's Joinville 1st Specs": {
+            "level": 50,
+            "evs": {
+                "hp": 100,
+                "at": 0,
+                "df": 132,
+                "sa": 164,
+                "sd": 4,
+                "sp": 108
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Ice",
+            "item": "Choice Specs",
+            "moves": [
+                "Blizzard",
+                "Moonblast",
+                "Ice Beam",
+                "Freeze-Dry"
+            ]
+        },
+    },
+    //"Golem-Alola": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Sandslash-Alola": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Weezing-Galar": {
+        "45mice's 24 Worlds T16 Poison Spread": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 4,
+                "sa": 4,
+                "sd": 236,
+                "sp": 12
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "ability": "Neutralizing Gas",
+            "tera_type": "Grass",
+            "item": "Mental Herb",
+            "moves": [
+                "Dazzling Gleam",
+                "Poison Gas",
+                "Toxic Spikes",
+                "Protect"
+            ]
+        },
+        "Tera Fire Specs": {
+            "level": 50,
+            "evs": {
+                "hp": 116,
+                "at": 0,
+                "df": 4,
+                "sa": 196,
+                "sd": 116,
+                "sp": 76
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Neutralizing Gas",
+            "tera_type": "Fire",
+            "item": "Choice Specs",
+            "moves": [
+                "Sludge Bomb",
+                "Dazzling Gleam",
+                "Strange Steam",
+                "Flamethrower"
+            ]
+        },
+        "General Disruption": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 156,
+                "sa": 0,
+                "sd": 100,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "ability": "Neutralizing Gas",
+            "tera_type": "Flying",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Sludge Bomb",
+                "Dazzling Gleam",
+                "Strange Steam",
+                "Clear Smog"
+            ]
+        },
+    },
+    "Ursaluna-Bloodmoon": {
+        "Leftovers Yawn": {
+            "level": 50,
+            "evs": {
+                "hp": 164,
+                "at": 0,
+                "df": 4,
+                "sa": 36,
+                "sd": 164,
+                "sp": 140
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Electric",
+            "item": "Leftovers",
+            "moves": [
+                "Earth Power",
+                "Blood Moon",
+                "Yawn",
+                "Protect"
+            ]
+        },
+        "Tera Water AV": {
+            "level": 50,
+            "evs": {
+                "hp": 148,
+                "at": 0,
+                "df": 12,
+                "sa": 116,
+                "sd": 180,
+                "sp": 52
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Water",
+            "item": "Assault Vest",
+            "moves": [
+                "Hyper Voice",
+                "Earth Power",
+                "Blood Moon",
+                "Vacuum Wave"
+            ]
+        },
+        "Modest Turbo Bear": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Normal",
+            "item": "Life Orb",
+            "moves": [
+                "Hyper Voice",
+                "Earth Power",
+                "Blood Moon",
+                "Vacuum Wave"
+            ]
+        },
+        "Timid Turbo Bear": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Normal",
+            "item": "Life Orb",
+            "moves": [
+                "Hyper Voice",
+                "Earth Power",
+                "Blood Moon",
+                "Vacuum Wave"
+            ]
+        },
+        "Nails' GC Winning AV": {
+            "level": 50,
+            "evs": {
+                "hp": 140,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 116,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Normal",
+            "item": "Assault Vest",
+            "moves": [
+                "Hyper Voice",
+                "Earth Power",
+                "Blood Moon",
+                "Vacuum Wave"
+            ]
+        },
+        "Trick Room Offense": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 12,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 0,
+            },
+            "nature": "Quiet",
+            "tera_type": "Normal",
+            "item": "Life Orb",
+            "moves": [
+                "Hyper Voice",
+                "Earth Power",
+                "Blood Moon",
+                "Vacuum Wave"
+            ]
+        },
+    },
+    //"Torterra": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Infernape": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Empoleon": {
+        "Offensive Assault Vest": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Water",
+            "ability": "Competitive",
+            "item": "Assault Vest",
+            "moves": [
+                "Flash Cannon",
+                "Water Pledge",
+                "Ice Beam",
+                "Vacuum Wave"
+            ]
+        },
+    },
+
+    //Indigo Disk DLC
+
+    //"Dodrio": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Exeggutor": {
+        "Offensive Life Orb Chlorophyll": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Fire",
+            "ability": "Chlorophyll",
+            "item": "Life Orb",
+            "moves": [
+                "Expanding Force",
+                "Leaf Storm",
+                "Giga Drain",
+                "Tera Blast"
+            ]
+        },
+    },
+    //"Exeggutor-Alola": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Rhydon": {
+        "Miraidon Wall": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 12,
+                "sa": 0,
+                "sd": 244,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 0,
+            },
+            "nature": "Brave",
+            "tera_type": "Fairy",
+            "item": "Eviolite",
+            "moves": [
+                "High Horsepower",
+                "Rock Slide",
+                "Crunch",
+                "Protect"
+            ]
+        },
+    },
+    //"Rhyperior": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Electabuzz": {
+        "Full Bulk Follow Me": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 252,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "tera_type": "Ghost",
+            "ability": "Static",
+            "item": "Eviolite",
+            "moves": [
+                "Volt Switch",
+                "Electroweb",
+                "Thunderbolt",
+                "Follow Me"
+            ]
+        },
+    },
+    //"Electivire": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Magmar": {
+        "Full Bulk Follow Me": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 252,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "tera_type": "Grass",
+            "ability": "Flame Body",
+            "item": "Eviolite",
+            "moves": [
+                "Overheat",
+                "Flamethrower",
+                "Clear Smog",
+                "Follow Me"
+            ]
+        },
+    },
+    //"Magmortar": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Zebstrika": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Smeargle": {
+        "Support + Guillotine": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 252,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Ghost",
+            "ability": "Moody",
+            "item": "Focus Sash",
+            "moves": [
+                "Fake Out",
+                "Follow Me",
+                "Spore",
+                "Guillotine"
+            ]
+        },
+        "Slow Decorate": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 252,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 0,
+            },
+            "nature": "Relaxed",
+            "tera_type": "Grass",
+            "ability": "Own Tempo",
+            "item": "Focus Sash",
+            "moves": [
+                "Fake Out",
+                "Follow Me",
+                "Spore",
+                "Decorate"
+            ]
+        },
+    },
+    //"Alcremie": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Flygon": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Toucannon": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Tentacruel": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Kingdra": {
+        "Tera Stellar Rain Sweeper": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "hp": 29,
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Stellar",
+            "item": "Life Orb",
+            "moves": [
+                "Muddy Water",
+                "Draco Meteor",
+                "Hurricane",
+                "Weather Ball"
+            ]
+        },
+    },
+    "Whimsicott": {
+        "Sash Tailwind": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Ghost",
+            "ability": "Prankster",
+            "item": "Focus Sash",
+            "moves": [
+                "Moonblast",
+                "Energy Ball",
+                "Tailwind",
+                "Sunny Day"
+            ]
+        },
+        "Bulky Covert Cloak": {
+            "level": 50,
+            "evs": {
+                "hp": 156,
+                "at": 0,
+                "df": 0,
+                "sa": 0,
+                "sd": 204,
+                "sp": 148
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Ghost",
+            "ability": "Prankster",
+            "item": "Covert Cloak",
+            "moves": [
+                "Moonblast",
+                "Light Screen",
+                "Tailwind",
+                "Encore"
+            ]
+        },
+    },
+    "Comfey": {
+        "Priority Partner Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 156,
+                "sa": 36,
+                "sd": 60,
+                "sp": 4
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "tera_type": "Steel",
+            "item": "Leftovers",
+            "moves": [
+                "Draining Kiss",
+                "Protect",
+                "Floral Healing",
+                "Trick Room"
+            ]
+        },
+    },
+    //"Vileplume": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Bellossom": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Lanturn": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Malamar": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Araquanid": {
+        "Clear Amulet TR Offense": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 0,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 0,
+            },
+            "nature": "Brave",
+            "tera_type": "Water",
+            "item": "Clear Amulet",
+            "moves": [
+                "Liquidation",
+                "Leech Life",
+                "Lunge",
+                "Bug Bite"
+            ]
+        },
+        "Leftovers Infestation": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 252,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 0,
+            },
+            "nature": "Relaxed",
+            "tera_type": "Grass",
+            "item": "Leftovers",
+            "moves": [
+                "Liquidation",
+                "Infestation",
+                "Wide Guard",
+                "Protect"
+            ]
+        },
+    },
+    //"Hitmonlee": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Hitmonchan": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Hitmontop": {
+        "Tera Steel AV": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 0,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "tera_type": "Steel",
+            "ability": "Intimidate",
+            "item": "Assault Vest",
+            "moves": [
+                "Fake Out",
+                "Close Combat",
+                "Triple Axel",
+                "Bullet Punch"
+            ]
+        },
+    },
+    "Excadrill": {
+        "Tera Stellar Swords Dance": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Stellar",
+            "item": "Clear Amulet",
+            "moves": [
+                "High Horsepower",
+                "Iron Head",
+                "Rock Slide",
+                "Swords Dance"
+            ]
+        },
+    },
+    //"Meowstic": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Meowstic-F": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Minior": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Rampardos": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Bastiodon": {
+        "Courtesy of SolCal": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 76,
+                "sa": 0,
+                "sd": 180,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 0
+            },
+            "nature": "Calm",
+            "tera_type": "Grass",
+            "item": "Covert Cloak",
+            "moves": [
+                "Foul Play",
+                "Body Press",
+                "Wide Guard",
+                "Iron Defense"
+            ]
+        },
+    },
+    "Cinccino": {
+        "Technician Loaded Dice Setup": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Grass",
+            "ability": "Technician",
+            "item": "Loaded Dice",
+            "moves": [
+                "Tail Slap",
+                "Triple Axel",
+                "Bullet Seed",
+                "Tidy Up"
+            ]
+        },
+    },
+    //"Skarmory": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Plusle": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Minun": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Scrafty": {
+        "Tera Poison Offensive AV": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 156,
+                "df": 60,
+                "sa": 0,
+                "sd": 36,
+                "sp": 4
+            },
+            "nature": "Adamant",
+            "tera_type": "Poison",
+            "item": "Assault Vest",
+            "moves": [
+                "Knock Off",
+                "Drain Punch",
+                "Close Combat",
+                "Fake Out"
+            ]
+        },
+    },
+    //"Golurk": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Porygon2": {
+        "Mixed Offense Download": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 28,
+                "df": 140,
+                "sa": 52,
+                "sd": 36,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 0,
+            },
+            "nature": "Quiet",
+            "tera_type": "Poison",
+            "ability": "Download",
+            "item": "Eviolite",
+            "moves": [
+                "Tera Blast",
+                "Ice Beam",
+                "Recover",
+                "Trick Room",
+            ]
+        },
+        "Tera Ground Coverage": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 164,
+                "sa": 0,
+                "sd": 92,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "tera_type": "Ground",
+            "ability": "Trace",
+            "item": "Eviolite",
+            "moves": [
+                "Tera Blast",
+                "Foul Play",
+                "Recover",
+                "Eerie Impulse"
+            ]
+        },
+        "Bolt Beam Trick Room": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 156,
+                "sa": 0,
+                "sd": 100,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "tera_type": "Ghost",
+            "ability": "Trace",
+            "item": "Eviolite",
+            "moves": [
+                "Thunderbolt",
+                "Ice Beam",
+                "Recover",
+                "Trick Room"
+            ]
+        },
+    },
+    "Porygon-Z": {
+        "Tera Fairy Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 228,
+                "at": 0,
+                "df": 84,
+                "sa": 196,
+                "sd": 0,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Fairy",
+            "ability": "Adaptability",
+            "item": "Life Orb",
+            "moves": [
+                "Tera Blast",
+                "Hyper Beam",
+                "Ice Beam",
+                "Thunderbolt"
+            ]
+        },
+    },
+    //"Galvantula": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Metagross": {
+        "Assault Vest Set": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 4
+            },
+            "nature": "Adamant",
+            "tera_type": "Water",
+            "item": "Assault Vest",
+            "moves": [
+                "Heavy Slam",
+                "Psychic Fangs",
+                "Bullet Punch",
+                "Stomping Tantrum"
+            ]
+        },
+    },
+    //"Dewgong": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Lapras": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Reuniclus": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Granbull": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Archaludon": {
+        "Stamina Assault Vest": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 4,
+                "sa": 164,
+                "sd": 68,
+                "sp": 20
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Grass",
+            "ability": "Stamina",
+            "item": "Assault Vest",
+            "moves": [
+                "Flash Cannon",
+                "Draco Meteor",
+                "Electro Shot",
+                "Body Press"
+            ]
+        },
+        "Stellar Sturdy Power Herb": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Stellar",
+            "ability": "Sturdy",
+            "item": "Power Herb",
+            "moves": [
+                "Electro Shot",
+                "Flash Cannon",
+                "Draco Meteor",
+                "Dragon Pulse"
+            ]
+        },
+        "Electric Stalwart Power Herb": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Electric",
+            "ability": "Stalwart",
+            "item": "Power Herb",
+            "moves": [
+                "Electro Shot",
+                "Thunderbolt",
+                "Draco Meteor",
+                "Dragon Pulse"
+            ]
+        },
+    },
+    "Hydrapple": {
+        "Offensive Assault Vest": {
+            "level": 50,
+            "evs": {
+                "hp": 228,
+                "at": 0,
+                "df": 4,
+                "sa": 236,
+                "sd": 28,
+                "sp": 12
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Fire",
+            "ability": "Regenerator",
+            "item": "Assault Vest",
+            "moves": [
+                "Giga Drain",
+                "Fickle Beam",
+                "Earth Power",
+                "Pollen Puff"
+            ]
+        },
+    },
+    "Venusaur": {
+        "Tera Ghost Sash Sleep Powder": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Ghost",
+            "ability": "Chlorophyll",
+            "item": "Focus Sash",
+            "moves": [
+                "Grass Knot",
+                "Sludge Bomb",
+                "Sleep Powder",
+                "Protect"
+            ]
+        },
+        "Offensive Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Fire",
+            "ability": "Chlorophyll",
+            "item": "Life Orb",
+            "moves": [
+                "Leaf Storm",
+                "Sludge Bomb",
+                "Earth Power",
+                "Tera Blast"
+            ]
+        },
+    },
+    //"Blastoise": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Meganium": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    //"Feraligatr": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Sceptile": {
+        "Designated Speedy Pledge": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Ghost",
+            "ability": "Unburden",
+            "item": "Focus Sash",
+            "moves": [
+                "Grass Pledge",
+                "Endeavor",
+                "Leaf Storm",
+                "Tera Blast"
+            ]
+        },
+    },
+    "Blaziken": {
+        "Clear Amulet Speed Boost": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "tera_type": "Ghost",
+            "ability": "Speed Boost",
+            "item": "Clear Amulet",
+            "moves": [
+                "Flare Blitz",
+                "Close Combat",
+                "Upper Hand",
+                "Brave Bird"
+            ]
+        },
+        "Special Sash Support": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Ghost",
+            "ability": "Speed Boost",
+            "item": "Focus Sash",
+            "moves": [
+                "Heat Wave",
+                "Aura Sphere",
+                "Vacuum Wave",
+                "Coaching"
+            ]
+        },
+    },
+    //"Swampert": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Serperior": {
+        "Jamie Boyt Spread with Tera Fire": {
+            "level": 50,
+            "evs": {
+                "hp": 116,
+                "at": 0,
+                "df": 4,
+                "sa": 132,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Timid",
+            "tera_type": "Fire",
+            "ability": "Contrary",
+            "item": "Wide Lens",
+            "moves": [
+                "Leaf Storm",
+                "Tera Blast",
+                "Dragon Pulse",
+                "Giga Drain"
+            ]
+        },
+    },
+    //"Emboar": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Incineroar": {
+        "Max Speed Safety Goggles": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 4,
+                "df": 4,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Ghost",
+            "ability": "Intimidate",
+            "item": "Safety Goggles",
+            "moves": [
+                "Flare Blitz",
+                "Knock Off",
+                "Fake Out",
+                "Parting Shot"
+            ]
+        },
+        "Tera Grass Assault Vest": {
+            "level": 50,
+            "evs": {
+                "hp": 228,
+                "at": 0,
+                "df": 188,
+                "sa": 0,
+                "sd": 92,
+                "sp": 0
+            },
+            "nature": "Impish",
+            "tera_type": "Grass",
+            "ability": "Intimidate",
+            "item": "Assault Vest",
+            "moves": [
+                "Flare Blitz",
+                "Knock Off",
+                "Fake Out",
+                "U-turn"
+            ]
+        },
+        "Physically Defensive Rocky Helmet": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 4,
+                "df": 196,
+                "sa": 0,
+                "sd": 52,
+                "sp": 12
+            },
+            "nature": "Impish",
+            "tera_type": "Grass",
+            "ability": "Intimidate",
+            "item": "Rocky Helmet",
+            "moves": [
+                "Knock Off",
+                "Fake Out",
+                "Will-O-Wisp",
+                "Parting Shot"
+            ]
+        },
+        "Ol' Reliable Bulky Sitrus": {
+            "level": 50,
+            "evs": {
+                "hp": 236,
+                "at": 44,
+                "df": 20,
+                "sa": 0,
+                "sd": 124,
+                "sp": 84
+            },
+            "nature": "Careful",
+            "tera_type": "Water",
+            "ability": "Intimidate",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Flare Blitz",
+                "Knock Off",
+                "Fake Out",
+                "Parting Shot"
+            ]
+        },
+    },
+    "Primarina": {
+        "Tera Poison Sitrus": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Poison",
+            "ability": "Liquid Voice",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Hyper Voice",
+                "Moonblast",
+                "Dazzling Gleam",
+                "Water Pledge"
+            ]
+        },
+    },
+    "Gouging Fire": {
+        "Regulation F Clear Amulet": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "tera_type": "Fire",
+            "item": "Clear Amulet",
+            "moves": [
+                "Heat Crash",
+                "Breaking Swipe",
+                "Earthquake",
+                "Dragon Claw"
+            ]
+        },
+        "Speed Booster Support": {
+            "level": 50,
+            "evs": {
+                "hp": 196,
+                "at": 100,
+                "df": 4,
+                "sa": 0,
+                "sd": 4,
+                "sp": 204
+            },
+            "nature": "Jolly",
+            "tera_type": "Fairy",
+            "item": "Booster Energy",
+            "moves": [
+                "Flare Blitz",
+                "Breaking Swipe",
+                "Howl",
+                "Protect"
+            ]
+        },
+    },
+    "Raging Bolt": {
+        "Tera Fairy AV": {
+            "level": 50,
+            "evs": {
+                "hp": 188,
+                "at": 0,
+                "df": 132,
+                "sa": 108,
+                "sd": 4,
+                "sp": 76
+            },
+            "ivs": {
+                "at": 20,
+            },
+            "nature": "Modest",
+            "tera_type": "Fairy",
+            "item": "Assault Vest",
+            "moves": [
+                "Thunderbolt",
+                "Draco Meteor",
+                "Thunderclap",
+                "Snarl"
+            ]
+        },
+        "Fast Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 20,
+            },
+            "nature": "Modest",
+            "item": "Life Orb",
+            "moves": [
+                "Thunderbolt",
+                "Draco Meteor",
+                "Thunderclap",
+                "Volt Switch"
+            ]
+        },
+        "Booster Energy Offense": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 20,
+            },
+            "nature": "Modest",
+            "item": "Booster Energy",
+            "moves": [
+                "Thunderbolt",
+                "Dragon Pulse",
+                "Thunderclap",
+                "Calm Mind"
+            ]
+        },
+    },
+    "Iron Boulder": {
+        "Tera Grass Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Grass",
+            "item": "Life Orb",
+            "moves": [
+                "Mighty Cleave",
+                "Psycho Cut",
+                "Close Combat",
+                "Sacred Sword"
+            ]
+        },
+    },
+    "Iron Crown": {
+        "Tera Ground Life Orb with Miraidon": {
+            "level": 50,
+            "evs": {
+                "hp": 28,
+                "at": 0,
+                "df": 20,
+                "sa": 204,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 20,
+            },
+            "nature": "Timid",
+            "tera_type": "Ground",
+            "item": "Life Orb",
+            "moves": [
+                "Tachyon Cutter",
+                "Psyshock",
+                "Tera Blast",
+                "Volt Switch"
+            ]
+        },
+        "Psyspam SpAtk Booster": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 20,
+            },
+            "nature": "Timid",
+            "tera_type": "Water",
+            "item": "Booster Energy",
+            "moves": [
+                "Tachyon Cutter",
+                "Expanding Force",
+                "Focus Blast",
+                "Tera Blast"
+            ]
+        },
+        "Psyspam Speed Booster": {
+            "level": 50,
+            "evs": {
+                "hp": 76,
+                "at": 0,
+                "df": 4,
+                "sa": 172,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 20,
+            },
+            "nature": "Timid",
+            "tera_type": "Water",
+            "item": "Booster Energy",
+            "moves": [
+                "Tachyon Cutter",
+                "Expanding Force",
+                "Focus Blast",
+                "Tera Blast"
+            ]
+        },
+        "Psyspam Choice Specs": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 20,
+            },
+            "nature": "Timid",
+            "tera_type": "Psychic",
+            "item": "Choice Specs",
+            "moves": [
+                "Tachyon Cutter",
+                "Expanding Force",
+                "Focus Blast",
+                "Volt Switch"
+            ]
+        },
+    },
+    "Walking Wake": {
+        "Life Orb with Speed Protosynthesis": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 4,
+                "sa": 244,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "item": "Life Orb",
+            "moves": [
+                "Hydro Steam",
+                "Draco Meteor",
+                "Flamethrower",
+                "Dragon Pulse"
+            ]
+        },
+        "Masayoshi Kuroo's Melbourne 1st AV Jet": {
+            "level": 50,
+            "evs": {
+                "hp": 108,
+                "at": 0,
+                "df": 0,
+                "sa": 164,
+                "sd": 0,
+                "sp": 236
+            },
+            "nature": "Timid",
+            "item": "Assault Vest",
+            "moves": [
+                "Hydro Steam",
+                "Draco Meteor",
+                "Snarl",
+                "Aqua Jet"
+            ]
+        },
+    },
+    "Iron Leaves": {
+        "Life Orb Tera Normal": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Normal",
+            "item": "Life Orb",
+            "moves": [
+                "Psyblade",
+                "Megahorn",
+                "Leaf Blade",
+                "Sacred Sword"
+            ]
+        },
+    },
+    //"Raikou": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Entei": {
+        "Lexicon's Portland 1st Tera Grass AV": {
+            "level": 50,
+            "evs": {
+                "hp": 68,
+                "at": 116,
+                "df": 20,
+                "sa": 0,
+                "sd": 148,
+                "sp": 156
+            },
+            "nature": "Adamant",
+            "tera_type": "Grass",
+            "ability": "Inner Focus",
+            "item": "Assault Vest",
+            "moves": [
+                "Sacred Fire",
+                "Extreme Speed",
+                "Stomping Tantrum",
+                "Snarl"
+            ]
+        },
+        "Tera Normal Choice Band": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "tera_type": "Normal",
+            "ability": "Inner Focus",
+            "item": "Choice Band",
+            "moves": [
+                "Sacred Fire",
+                "Extreme Speed",
+                "Stomping Tantrum",
+                "Flare Blitz"
+            ]
+        },
+    },
+    "Suicune": {
+        "Standard Tailwind Support": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 76,
+                "sa": 4,
+                "sd": 124,
+                "sp": 60
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Calm",
+            "tera_type": "Grass",
+            "ability": "Inner Focus",
+            "item": "Leftovers",
+            "moves": [
+                "Scald",
+                "Snarl",
+                "Icy Wind",
+                "Tailwind"
+            ]
+        },
+    },
+    //"Regirock": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+    "Regice": {
+        "More Specs Blizzard Spam": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 4
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Water",
+            "ability": "Ice Body",
+            "item": "Choice Specs",
+            "moves": [
+                "Blizzard",
+                "Thunderbolt",
+                "Ice Beam",
+                "Tera Blast"
+            ]
+        },
+    },
+    "Registeel": {
+        "Leftovers Body Press": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 92,
+                "df": 100,
+                "sa": 0,
+                "sd": 60,
+                "sp": 0
+            },
+            "nature": "Relaxed",
+            "tera_type": "Water",
+            "item": "Leftovers",
+            "moves": [
+                "Body Press",
+                "Heavy Slam",
+                "Iron Defense",
+                "Protect"
+            ]
+        },
+    },
+    "Latias": {
+        "Bulky Tailwind Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 60,
+                "sa": 4,
+                "sd": 4,
+                "sp": 188
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Poison",
+            "item": "Rocky Helmet",
+            "moves": [
+                "Mist Ball",
+                "Ice Beam",
+                "Draco Meteor",
+                "Tailwind"
+            ]
+        },
+    },
+    "Latios": {
+        "Offense Soul Dew": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Steel",
+            "item": "Soul Dew",
+            "moves": [
+                "Draco Meteor",
+                "Luster Purge",
+                "Ice Beam",
+                "Tera Blast"
+            ]
+        },
+    },
+    "Regigigas": {
+        "Tera Ghost Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "tera_type": "Ghost",
+            "item": "Life Orb",
+            "moves": [
+                "Double-Edge",
+                "Heavy Slam",
+                "Knock Off",
+                "High Horsepower"
+            ]
+        },
+    },
+    "Cobalion": {
+        "Offense Zamazenta at home (with Miraidon)": {
+            "level": 50,
+            "evs": {
+                "hp": 164,
+                "at": 4,
+                "df": 244,
+                "sa": 0,
+                "sd": 4,
+                "sp": 92
+            },
+            "nature": "Impish",
+            "tera_type": "Dragon",
+            "item": "Electric Seed",
+            "moves": [
+                "Body Press",
+                "Heavy Slam",
+                "Iron Defense",
+                "Taunt"
+            ]
+        },
+    },
+    "Terrakion": {
+        "Life Orb Tera Grass": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Grass",
+            "item": "Life Orb",
+            "moves": [
+                "Rock Slide",
+                "Close Combat",
+                "Sacred Sword",
+                "Iron Head"
+            ]
+        },
+    },
+    //"Virizion": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+
+    //GS Cup
+
+    "Mewtwo": {
+        "Getting Calyrex's Coffee": {
+            "level": 50,
+            "evs": {
+                "hp": 52,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 4,
+                "sp": 196
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "ability": "Unnerve",
+            "item": "Life Orb",
+            "moves": [
+                "Expanding Force",
+                "Psystrike",
+                "Aura Sphere",
+                "Ice Beam"
+            ]
+        },
+    },
+    "Ho-Oh": {
+        "Tera Grass Clear Amulet": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 0,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "tera_type": "Grass",
+            "ability": "Regenerator",
+            "item": "Clear Amulet",
+            "moves": [
+                "Sacred Fire",
+                "Brave Bird",
+                "Tera Blast",
+                "Recover"
+            ]
+        },
+    },
+    "Lugia": {
+        "Tera Fairy WP CM": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 0,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Fairy",
+            "ability": "Multiscale",
+            "item": "Weakness Policy",
+            "moves": [
+                "Aeroblast",
+                "Earth Power",
+                "Psyshock",
+                "Calm Mind"
+            ]
+        },
+    },
+    "Kyogre": {
+        "Shiliang Tang's NAIC T8 AV": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 4,
+                "sa": 236,
+                "sd": 4,
+                "sp": 12
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Grass",
+            "item": "Assault Vest",
+            "moves": [
+                "Water Spout",
+                "Origin Pulse",
+                "Ice Beam",
+                "Thunder"
+            ]
+        },
+        "Calm Mind Leftovers": {
+            "level": 50,
+            "evs": {
+                "hp": 132,
+                "at": 0,
+                "df": 140,
+                "sa": 76,
+                "sd": 12,
+                "sp": 148
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Grass",
+            "item": "Leftovers",
+            "moves": [
+                "Origin Pulse",
+                "Ice Beam",
+                "Calm Mind",
+                "Protect"
+            ]
+        },
+        "Max Speed Mystic Water": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Grass",
+            "item": "Mystic Water",
+            "moves": [
+                "Water Spout",
+                "Origin Pulse",
+                "Ice Beam",
+                "Thunder"
+            ]
+        },
+        "Tera Water Scarf": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "item": "Choice Scarf",
+            "moves": [
+                "Water Spout",
+                "Origin Pulse",
+                "Ice Beam",
+                "Thunder"
+            ]
+        },
+    },
+    "Groudon": {
+        "Bulky Assault Vest": {
+            "level": 50,
+            "evs": {
+                "hp": 188,
+                "at": 76,
+                "df": 12,
+                "sa": 0,
+                "sd": 124,
+                "sp": 108
+            },
+            "nature": "Adamant",
+            "tera_type": "Fire",
+            "item": "Assault Vest",
+            "moves": [
+                "Precipice Blades",
+                "Heat Crash",
+                "Thunder Punch",
+                "High Horsepower"
+            ]
+        },
+        "Basic Clear Amulet": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "tera_type": "Fire",
+            "item": "Clear Amulet",
+            "moves": [
+                "Precipice Blades",
+                "Heat Crash",
+                "Fire Punch",
+                "Rock Slide"
+            ]
+        },
+        "Bo1 Surprise Scarf": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Fire",
+            "item": "Choice Scarf",
+            "moves": [
+                "Precipice Blades",
+                "Heat Crash",
+                "Thunder Punch",
+                "Crunch"
+            ]
+        },
+    },
+    "Rayquaza": {
+        "Tera Normal Clear Amulet Espeed": {
+            "level": 50,
+            "evs": {
+                "hp": 228,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 28
+            },
+            "nature": "Adamant",
+            "tera_type": "Normal",
+            "item": "Clear Amulet",
+            "moves": [
+                "Dragon Ascent",
+                "Extreme Speed",
+                "Swords Dance",
+                "Protect"
+            ]
+        },
+    },
+    "Dialga": {
+        "No Origin Forme For a Spore Immunity": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 0,
+            },
+            "nature": "Quiet",
+            "tera_type": "Fairy",
+            "ability": "Telepathy",
+            "item": "Safety Goggles",
+            "moves": [
+                "Flash Cannon",
+                "Draco Meteor",
+                "Thunderbolt",
+                "Trick Room"
+            ]
+        },
+    },
+    "Dialga-Origin": {
+        "Tera Fairy Trick Room": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Fairy",
+            "ability": "Telepathy",
+            "moves": [
+                "Flash Cannon",
+                "Draco Meteor",
+                "Dragon Pulse",
+                "Trick Room"
+            ]
+        },
+    },
+    "Palkia": {
+        "Life Orb Trick Room": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 0,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 0,
+            },
+            "nature": "Quiet",
+            "tera_type": "Steel",
+            "ability": "Telepathy",
+            "item": "Lustrous Orb",
+            "moves": [
+                "Spacial Rend",
+                "Hydro Pump",
+                "Earth Power",
+                "Trick Room"
+            ]
+        },
+    },
+    "Palkia-Origin": {
+        "Fast Tera Steel": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Steel",
+            "moves": [
+                "Spacial Rend",
+                "Hydro Pump",
+                "Earth Power",
+                "Surf"
+            ]
+        },
+    },
+    "Giratina": {
+        "Bulky Lefties Calm Mind": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 156,
+                "sa": 52,
+                "sd": 44,
+                "sp": 4
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Calm",
+            "tera_type": "Fairy",
+            "ability": "Pressure",
+            "item": "Leftovers",
+            "moves": [
+                "Hex",
+                "Dragon Pulse",
+                "Calm Mind",
+                "Protect"
+            ]
+        },
+    },
+    "Giratina-Origin": {
+        "Most Popular 1760s Spread?": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 52,
+                "df": 4,
+                "sa": 156,
+                "sd": 44,
+                "sp": 0
+            },
+            "nature": "Brave",
+            "tera_type": "Steel",
+            "moves": [
+                "Shadow Sneak",
+                "Draco Meteor",
+                "Hex",
+                "Poltergeist"
+            ]
+        },
+    },
+    "Reshiram": {
+        "Bulky Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 4
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Fire",
+            "item": "Life Orb",
+            "moves": [
+                "Blue Flare",
+                "Heat Wave",
+                "Draco Meteor",
+                "Earth Power"
+            ]
+        },
+    },
+    "Zekrom": {
+        "That's a Weird Way to Spell Miraidon": {
+            "level": 50,
+            "evs": {
+                "hp": 156,
+                "at": 252,
+                "df": 4,
+                "sa": 0,
+                "sd": 76,
+                "sp": 20
+            },
+            "nature": "Adamant",
+            "tera_type": "Ground",
+            "item": "Assault Vest",
+            "moves": [
+                "Bolt Strike",
+                "Breaking Swipe",
+                "Crunch",
+                "Tera Blast"
+            ]
+        },
+    },
+    "Kyurem-Black": {
+        "DD Loaded Dice": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Ghost",
+            "item": "Loaded Dice",
+            "moves": [
+                "Icicle Spear",
+                "Scale Shot",
+                "Fusion Bolt",
+                "Dragon Dance"
+            ]
+        },
+    },
+    "Kyurem-White": {
+        "Tera Ice Specs Blizzard Spam": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 0,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Ice",
+            "item": "Choice Specs",
+            "moves": [
+                "Blizzard",
+                "Freeze-Dry",
+                "Earth Power",
+                "Fusion Flare"
+            ]
+        },
+    },
+    "Solgaleo": {
+        "Tera Fairy Weakness Policy": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Adamant",
+            "tera_type": "Fairy",
+            "item": "Weakness Policy",
+            "moves": [
+                "Sunsteel Strike",
+                "Psychic Fangs",
+                "Close Combat",
+                "Knock Off"
+            ]
+        },
+    },
+    "Lunala": {
+        "Tang Team Fairy Electric Seed": {
+            "level": 50,
+            "evs": {
+                "hp": 132,
+                "at": 0,
+                "df": 172,
+                "sa": 180,
+                "sd": 12,
+                "sp": 12
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Fairy",
+            "item": "Electric Seed",
+            "moves": [
+                "Moongeist Beam",
+                "Moonblast",
+                "Trick Room",
+                "Wide Guard"
+            ]
+        },
+        "Tera Water Psyspam Meteor Beam": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 0,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Water",
+            "item": "Power Herb",
+            "moves": [
+                "Moongeist Beam",
+                "Meteor Beam",
+                "Expanding Force",
+                "Wide Guard"
+            ]
+        },
+        "45mice's NAIC Top 16 Lefties CM": {
+            "level": 50,
+            "evs": {
+                "hp": 92,
+                "at": 0,
+                "df": 204,
+                "sa": 108,
+                "sd": 4,
+                "sp": 100
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Fairy",
+            "item": "Leftovers",
+            "moves": [
+                "Moongeist Beam",
+                "Moonblast",
+                "Protect",
+                "Calm Mind"
+            ]
+        },
+    },
+    "Necrozma-Dusk-Mane": {
+        "Trick Room Swords Dance": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 0,
+            },
+            "nature": "Brave",
+            "tera_type": "Normal",
+            "item": "Clear Amulet",
+            "moves": [
+                "Sunsteel Strike",
+                "Photon Geyser",
+                "Psychic Fangs",
+                "Swords Dance"
+            ]
+        },
+    },
+    "Necrozma-Dawn-Wings": {
+        "Trick Room Meteor Beam": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 0,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 0,
+            },
+            "nature": "Quiet",
+            "tera_type": "Fairy",
+            "item": "Power Herb",
+            "moves": [
+                "Moongeist Beam",
+                "Expanding Force",
+                "Meteor Beam",
+                "Photon Geyser"
+            ]
+        },
+    },
+    "Zacian-Crowned": {
+        "Tera Fairy Fast Offense": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "item": "Rusted Sword",
+            "moves": [
+                "Behemoth Blade",
+                "Play Rough",
+                "Sacred Sword",
+                "Swords Dance"
+            ]
+        },
+        "Tera Ground Tera Blast": {
+            "level": 50,
+            "evs": {
+                "hp": 108,
+                "at": 204,
+                "df": 4,
+                "sa": 0,
+                "sd": 4,
+                "sp": 188
+            },
+            "nature": "Jolly",
+            "tera_type": "Ground",
+            "item": "Rusted Sword",
+            "moves": [
+                "Behemoth Blade",
+                "Tera Blast",
+                "Sacred Sword",
+                "Protect"
+            ]
+        },
+    },
+    "Zamazenta-Crowned": {
+        "Michael Kelsch's 24 Worlds T4 Max Speed": {
+            "level": 50,
+            "evs": {
+                "hp": 92,
+                "at": 4,
+                "df": 156,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Impish",
+            "tera_type": "Dragon",
+            "item": "Rusted Shield",
+            "moves": [
+                "Body Press",
+                "Heavy Slam",
+                "Wide Guard",
+                "Protect"
+            ]
+        },
+        "Bulky Tera Grass": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 156,
+                "sa": 0,
+                "sd": 100,
+                "sp": 0
+            },
+            "nature": "Impish",
+            "tera_type": "Grass",
+            "item": "Rusted Shield",
+            "moves": [
+                "Body Press",
+                "Heavy Slam",
+                "Behemoth Bash",
+                "Wide Guard"
+            ]
+        },
+        "Faster Tera Dragon": {
+            "level": 50,
+            "evs": {
+                "hp": 156,
+                "at": 0,
+                "df": 156,
+                "sa": 0,
+                "sd": 0,
+                "sp": 196
+            },
+            "nature": "Impish",
+            "tera_type": "Dragon",
+            "item": "Rusted Shield",
+            "moves": [
+                "Body Press",
+                "Heavy Slam",
+                "Wide Guard",
+                "Behemoth Bash"
+            ]
+        },
+    },
+    "Eternatus": {
+        "Cosmic Power Stall": {
+            "level": 50,
+            "evs": {
+                "hp": 220,
+                "at": 0,
+                "df": 196,
+                "sa": 4,
+                "sd": 84,
+                "sp": 4
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "tera_type": "Dark",
+            "item": "Leftovers",
+            "moves": [
+                "Sludge Bomb",
+                "Flamethrower",
+                "Recover",
+                "Cosmic Power"
+            ]
+        },
+    },
+    "Calyrex-Ice Rider": {
+        "MDB's Utrecht 1st Bulky Leech Seed": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 36,
+                "df": 4,
+                "sa": 0,
+                "sd": 196,
+                "sp": 20
+            },
+            "nature": "Adamant",
+            "tera_type": "Water",
+            "item": "Leftovers",
+            "moves": [
+                "Glacial Lance",
+                "Leech Seed",
+                "Trick Room",
+                "Protect"
+            ]
+        },
+        "Tera Fire Min Speed": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 164,
+                "df": 0,
+                "sa": 0,
+                "sd": 100,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 0,
+            },
+            "nature": "Brave",
+            "tera_type": "Fire",
+            "item": "Clear Amulet",
+            "moves": [
+                "Glacial Lance",
+                "High Horsepower",
+                "Close Combat",
+                "Trick Room"
+            ]
+        },
+        "Tera Normal Adamant": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 116,
+                "df": 4,
+                "sa": 0,
+                "sd": 132,
+                "sp": 4
+            },
+            "nature": "Adamant",
+            "tera_type": "Normal",
+            "item": "Clear Amulet",
+            "moves": [
+                "Glacial Lance",
+                "High Horsepower",
+                "Close Combat",
+                "Trick Room"
+            ]
+        },
+    },
+    "Calyrex-Shadow Rider": {
+        "Basic Sash Tera Ghost": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Ghost",
+            "item": "Focus Sash",
+            "moves": [
+                "Astral Barrage",
+                "Psychic",
+                "Pollen Puff",
+                "Protect"
+            ]
+        },
+        "Tera Dark Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 28,
+                "at": 0,
+                "df": 4,
+                "sa": 220,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Dark",
+            "item": "Life Orb",
+            "moves": [
+                "Astral Barrage",
+                "Psychic",
+                "Dark Pulse",
+                "Expanding Force"
+            ]
+        },
+        "ck49's Los Angeles T4 CM Cloak": {
+            "level": 50,
+            "evs": {
+                "hp": 180,
+                "at": 0,
+                "df": 84,
+                "sa": 84,
+                "sd": 4,
+                "sp": 156
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Fairy",
+            "item": "Covert Cloak",
+            "moves": [
+                "Astral Barrage",
+                "Draining Kiss",
+                "Nasty Plot",
+                "Protect"
+            ]
+        },
+        "Tera Normal Sitrus": {
+            "level": 50,
+            "evs": {
+                "hp": 84,
+                "at": 0,
+                "df": 12,
+                "sa": 156,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Normal",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Astral Barrage",
+                "Psyshock",
+                "Psychic",
+                "Expanding Force"
+            ]
+        },
+        "Choice Specs Tera Ghost": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Ghost",
+            "item": "Choice Specs",
+            "moves": [
+                "Astral Barrage",
+                "Expanding Force",
+                "Pollen Puff",
+                "Shadow Ball"
+            ]
+        },
+    },
+    "Koraidon": {
+        "Jolly Max Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Fire",
+            "item": "Life Orb",
+            "moves": [
+                "Close Combat",
+                "Flare Blitz",
+                "Flame Charge",
+                "Dragon Claw"
+            ]
+        },
+        "AndrewFVGC's San Antonio T4 Scale Shot": {
+            "level": 50,
+            "evs": {
+                "hp": 116,
+                "at": 196,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 196
+            },
+            "nature": "Adamant",
+            "tera_type": "Fire",
+            "item": "Loaded Dice",
+            "moves": [
+                "Collision Course",
+                "Flare Blitz",
+                "Scale Shot",
+                "Protect"
+            ]
+        },
+        "Bulkier Clear Amulet": {
+            "level": 50,
+            "evs": {
+                "hp": 204,
+                "at": 68,
+                "df": 20,
+                "sa": 0,
+                "sd": 20,
+                "sp": 196
+            },
+            "nature": "Adamant",
+            "tera_type": "Fire",
+            "item": "Clear Amulet",
+            "moves": [
+                "Collision Course",
+                "Flare Blitz",
+                "Flame Charge",
+                "Helping Hand"
+            ]
+        },
+    },
+    "Miraidon": {
+        "ceree's 24 Worlds 1st Fairy Specs": {
+            "level": 50,
+            "evs": {
+                "hp": 44,
+                "at": 0,
+                "df": 4,
+                "sa": 244,
+                "sd": 12,
+                "sp": 204
+            },
+            "nature": "Modest",
+            "tera_type": "Fairy",
+            "item": "Choice Specs",
+            "moves": [
+                "Electro Drift",
+                "Draco Meteor",
+                "Volt Switch",
+                "Dazzling Gleam"
+            ]
+        },
+        "Tang Team AV Tera Electric": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 20,
+                "sa": 212,
+                "sd": 4,
+                "sp": 20
+            },
+            "nature": "Modest",
+            "tera_type": "Electric",
+            "item": "Assault Vest",
+            "moves": [
+                "Electro Drift",
+                "Draco Meteor",
+                "Volt Switch",
+                "Snarl"
+            ]
+        },
+        "Scarf Tera Electric": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Timid",
+            "tera_type": "Electric",
+            "item": "Choice Scarf",
+            "moves": [
+                "Electro Drift",
+                "Draco Meteor",
+                "Volt Switch",
+                "Snarl"
+            ]
+        },
+        "Modest Specs Tera Electric": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "nature": "Modest",
+            "tera_type": "Electric",
+            "item": "Choice Specs",
+            "moves": [
+                "Electro Drift",
+                "Draco Meteor",
+                "Volt Switch",
+                "Discharge"
+            ]
+        },
+    },
+    "Terapagos": {
+        "Fast Choice Specs": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 15,
+            },
+            "nature": "Modest",
+            "item": "Choice Specs",
+            "moves": [
+                "Tera Starstorm",
+                "Earth Power",
+                "Dark Pulse",
+                "Hyper Beam"
+            ]
+        },
+        "Calm Mind Sub": {
+            "level": 50,
+            "evs": {
+                "hp": 172,
+                "at": 0,
+                "df": 52,
+                "sa": 132,
+                "sd": 4,
+                "sp": 148
+            },
+            "ivs": {
+                "at": 15,
+            },
+            "nature": "Bold",
+            "item": "Leftovers",
+            "moves": [
+                "Tera Starstorm",
+                "Substitute",
+                "Protect",
+                "Calm Mind"
+            ]
+        },
+        "Calm Mind + Coverage Move": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 4
+            },
+            "ivs": {
+                "at": 15,
+            },
+            "nature": "Modest",
+            "item": "Covert Cloak",
+            "moves": [
+                "Tera Starstorm",
+                "Earth Power",
+                "Flamethrower",
+                "Calm Mind"
+            ]
+        },
+    },
+
+    //Mythical
+
+    "Mew": {
+        "Transform Imprison": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Ghost",
+            "item": "Focus Sash",
+            "moves": [
+                "Transform",
+                "Imprison",
+                "Trick Room",
+                "Protect"
+            ]
+        },
+    },
+    "Jirachi": {
+        "Scarf Hax Spam": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Water",
+            "item": "Choice Scarf",
+            "moves": [
+                "Iron Head",
+                "Zen Headbutt",
+                "Body Slam",
+                "U-turn"
+            ]
+        },
+    },
+    "Deoxys-Attack": {
+        "Sash Mixed Psy Spam": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 4,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Hasty",
+            "item": "Focus Sash",
+            "moves": [
+                "Expanding Force",
+                "Psycho Boost",
+                "Superpower",
+                "Dark Pulse"
+            ]
+        },
+    },
+    "Deoxys-Defense": {
+        "Stored Power Sponge": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 156,
+                "sa": 4,
+                "sd": 100,
+                "sp": 4
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Calm",
+            "tera_type": "Dark",
+            "item": "Leftovers",
+            "moves": [
+                "Stored Power",
+                "Recover",
+                "Cosmic Power",
+                "Double Team"
+            ]
+        },
+    },
+    "Deoxys-Speed": {
+        "Modest Specs Psy Spam": {
+            "level": 50,
+            "evs": {
+                "hp": 4,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "item": "Choice Specs",
+            "moves": [
+                "Expanding Force",
+                "Psycho Boost",
+                "Dark Pulse",
+                "Icy Wind"
+            ]
+        },
+    },
+    "Manaphy": {
+        "Tail Glow Heart Swap": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Grass",
+            "item": "Leftovers",
+            "moves": [
+                "Scald",
+                "Dazzling Gleam",
+                "Tail Glow",
+                "Heart Swap"
+            ]
+        },
+    },
+    "Darkrai": {
+        "Dark Void has returned": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Ghost",
+            "item": "Focus Sash",
+            "moves": [
+                "Dark Pulse",
+                "Sludge Bomb",
+                "Dark Void",
+                "Icy Wind"
+            ]
+        },
+    },
+    "Shaymin-Sky": {
+        "Sash STABs Tailwind": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Ghost",
+            "item": "Focus Sash",
+            "moves": [
+                "Seed Flare",
+                "Air Slash",
+                "Tailwind",
+                "Protect"
+            ]
+        },
+    },
+    "Arceus": {
+        "Extreme Killer": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 4
+            },
+            "nature": "Adamant",
+            "tera_type": "Ghost",
+            "item": "Clear Amulet",
+            "moves": [
+                "Extreme Speed",
+                "Shadow Claw",
+                "Swords Dance",
+                "Stomping Tantrum"
+            ]
+        },
+        "Fairy CM": {
+            "level": 50,
+            "evs": {
+                "hp": 148,
+                "at": 0,
+                "df": 0,
+                "sa": 164,
+                "sd": 0,
+                "sp": 196
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Ground",
+            "item": "Pixie Plate",
+            "moves": [
+                "Judgment",
+                "Earth Power",
+                "Calm Mind",
+                "Flamethrower"
+            ]
+        },
+        "Ground CM": {
+            "level": 50,
+            "evs": {
+                "hp": 180,
+                "at": 0,
+                "df": 0,
+                "sa": 188,
+                "sd": 0,
+                "sp": 140
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Fairy",
+            "item": "Earth Plate",
+            "moves": [
+                "Judgment",
+                "Ice Beam",
+                "Calm Mind",
+                "Dazzling Gleam"
+            ]
+        },
+        "Water CM": {
+            "level": 50,
+            "evs": {
+                "hp": 212,
+                "at": 0,
+                "df": 156,
+                "sa": 92,
+                "sd": 4,
+                "sp": 44
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Grass",
+            "item": "Splash Plate",
+            "moves": [
+                "Judgment",
+                "Ice Beam",
+                "Calm Mind",
+                "Protect"
+            ]
+        },
+        "Fire Support": {
+            "level": 50,
+            "evs": {
+                "hp": 220,
+                "at": 0,
+                "df": 0,
+                "sa": 156,
+                "sd": 0,
+                "sp": 132
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Water",
+            "item": "Flame Plate",
+            "moves": [
+                "Judgment",
+                "Heat Wave",
+                "Earth Power",
+                "Tailwind"
+            ]
+        },
+        "Dark Perish Support": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 156,
+                "sa": 0,
+                "sd": 100,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "tera_type": "Fairy",
+            "item": "Dread Plate",
+            "moves": [
+                "Foul Play",
+                "Snarl",
+                "Perish Song",
+                "Protect"
+            ]
+        },
+        "Ghost TR Support": {
+            "level": 50,
+            "evs": {
+                "hp": 132,
+                "at": 0,
+                "df": 4,
+                "sa": 252,
+                "sd": 4,
+                "sp": 116
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Fairy",
+            "item": "Spooky Plate",
+            "moves": [
+                "Judgment",
+                "Dazzling Gleam",
+                "Trick Room",
+                "Will-O-Wisp"
+            ]
+        },
+        "Fighting Body Press": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 188,
+                "sa": 0,
+                "sd": 76,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Bold",
+            "tera_type": "Fire",
+            "item": "Fist Plate",
+            "moves": [
+                "Body Press",
+                "Dark Pulse",
+                "Iron Defense",
+                "Recover"
+            ]
+        },
+    },
+    "Keldeo": {
+        "Life Orb Coaching": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Timid",
+            "tera_type": "Stellar",
+            "item": "Life Orb",
+            "moves": [
+                "Secret Sword",
+                "Muddy Water",
+                "Coaching",
+                "Protect"
+            ]
+        },
+    },
+    "Meloetta": {
+        "Mixed Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 132,
+                "df": 0,
+                "sa": 124,
+                "sd": 0,
+                "sp": 252
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Naive",
+            "tera_type": "Ghost",
+            "item": "Life Orb",
+            "moves": [
+                "Relic Song",
+                "Close Combat",
+                "Tera Blast",
+                "Protect"
+            ]
+        },
+    },
+    "Diancie": {
+        "Diamond Storm Body Press": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 252,
+                "sa": 0,
+                "sd": 4,
+                "sp": 0
+            },
+            "nature": "Impish",
+            "tera_type": "Grass",
+            "item": "Leftovers",
+            "moves": [
+                "Diamond Storm",
+                "Body Press",
+                "Play Rough",
+                "Protect"
+            ]
+        },
+    },
+    "Hoopa-Unbound": {
+        "Mixed Attacker TR": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 252,
+                "df": 0,
+                "sa": 4,
+                "sd": 0,
+                "sp": 0
+            },
+            "ivs": {
+                "sp": 0,
+            },
+            "nature": "Brave",
+            "tera_type": "Poison",
+            "item": "Life Orb",
+            "moves": [
+                "Hyperspace Fury",
+                "Expanding Force",
+                "Gunk Shot",
+                "Trick Room"
+            ]
+        },
+    },
+    "Volcanion": {
+        "Assault Vest Offense": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Modest",
+            "tera_type": "Ground",
+            "item": "Assault Vest",
+            "moves": [
+                "Steam Eruption",
+                "Heat Wave",
+                "Earth Power",
+                "Overheat"
+            ]
+        },
+    },
+    "Magearna": {
+        "TR Life Orb": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 0,
+                "df": 0,
+                "sa": 252,
+                "sd": 4,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+                "sp": 0,
+            },
+            "nature": "Quiet",
+            "tera_type": "Water",
+            "item": "Life Orb",
+            "moves": [
+                "Flash Cannon",
+                "Dazzling Gleam",
+                "Fleur Cannon",
+                "Trick Room"
+            ]
+        },
+    },
+    "Zarude": {
+        "Sun Offensive Support": {
+            "level": 50,
+            "evs": {
+                "hp": 0,
+                "at": 252,
+                "df": 0,
+                "sa": 0,
+                "sd": 4,
+                "sp": 252
+            },
+            "nature": "Jolly",
+            "tera_type": "Water",
+            "item": "Leftovers",
+            "moves": [
+                "Solar Blade",
+                "Knock Off",
+                "U-turn",
+                "Jungle Healing"
+            ]
+        },
+    },
+    "Pecharunt": {
+        "Poison Gas Hex": {
+            "level": 50,
+            "evs": {
+                "hp": 220,
+                "at": 0,
+                "df": 4,
+                "sa": 4,
+                "sd": 252,
+                "sp": 28
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Calm",
+            "tera_type": "Dark",
+            "item": "Leftovers",
+            "moves": [
+                "Malignant Chain",
+                "Hex",
+                "Poison Gas",
+                "Parting Shot"
+            ]
+        },
+    },
+
+    //base
+
+    //"": {
+    //    "": {
+    //        "level": 50,
+    //        "evs": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "ivs": {
+    //            "at": 0,
+    //        },
+    //        "nature": "",
+    //        "tera_type": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+
+}


### PR DESCRIPTION
## Summary
- Whitelist `frontend-rewrite/src/data/` in `.gitignore` alongside the existing `frontend/src/data/` exception
- Tracks `setdex-gen9.ts` which was being excluded by the global `data/` ignore rule (meant for H2 database)
- Fixes Docker build failure for the frontend-rewrite beta deployment workflow

## Test plan
- [ ] Re-run "Deploy Beta (Frontend Rewrite)" workflow and verify the build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)