### PR TITLE
ci: skip beta deploy when merging main back to develop

### DIFF
--- a/.github/workflows/deploy-beta-versioned.yml
+++ b/.github/workflows/deploy-beta-versioned.yml
@@ -29,6 +29,7 @@ jobs:
   version-bump:
     name: Bump Version
     runs-on: ubuntu-latest
+    if: "!startsWith(github.event.head_commit.message, 'Merge branch ''main''')"
     outputs:
       new_version: ${{ steps.bump.outputs.version }}
       bumped: ${{ steps.bump.outputs.bumped }}


### PR DESCRIPTION
## Summary

- Adds an `if` condition to the `version-bump` job in `deploy-beta-versioned.yml` that skips the entire workflow when the triggering commit is a merge from main
- Since `build-and-push` and `deploy` both depend on `version-bump`, they cascade-skip automatically

## Why

When a develop→main PR is merged, GitHub pushes a sync merge commit back to develop with the message `"Merge branch 'main' into develop"`. This was incorrectly triggering a new beta version bump + deploy.

## Test plan

- [ ] Merge a PR from develop → main and confirm the beta versioned workflow does **not** fire on the subsequent sync commit
- [ ] Push a normal commit to develop and confirm the workflow still fires as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)