### PR TITLE
Fix calculator always using level 50 for VGC

### DIFF
--- a/frontend/src/components/calc/PokemonPanel.tsx
+++ b/frontend/src/components/calc/PokemonPanel.tsx
@@ -232,7 +232,7 @@ const PokemonPanel: React.FC<PokemonPanelProps> = ({
       nature: mon.nature || "Hardy",
       teraType: teraDefaults ? teraDefaults.teraType : (mon.tera_type || null),
       status: statusForItem(mon.item),
-      level: mon.level || 50,
+      level: 50,
       moves: (mon.moves || []).slice(0, 4).map((name) => ({
         name: typeof name === "string" ? name : "",
         crit: false,

--- a/frontend/src/hooks/useDamageCalc.ts
+++ b/frontend/src/hooks/useDamageCalc.ts
@@ -8,7 +8,7 @@ function buildPokemon(state: PokemonState): Pokemon | null {
   if (!state.species) return null;
 
   const opts: Record<string, unknown> = {
-    level: state.level || 50,
+    level: 50,
     nature: state.nature || undefined,
     ability: state.ability || undefined,
     item: state.item || undefined,

--- a/frontend/src/utils/calcUtils.ts
+++ b/frontend/src/utils/calcUtils.ts
@@ -71,7 +71,7 @@ export function setdexToState(setdexEntry: SetdexEntry): PokemonState {
 
   return {
     species: "",
-    level: setdexEntry.level || 50,
+    level: 50,
     nature: setdexEntry.nature || "Hardy",
     ability: setdexEntry.ability || "",
     item: setdexEntry.item || "",


### PR DESCRIPTION
## Summary
- Hardcode level 50 in all calculator entry points (`useDamageCalc`, `calcUtils`, `PokemonPanel`) instead of using the Pokemon's stored level
- VGC battles are always level 50, but pokepastes/setdex entries can have different levels (e.g., 77), causing incorrect damage calculations

## Test plan
- [ ] Load a team with a non-level-50 Pokemon (e.g., level 77 Flutter Mane from a pokepaste)
- [ ] Verify the calculator shows level 50 stats and correct damage output
- [ ] Verify setdex Pokemon also load at level 50

🤖 Generated with [Claude Code](https://claude.com/claude-code)