### PR TITLE
fix: skip PokeAPI call for form-Pokemon with known static data

### DIFF
--- a/frontend/src/services/pokemonService.ts
+++ b/frontend/src/services/pokemonService.ts
@@ -88,6 +88,12 @@ export async function getPokemon(identifier: string | number): Promise<PokemonDa
     return cached.data;
   }
 
+  // Check static fallback before hitting API (avoids 404s for form-Pokemon like landorus, urshifu)
+  const staticKey = typeof normalizedId === "string" ? normalizedId : String(normalizedId);
+  if (COMMON_VGC_POKEMON[staticKey]) {
+    return enrichFallbackData(COMMON_VGC_POKEMON[staticKey], staticKey);
+  }
+
   // Try to fetch from API
   try {
     await initialize();
@@ -101,11 +107,9 @@ export async function getPokemon(identifier: string | number): Promise<PokemonDa
     console.warn(`Failed to fetch Pokemon from API: ${identifier}`, error);
   }
 
-  // Fallback to static data
-  const staticKey = typeof identifier === "string" ? identifier.toLowerCase() : String(identifier);
+  // Fallback to static data (for any not caught above)
   if (COMMON_VGC_POKEMON[staticKey]) {
-    const fallbackData = enrichFallbackData(COMMON_VGC_POKEMON[staticKey], staticKey);
-    return fallbackData;
+    return enrichFallbackData(COMMON_VGC_POKEMON[staticKey], staticKey);
   }
 
   // Fallback to sprite map


### PR DESCRIPTION
## Summary
- Form-Pokemon like Landorus, Tornadus, and Urshifu have no bare-name entry in PokeAPI (they require a form suffix like `-therian`), causing 404s on every page load
- Moves the `COMMON_VGC_POKEMON` static lookup to run **before** the API call, so known form-Pokemon resolve immediately without a network request
- Sprites were already loading correctly (sprite map has its own lookup); this eliminates the console noise and unnecessary API hammering

## Test plan
- [ ] Open replays page with a team containing Landorus, Tornadus, or Urshifu — no 404s in console
- [ ] Normal Pokemon (Incineroar, Amoonguss, etc.) still fetch from PokeAPI as expected
- [ ] Pokemon in `COMMON_VGC_POKEMON` resolve without any network request

🤖 Generated with [Claude Code](https://claude.com/claude-code)