### PR TITLE
fix: resolve persistent 403 on expired token (auth refresh flow)

### DIFF
--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/security/JwtAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,36 @@
+package com.yeskatronics.vs_recorder_backend.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yeskatronics.vs_recorder_backend.dto.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        log.warn("Unauthorized request to {}: {}", request.getRequestURI(), authException.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.UNAUTHORIZED.value(), "Unauthorized",
+                "Authentication required. Please provide a valid token.",
+                request.getRequestURI());
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+    }
+}

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/security/SecurityConfig.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/security/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthFilter;
     private final CustomUserDetailsService userDetailsService;
     private final CorsConfigurationSource corsConfigurationSource;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     /**
      * Configure security filter chain
@@ -59,6 +60,9 @@ public class SecurityConfig {
                 )
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // No sessions, JWT only
+                )
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                 )
                 .authenticationProvider(authenticationProvider())
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -33,7 +33,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         } catch (err) {
           console.error("Auth verification failed:", err);
           localStorage.removeItem("token");
-          localStorage.removeItem("refreshToken");
+          // Do NOT remove refreshToken — client.ts interceptor handles cleanup
+          // if the refresh also fails. Removing it here prevents silent recovery.
           localStorage.removeItem("user");
           setUser(null);
         }


### PR DESCRIPTION
## Summary
- **Backend**: Add `JwtAuthenticationEntryPoint` so Spring returns `401` (not `403`) for unauthenticated requests; wire it into `SecurityConfig`
- **Frontend**: Preserve `refreshToken` in `AuthContext.initAuth` catch block so silent recovery is possible; rewrite `client.ts` request interceptor to proactively refresh tokens within 5 minutes of expiry; extend response interceptor to handle `403` as a safety net

## Root Causes Fixed
Three bugs chained together to cause a persistent 403 that only cleared on hard refresh:
1. `SecurityConfig` had no `AuthenticationEntryPoint` → Spring's default treated auth failures as `AccessDeniedException` (403)
2. `client.ts` response interceptor only retried on `status === 401` → 403 bypassed refresh entirely
3. `AuthContext.initAuth` catch block removed `refreshToken` from localStorage → silent recovery impossible even with a valid refresh token

## Test Plan
- [ ] `curl -i -X GET http://localhost:8080/api/teams -H "Authorization: Bearer invalid_token"` → expect `HTTP/1.1 401` JSON (previously 403)
- [ ] Set `jwt.access-expiration=10000` (10s), log in, wait 10s, navigate → network tab shows `POST /api/auth/refresh` fires *before* data call; user stays logged in
- [ ] Same 10s setup, hard-refresh (F5) → `initAuth` proactively refreshes; user stays logged in
- [ ] Trigger 3–4 simultaneous calls with expired token → only **one** `POST /api/auth/refresh` in network tab
- [ ] Set both expirations to 10s, log in, wait 10s, navigate → refresh fails → redirect to `/signin`, no infinite loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)