### PR TITLE
Add public landing page for unauthenticated visitors

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Pokemon VGC replay analysis, team stats, matchup planning, and damage calculator." />
+    <meta property="og:site_name" content="VS Recorder" />
     <title>VS Recorder</title>
   </head>
   <body class="dark:bg-gray-900">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,6 @@ import SignUp from "./pages/AuthPages/SignUp";
 import ForgotPassword from "./pages/AuthPages/ForgotPassword";
 import ResetPassword from "./pages/AuthPages/ResetPassword";
 import NotFound from "./pages/OtherPage/NotFound";
-import AppLayout from "./layout/AppLayout";
 import TeamLayout from "./layout/TeamLayout";
 import { ScrollToTop } from "./components/common/ScrollToTop";
 import HomePage from "./pages/Dashboard/HomePage";
@@ -21,7 +20,7 @@ import MatchupPlannerPage from "./pages/Team/MatchupPlannerPage";
 import PokemonNotesPage from "./pages/Team/PokemonNotesPage";
 import CalculatorPage from "./pages/Team/CalculatorPage";
 import TypeChartPage from "./pages/Team/TypeChartPage";
-import ProtectedRoute from "./components/auth/ProtectedRoute";
+import RootRoute from "./components/auth/RootRoute";
 import PublicRoute from "./components/auth/PublicRoute";
 import * as pokemonService from "./services/pokemonService";
 
@@ -68,18 +67,12 @@ export default function App() {
           }
         />
 
-        {/* Protected dashboard */}
-        <Route
-          element={
-            <ProtectedRoute>
-              <AppLayout />
-            </ProtectedRoute>
-          }
-        >
-          <Route index path="/" element={<HomePage />} />
-          <Route path="/about" element={<AboutPage />} />
-          <Route path="/announcements" element={<AnnouncementsPage />} />
-          <Route path="/team/:teamId" element={<TeamLayout />}>
+        {/* Root: Landing page (unauth) or Dashboard (auth) */}
+        <Route path="/" element={<RootRoute />}>
+          <Route index element={<HomePage />} />
+          <Route path="about" element={<AboutPage />} />
+          <Route path="announcements" element={<AnnouncementsPage />} />
+          <Route path="team/:teamId" element={<TeamLayout />}>
             <Route index element={<Navigate to="replays" replace />} />
             <Route path="replays" element={<ReplaysPage />} />
             <Route path="game-by-game" element={<GameByGamePage />} />

--- a/frontend/src/components/auth/RootRoute.tsx
+++ b/frontend/src/components/auth/RootRoute.tsx
@@ -1,0 +1,40 @@
+import { Outlet, useLocation } from "react-router";
+import { useAuth } from "../../context/AuthContext";
+import AppLayout from "../../layout/AppLayout";
+import LandingHome from "../../pages/Landing/LandingHome";
+import LandingNav from "../../pages/Landing/LandingNav";
+import LandingFooter from "../../pages/Landing/LandingFooter";
+
+const RootRoute = () => {
+  const { isAuthenticated, loading } = useAuth();
+  const location = useLocation();
+
+  if (loading) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="h-10 w-10 animate-spin rounded-full border-4 border-emerald-500 border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (isAuthenticated) {
+    return <AppLayout />;
+  }
+
+  // Unauthenticated: landing home on "/", or public page wrapper for child routes
+  if (location.pathname === "/") {
+    return <LandingHome />;
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col dark:bg-gray-900">
+      <LandingNav />
+      <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 sm:px-6">
+        <Outlet />
+      </main>
+      <LandingFooter />
+    </div>
+  );
+};
+
+export default RootRoute;

--- a/frontend/src/components/auth/SignInForm.tsx
+++ b/frontend/src/components/auth/SignInForm.tsx
@@ -43,7 +43,7 @@ export default function SignInForm() {
           className="inline-flex items-center text-sm text-gray-500 transition-colors hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
         >
           <ChevronLeftIcon className="size-5" />
-          Back to dashboard
+          Back to home
         </Link>
       </div>
       <div className="flex flex-col justify-center flex-1 w-full max-w-md mx-auto">

--- a/frontend/src/components/auth/SignUpForm.tsx
+++ b/frontend/src/components/auth/SignUpForm.tsx
@@ -41,7 +41,7 @@ export default function SignUpForm() {
           className="inline-flex items-center text-sm text-gray-500 transition-colors hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
         >
           <ChevronLeftIcon className="size-5" />
-          Back to dashboard
+          Back to home
         </Link>
       </div>
       <div className="flex flex-col justify-center flex-1 w-full max-w-md mx-auto">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -291,6 +291,14 @@ layer(base);
   }
 }
 
+@utility fade-in-up {
+  animation: fadeInUp 0.6s ease-out both;
+}
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(16px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
 .tableCheckbox:checked ~ span span {
   @apply opacity-100;
 }

--- a/frontend/src/pages/Landing/AnnouncementsSection.tsx
+++ b/frontend/src/pages/Landing/AnnouncementsSection.tsx
@@ -1,0 +1,59 @@
+import { Link } from "react-router";
+import { ArrowRight } from "lucide-react";
+import announcements from "../../data/announcements.json";
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr + "T00:00:00");
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export default function AnnouncementsSection() {
+  const latest = announcements.slice(0, 3);
+
+  return (
+    <section className="bg-gray-50 py-16 dark:bg-gray-950 sm:py-24">
+      <div className="mx-auto max-w-4xl px-4 sm:px-6">
+        <div className="mb-8 text-center">
+          <h2 className="text-2xl font-bold text-gray-800 dark:text-white/90 sm:text-3xl">
+            Latest Updates
+          </h2>
+        </div>
+
+        <div className="space-y-4">
+          {latest.map((a) => (
+            <div
+              key={a.id}
+              className="rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-800 dark:bg-gray-900"
+            >
+              <div className="mb-2 flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
+                <h3 className="font-semibold text-gray-800 dark:text-white/90">
+                  {a.title}
+                </h3>
+                <span className="text-xs text-gray-400 dark:text-gray-500">
+                  {formatDate(a.date)}
+                </span>
+              </div>
+              <p className="text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+                {a.message}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-6 text-center">
+          <Link
+            to="/announcements"
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-brand-500 transition-colors hover:text-brand-600 dark:text-brand-400 dark:hover:text-brand-300"
+          >
+            View All Announcements
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/Landing/FeaturesSection.tsx
+++ b/frontend/src/pages/Landing/FeaturesSection.tsx
@@ -1,0 +1,91 @@
+import {
+  Download,
+  BarChart3,
+  Swords,
+  Calculator,
+  FolderOpen,
+  Activity,
+} from "lucide-react";
+
+const features = [
+  {
+    icon: Download,
+    title: "Replay Import",
+    description:
+      "Paste a Pokemon Showdown replay link and VS Recorder automatically parses leads, picks, and results.",
+    color: "text-blue-500 bg-blue-50 dark:bg-blue-500/10",
+  },
+  {
+    icon: BarChart3,
+    title: "Team Analytics",
+    description:
+      "Track win rates, usage stats, and trends across all your replays for every team you build.",
+    color: "text-emerald-500 bg-emerald-50 dark:bg-emerald-500/10",
+  },
+  {
+    icon: Swords,
+    title: "Matchup Planning",
+    description:
+      "Build game plans for tournament opponents. Plan leads, counters, and strategies for any matchup.",
+    color: "text-orange-500 bg-orange-50 dark:bg-orange-500/10",
+  },
+  {
+    icon: Calculator,
+    title: "Damage Calculator",
+    description:
+      "Built-in damage calculator loaded with your team's sets, so you can run calcs without switching tabs.",
+    color: "text-purple-500 bg-purple-50 dark:bg-purple-500/10",
+  },
+  {
+    icon: FolderOpen,
+    title: "Team Organization",
+    description:
+      "Organize teams into folders, import from Pokepaste, and keep everything sorted by regulation.",
+    color: "text-brand-500 bg-brand-50 dark:bg-brand-500/10",
+  },
+  {
+    icon: Activity,
+    title: "Move Usage Analysis",
+    description:
+      "See which moves each Pokemon uses most, how often they're brought, and what your leads look like.",
+    color: "text-pink-500 bg-pink-50 dark:bg-pink-500/10",
+  },
+];
+
+export default function FeaturesSection() {
+  return (
+    <section id="features" className="bg-white py-16 dark:bg-gray-900 sm:py-24">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="mb-12 text-center">
+          <h2 className="text-3xl font-bold text-gray-800 dark:text-white/90 sm:text-4xl">
+            Everything you need to compete
+          </h2>
+          <p className="mx-auto mt-3 max-w-lg text-gray-500 dark:text-gray-400">
+            From replay tracking to opponent scouting — all in one place.
+          </p>
+        </div>
+
+        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {features.map((f) => (
+            <div
+              key={f.title}
+              className="rounded-2xl border border-gray-200 bg-white p-5 transition-shadow hover:shadow-theme-md dark:border-gray-800 dark:bg-white/[0.03]"
+            >
+              <div
+                className={`mb-3 flex h-10 w-10 items-center justify-center rounded-lg ${f.color}`}
+              >
+                <f.icon className="h-5 w-5" />
+              </div>
+              <h3 className="font-semibold text-gray-800 dark:text-white/90">
+                {f.title}
+              </h3>
+              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                {f.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/Landing/HeroSection.tsx
+++ b/frontend/src/pages/Landing/HeroSection.tsx
@@ -1,0 +1,54 @@
+import { Link } from "react-router";
+import GridShape from "../../components/common/GridShape";
+
+export default function HeroSection() {
+  const handleScrollToFeatures = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    document.getElementById("features")?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  return (
+    <section className="relative overflow-hidden bg-brand-950 dark:bg-gray-950">
+      <GridShape />
+      <div className="mx-auto max-w-4xl px-4 py-20 text-center sm:py-28 lg:py-36">
+        <h1 className="fade-in-up text-4xl font-bold tracking-tight text-white sm:text-5xl lg:text-6xl">
+          Level Up Your{" "}
+          <span className="bg-gradient-to-r from-emerald-400 to-blue-400 bg-clip-text text-transparent">
+            VGC Game
+          </span>
+        </h1>
+
+        <p className="mx-auto mt-5 max-w-xl text-lg text-gray-300 sm:text-xl">
+          Track replays, analyze matchups, and plan for any opponent.
+        </p>
+
+        <div className="fade-in-up mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row sm:gap-4">
+          <Link
+            to="/signup"
+            className="w-full rounded-lg bg-brand-500 px-6 py-3 text-sm font-semibold text-white shadow-lg transition-colors hover:bg-brand-600 sm:w-auto"
+          >
+            Get Started
+          </Link>
+          <a
+            href="#features"
+            onClick={handleScrollToFeatures}
+            className="w-full rounded-lg border border-gray-600 px-6 py-3 text-sm font-semibold text-gray-200 transition-colors hover:border-gray-500 hover:bg-white/5 sm:w-auto"
+          >
+            See Features
+          </a>
+        </div>
+
+        <div className="mx-auto mt-12 max-w-3xl overflow-hidden rounded-xl border border-gray-700/50 bg-gray-900/50 shadow-2xl">
+          <img
+            src="/images/screenshots/dashboard.png"
+            alt="VS Recorder Dashboard"
+            className="w-full"
+            onError={(e) => {
+              (e.target as HTMLElement).parentElement!.style.display = "none";
+            }}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/Landing/LandingFooter.tsx
+++ b/frontend/src/pages/Landing/LandingFooter.tsx
@@ -1,0 +1,58 @@
+import { Link } from "react-router";
+import { Github, ExternalLink } from "lucide-react";
+
+export default function LandingFooter() {
+  return (
+    <footer className="border-t border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
+        <div className="flex flex-col items-center justify-between gap-6 md:flex-row">
+          <div className="text-center md:text-left">
+            <h3 className="bg-gradient-to-r from-emerald-400 to-blue-400 bg-clip-text text-base font-semibold text-transparent">
+              VS Recorder
+            </h3>
+            <p className="text-xs text-gray-400 dark:text-gray-500">
+              VGC Analytics
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center justify-center gap-4 text-sm text-gray-500 dark:text-gray-400">
+            <Link
+              to="/about"
+              className="transition-colors hover:text-gray-700 dark:hover:text-gray-300"
+            >
+              About
+            </Link>
+            <Link
+              to="/announcements"
+              className="transition-colors hover:text-gray-700 dark:hover:text-gray-300"
+            >
+              Announcements
+            </Link>
+            <a
+              href="https://github.com/Pocolip/vs-recorder"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 transition-colors hover:text-gray-700 dark:hover:text-gray-300"
+            >
+              <Github className="h-3.5 w-3.5" />
+              GitHub
+            </a>
+            <a
+              href="https://x.com/luisfrik"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 transition-colors hover:text-gray-700 dark:hover:text-gray-300"
+            >
+              Twitter/X
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          </div>
+
+          <p className="text-xs text-gray-400 dark:text-gray-500">
+            &copy; {new Date().getFullYear()} Luis Medina
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/frontend/src/pages/Landing/LandingHome.tsx
+++ b/frontend/src/pages/Landing/LandingHome.tsx
@@ -1,0 +1,46 @@
+import { Helmet } from "react-helmet-async";
+import LandingNav from "./LandingNav";
+import HeroSection from "./HeroSection";
+import FeaturesSection from "./FeaturesSection";
+import AnnouncementsSection from "./AnnouncementsSection";
+import LandingFooter from "./LandingFooter";
+
+export default function LandingHome() {
+  return (
+    <>
+      <Helmet>
+        <title>VS Recorder – Pokemon VGC Replay Analysis & Team Planning</title>
+        <meta
+          name="description"
+          content="Pokemon VGC replay analysis, team stats, matchup planning, and damage calculator."
+        />
+        <meta property="og:type" content="website" />
+        <meta
+          property="og:title"
+          content="VS Recorder – Pokemon VGC Replay Analysis & Team Planning"
+        />
+        <meta
+          property="og:description"
+          content="Track replays, analyze matchups, and plan for any opponent."
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+          name="twitter:title"
+          content="VS Recorder – Pokemon VGC Replay Analysis & Team Planning"
+        />
+        <meta
+          name="twitter:description"
+          content="Track replays, analyze matchups, and plan for any opponent."
+        />
+      </Helmet>
+
+      <LandingNav />
+      <main>
+        <HeroSection />
+        <FeaturesSection />
+        <AnnouncementsSection />
+      </main>
+      <LandingFooter />
+    </>
+  );
+}

--- a/frontend/src/pages/Landing/LandingNav.tsx
+++ b/frontend/src/pages/Landing/LandingNav.tsx
@@ -1,0 +1,30 @@
+import { Link } from "react-router";
+import { ThemeToggleButton } from "../../components/common/ThemeToggleButton";
+
+export default function LandingNav() {
+  return (
+    <header className="sticky top-0 z-50 border-b border-gray-200/60 bg-white/80 backdrop-blur-lg dark:border-gray-800/60 dark:bg-gray-900/80">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3 sm:px-6">
+        <span className="bg-gradient-to-r from-emerald-400 to-blue-400 bg-clip-text text-lg font-bold text-transparent">
+          VS Recorder
+        </span>
+
+        <div className="flex items-center gap-2 sm:gap-3">
+          <ThemeToggleButton />
+          <Link
+            to="/signin"
+            className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            Log In
+          </Link>
+          <Link
+            to="/signup"
+            className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-600"
+          >
+            Sign Up
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
Introduce a landing page at `/` with hero section, feature highlights, and latest announcements so new visitors see what VS Recorder offers before signing up. Authenticated users continue to see the dashboard.

- Add RootRoute component that renders LandingHome (unauth) or AppLayout (auth)
- Create Landing page components: LandingNav, HeroSection, FeaturesSection, AnnouncementsSection, LandingFooter
- Update App.tsx routing to use RootRoute instead of ProtectedRoute wrapper
- Add fade-in-up CSS animation and SEO meta tags to index.html
- Change auth page "Back to dashboard" links to "Back to home"