### PR TITLE
ci: fix PR status checks not resolving on develop→main PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,13 @@ name: CI
 
 on:
   push:
-    branches: ['*']
+    branches:
+      - 'feature/**'
+      - 'fix/**'
+      - 'bugfix/**'
   pull_request:
     branches: [main, develop]
+  workflow_dispatch:
 
 jobs:
   # Backend build and test


### PR DESCRIPTION
## Summary

- Scopes the `push` trigger in `ci.yml` to only `feature/**`, `fix/**`, and `bugfix/**` branches
- Adds `workflow_dispatch` for manual runs
- Removes `push: branches: ['*']` which was causing the issue

## Why

With `push: branches: ['*']` and `pull_request: branches: [main, develop]` both present, pushing to `develop` (which is the head of a develop→main PR) triggered **two competing CI runs** with the same job names. GitHub's PR status system saw both and couldn't resolve a final status for the PR, leaving checks in a broken/pending state.

Now:
- Feature/fix/bugfix branches get CI on push for immediate feedback
- PRs to main/develop get a single clean `pull_request`-context run that properly reports to the PR

## Test plan

- [ ] Open a PR from develop → main and confirm `Backend Build & Test` and `Frontend Build` checks appear and resolve correctly
- [ ] Push to a feature branch and confirm CI still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)