### PR TITLE
fix: matchup planner paste title and color on create

### DIFF
--- a/frontend/src/components/team/OpponentTeamCard.tsx
+++ b/frontend/src/components/team/OpponentTeamCard.tsx
@@ -88,11 +88,10 @@ const OpponentTeamCard: React.FC<OpponentTeamCardProps> = ({
 
       setLoadingTitle(true);
       try {
-        const parsed = await pokepasteService.fetchAndParse(
+        const title = await pokepasteService.fetchPasteTitle(
           opponentTeam.pokepaste,
         );
-        const firstMon = parsed[0];
-        setPasteTitle(firstMon?.name || null);
+        setPasteTitle(title);
       } catch {
         setPasteTitle(null);
       } finally {

--- a/frontend/src/hooks/useOpponentTeams.ts
+++ b/frontend/src/hooks/useOpponentTeams.ts
@@ -91,6 +91,7 @@ export const useOpponentTeams = (
       pokepaste: data.pokepaste,
       playerName: "",
       notes: data.notes || "",
+      color: data.color,
     });
 
     const transformedTeam = transformTeam(newTeam);

--- a/frontend/src/services/api/gamePlanApi.ts
+++ b/frontend/src/services/api/gamePlanApi.ts
@@ -38,7 +38,7 @@ export const gamePlanApi = {
   getTeams: (gamePlanId: number) =>
     apiClient.get(`/api/game-plans/${gamePlanId}/teams`) as Promise<GamePlanTeam[]>,
 
-  addTeam: (gamePlanId: number, data: { pokepaste: string; playerName: string; notes?: string }) =>
+  addTeam: (gamePlanId: number, data: { pokepaste: string; playerName: string; notes?: string; color?: string }) =>
     apiClient.post(`/api/game-plans/${gamePlanId}/teams`, data) as Promise<GamePlanTeam>,
 
   updateTeam: (gamePlanId: number, teamId: number, updates: Partial<GamePlanTeam>) =>

--- a/frontend/src/services/pokepasteService.ts
+++ b/frontend/src/services/pokepasteService.ts
@@ -395,6 +395,29 @@ export async function getCacheStats(): Promise<{
 }
 
 /**
+ * Fetch the paste title from a pokepaste or pokebin URL.
+ * Both services expose a /json endpoint with a title field.
+ */
+export async function fetchPasteTitle(pasteUrl: string): Promise<string | null> {
+  const detected = detectPasteService(pasteUrl);
+  if (!detected) return null;
+
+  const jsonUrl =
+    detected.type === "pokepaste"
+      ? `https://pokepast.es/${detected.pasteId}/json`
+      : `https://pokebin.com/${detected.pasteId}/json`;
+
+  try {
+    const res = await fetch(jsonUrl);
+    if (!res.ok) return null;
+    const json = await res.json() as { title?: string | null };
+    return json.title || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Get Pokemon names from a paste URL (simplified interface)
  */
 export async function getPokemonNames(


### PR DESCRIPTION
## Summary

- **Paste title**: Cards were displaying the first Pokémon's species name (e.g. "Weezing-Galar") as the matchup entry title instead of the actual paste title. Now fetches from the `/json` endpoint on both pokepast.es and pokebin to get the real title.
- **Card color**: Color selected in the "Add Matchup Team" modal was not being saved — `color` was never passed through `createOpponentTeam` → `gamePlanApi.addTeam`. Editing afterwards worked because `updateTeam` did pass it. Fixed by threading `color` through the create path and updating the API type signature.

## Test plan

- [x] Add a new matchup entry with a pokepast.es URL — card header should show the paste title, not a Pokémon name
- [x] Add a new matchup entry with a pokebin URL — same check
- [x] Add a new matchup entry with a non-default color selected — card border should reflect that color immediately after creation
- [x] Edit an existing entry's color — should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)