### PR TITLE
Add Group By Leads view to Matchup Planner

### DIFF
--- a/frontend/src/components/team/LeadGroupCard.tsx
+++ b/frontend/src/components/team/LeadGroupCard.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from "react";
+import { ChevronRight } from "lucide-react";
+import PokemonSprite from "../pokemon/PokemonSprite";
+import PokemonTeam from "../pokemon/PokemonTeam";
+import type { OpponentTeam } from "./OpponentTeamCard";
+import type { Composition } from "../../types";
+
+interface LeadGroupEntry {
+  opponentTeam: OpponentTeam;
+  composition: Composition;
+}
+
+interface LeadGroupCardProps {
+  lead1: string;
+  lead2: string;
+  teams: LeadGroupEntry[];
+}
+
+const LeadGroupCard: React.FC<LeadGroupCardProps> = ({
+  lead1,
+  lead2,
+  teams,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-white/[0.02]">
+      {/* Header: Lead pair + count (clickable) */}
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex w-full items-center justify-between bg-gray-50 p-4 text-left transition-colors hover:bg-gray-100 dark:bg-white/[0.02] dark:hover:bg-white/[0.05]"
+        style={{ borderRadius: isOpen ? "0.5rem 0.5rem 0 0" : "0.5rem" }}
+      >
+        <div className="w-20">
+          <ChevronRight
+            className={`h-4 w-4 text-gray-400 transition-transform ${isOpen ? "rotate-90" : ""}`}
+          />
+        </div>
+        <div className="rounded-lg border border-brand-200 bg-brand-50/50 p-1 dark:border-brand-400/30 dark:bg-brand-200/10">
+          <div className="flex gap-0.5">
+            <PokemonSprite name={lead1} size="lg" showTooltip />
+            <PokemonSprite name={lead2} size="lg" showTooltip />
+          </div>
+        </div>
+        <div className="flex w-20 justify-end">
+          <span className="rounded-full bg-brand-100 px-2.5 py-0.5 text-sm font-semibold text-brand-700 dark:bg-brand-500/20 dark:text-brand-300">
+            {teams.length} {teams.length === 1 ? "MU" : "MUs"}
+          </span>
+        </div>
+      </button>
+
+      {/* Body: Opponent teams list */}
+      {isOpen && (
+        <div className={`grid grid-cols-1 gap-px border-t border-gray-200 bg-gray-100 dark:border-gray-700 dark:bg-gray-800 ${teams.length >= 5 ? "sm:grid-cols-3" : ""}`}>
+          {teams.map(({ opponentTeam }, i) => (
+            <div
+              key={`${opponentTeam.id}-${i}`}
+              className={`flex justify-center px-3 py-2 ${i % 2 === 1 ? "bg-gray-50 dark:bg-white/[0.03]" : "bg-white dark:bg-white/[0.02]"}`}
+            >
+              {opponentTeam.pokepaste && (
+                <PokemonTeam pokepasteUrl={opponentTeam.pokepaste} size="sm" />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default LeadGroupCard;

--- a/frontend/src/data/announcements.json
+++ b/frontend/src/data/announcements.json
@@ -1,5 +1,11 @@
 [
   {
+    "id": "2026-03-01-group-by-leads",
+    "date": "2026-03-01",
+    "title": "Matchup Planner: Group By Leads",
+    "message": "New toggle on the Matchup Planner page! You can now group your strategy plans by lead pairs to quickly see which leads cover the most matchups. Hit the 'Group By Leads' button to try it out."
+  },
+  {
     "id": "2026-02-26-calc-matchup-stats",
     "date": "2026-02-26",
     "title": "Calc and Matchup Stat Fixes",


### PR DESCRIPTION
## Summary
- New "Group By Leads" toggle on the Matchup Planner page that groups strategy plans by lead pairs, sorted by usage count
- Collapsible cards with 3-column grid layout (5+ teams), single column for smaller lists
- Announcement added for the new feature

## Test plan
- [ ] Navigate to a team's Matchup Planner tab
- [ ] Add opponent teams with strategy plans sharing lead pairs
- [ ] Click "Group By Leads" and verify grouped view with correct counts
- [ ] Verify order-independent grouping (e.g. A+B and B+A grouped together)
- [ ] Click "Back to Planner" to restore original view
- [ ] Verify collapsible cards (closed by default)
- [ ] Test with no compositions — verify empty state
- [ ] Verify dark mode and mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)