### PR TITLE
Fix password reset always showing invalid token

### DIFF
--- a/frontend/src/pages/AuthPages/ResetPassword.tsx
+++ b/frontend/src/pages/AuthPages/ResetPassword.tsx
@@ -49,7 +49,7 @@ function ResetPasswordForm() {
     authApi
       .validateResetToken(token)
       .then((res) => {
-        setState(res.valid ? "form" : "invalid");
+        setState(res.success ? "form" : "invalid");
       })
       .catch(() => {
         setState("invalid");

--- a/frontend/src/services/api/authApi.ts
+++ b/frontend/src/services/api/authApi.ts
@@ -30,7 +30,7 @@ export const authApi = {
     apiClient.post("/api/auth/forgot-password", { email }) as Promise<{ message: string }>,
 
   validateResetToken: (token: string) =>
-    apiClient.get(`/api/auth/reset-password/validate?token=${token}`) as Promise<{ valid: boolean }>,
+    apiClient.get(`/api/auth/reset-password/validate?token=${token}`) as Promise<{ success: boolean; message: string }>,
 
   resetPassword: (data: { token: string; newPassword: string }) =>
     apiClient.post("/api/auth/reset-password", data) as Promise<{ message: string }>,


### PR DESCRIPTION
## Summary
- The frontend was checking `res.valid` on the validate-token response, but the backend returns `{ success: boolean, message: string }` — `res.valid` was always `undefined`, causing every reset link to show "Invalid or expired link"
- Updated `ResetPassword.tsx` to check `res.success` and fixed the type annotation in `authApi.ts`

## Test plan
- [ ] Request a password reset email
- [ ] Click the reset link in the email
- [ ] Verify the reset form appears instead of the "invalid link" error
- [ ] Complete the password reset and verify it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)