### PR TITLE
Fix calculator page bugs

### DIFF
--- a/frontend/src/hooks/useDamageCalc.ts
+++ b/frontend/src/hooks/useDamageCalc.ts
@@ -63,11 +63,15 @@ function buildField(fieldState: FieldState): Field {
   });
 }
 
-function buildMove(moveState: MoveState): Move {
+function buildMove(moveState: MoveState, isStellarTera = false): Move {
   const opts: Record<string, unknown> = { isCrit: moveState.crit };
 
   if (moveState.bpOverride) {
     opts.overrides = { basePower: moveState.bpOverride };
+  }
+
+  if (isStellarTera) {
+    opts.isStellarFirstUse = true;
   }
 
   return new Move(gen, moveState.name, opts);
@@ -102,7 +106,7 @@ export function useDamageCalc(
         .filter((m) => m.name)
         .map((m) => {
           try {
-            return calculate(gen, p1, p2, buildMove(m), field);
+            return calculate(gen, p1, p2, buildMove(m, p1State.isTera && p1State.teraType === "Stellar"), field);
           } catch {
             return null;
           }
@@ -112,7 +116,7 @@ export function useDamageCalc(
         .filter((m) => m.name)
         .map((m) => {
           try {
-            return calculate(gen, p2, p1, buildMove(m), reverseField);
+            return calculate(gen, p2, p1, buildMove(m, p2State.isTera && p2State.teraType === "Stellar"), reverseField);
           } catch {
             return null;
           }

--- a/frontend/src/utils/calcUtils.ts
+++ b/frontend/src/utils/calcUtils.ts
@@ -86,6 +86,18 @@ export function setdexToState(setdexEntry: SetdexEntry): PokemonState {
   };
 }
 
+const SPECIES_NAME_MAP: Record<string, string> = {
+  "Urshifu-Single Strike": "Urshifu",
+  "Urshifu-Rapid Strike": "Urshifu-Rapid-Strike",
+  "Calyrex-Ice Rider": "Calyrex-Ice",
+  "Calyrex-Shadow Rider": "Calyrex-Shadow",
+  "Lycanroc-Midday": "Lycanroc",
+};
+
+export function normalizeSpeciesName(name: string): string {
+  return SPECIES_NAME_MAP[name] || name;
+}
+
 export function getBaseStats(species: string): StatsTable | null {
   if (!species) return null;
   for (const s of gen.species) {


### PR DESCRIPTION
## Summary
- Enable tera type dropdown without requiring the tera checkbox to be ticked first
- Apply Tera Stellar 1.2x off-type damage bonus via `isStellarFirstUse`
- Always reset IVs/EVs to defaults when switching sidebar slots (prevents stale values like 0 Atk IV carrying over)
- Normalize setdex species names (e.g. "Urshifu-Single Strike" → "Urshifu") for `@smogon/calc` compatibility
- Default to first ability when setdex entry doesn't specify one (fixes Ursaluna formes)
- Auto-set Burned/Badly Poisoned status for Flame Orb/Toxic Orb holders

## Test plan
- [x] Open calculator with a team containing Landorus (0 Atk IV) and Urshifu — switch between them and verify IVs reset properly
- [x] Select Tera Stellar on attacker, pick an off-type move → damage should reflect the 1.2x boost
- [x] Verify tera type dropdown is selectable without checking the tera checkbox
- [x] Search "Urshifu" on defensive side from setdex → stats and types should display correctly
- [x] Select Ursaluna from setdex → ability should default to Guts
- [x] Select a Pokemon with Flame Orb → status should auto-set to Burned
- [x] Select a Pokemon with Toxic Orb → status should auto-set to Badly Poisoned

🤖 Generated with [Claude Code](https://claude.com/claude-code)