### PR TITLE
feat: add reviewed status to replays

### DIFF
--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/ReplayController.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/ReplayController.java
@@ -74,10 +74,17 @@ public class ReplayController {
 
         Replay savedReplay = replayService.createReplayFromUrl(teamId, request.getUrl());
 
-        // Update notes if provided
-        if (request.getNotes() != null && !request.getNotes().isEmpty()) {
+        // Apply optional fields (notes, reviewed) via partial update
+        boolean hasNotes = request.getNotes() != null && !request.getNotes().isEmpty();
+        boolean hasReviewed = Boolean.TRUE.equals(request.getReviewed());
+        if (hasNotes || hasReviewed) {
             Replay updates = new Replay();
-            updates.setNotes(request.getNotes());
+            if (hasNotes) {
+                updates.setNotes(request.getNotes());
+            }
+            if (hasReviewed) {
+                updates.setReviewed(true);
+            }
             savedReplay = replayService.updateReplay(savedReplay.getId(), updates);
         }
 

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/dto/ReplayDTO.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/dto/ReplayDTO.java
@@ -78,6 +78,8 @@ public class ReplayDTO {
         private String url;
 
         private String notes;
+
+        private Boolean reviewed;
     }
 
     /**
@@ -122,6 +124,8 @@ public class ReplayDTO {
         private String result;
 
         private LocalDateTime date;
+
+        private Boolean reviewed;
     }
 
     /**
@@ -141,6 +145,7 @@ public class ReplayDTO {
         private Integer gameNumber; // 1, 2, 3 for Bo3; null for Bo1
         private LocalDateTime date;
         private String notes;
+        private Boolean reviewed;
         private LocalDateTime createdAt;
     }
 
@@ -160,6 +165,7 @@ public class ReplayDTO {
         private Integer gameNumber; // 1, 2, 3 for Bo3; null for Bo1
         private LocalDateTime date;
         private String notes;
+        private Boolean reviewed;
         private LocalDateTime createdAt;
         private BattleData battleData;
     }

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/entities/Replay.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/entities/Replay.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
@@ -62,6 +63,10 @@ public class Replay {
     @Size(max = 10, message = "Result must not exceed 10 characters")
     @Column(length = 10)
     private String result; // 'win' or 'loss'
+
+    @Column(name = "reviewed", nullable = false)
+    @ColumnDefault("false")
+    private Boolean reviewed = false;
 
     /**
      * Game number in a Bo3 match set.

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/ReplayService.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/ReplayService.java
@@ -293,6 +293,11 @@ public class ReplayService {
             existingReplay.setDate(updates.getDate());
         }
 
+        // Update reviewed flag if provided
+        if (updates.getReviewed() != null) {
+            existingReplay.setReviewed(updates.getReviewed());
+        }
+
         // Note: battleLog is immutable and should not be updated
 
         Replay savedReplay = replayRepository.save(existingReplay);

--- a/frontend/src/components/modals/AddReplayModal.tsx
+++ b/frontend/src/components/modals/AddReplayModal.tsx
@@ -21,6 +21,7 @@ const AddReplayModal: React.FC<AddReplayModalProps> = ({
 }) => {
   const [replayUrl, setReplayUrl] = useState("");
   const [notes, setNotes] = useState("");
+  const [markReviewed, setMarkReviewed] = useState(false);
   const [bulkMode, setBulkMode] = useState(false);
   const [bulkUrls, setBulkUrls] = useState("");
   const [loading, setLoading] = useState(false);
@@ -32,6 +33,7 @@ const AddReplayModal: React.FC<AddReplayModalProps> = ({
     if (isOpen) {
       setReplayUrl("");
       setNotes("");
+      setMarkReviewed(false);
       setBulkMode(false);
       setBulkUrls("");
       setError("");
@@ -61,7 +63,7 @@ const AddReplayModal: React.FC<AddReplayModalProps> = ({
       setLoading(true);
       setError("");
       const cleanUrl = trimmedUrl.split("?")[0];
-      await replayService.createFromUrl(teamId, cleanUrl, notes.trim() || undefined);
+      await replayService.createFromUrl(teamId, cleanUrl, notes.trim() || undefined, markReviewed);
       onAdded();
       onClose();
     } catch (err) {
@@ -100,7 +102,8 @@ const AddReplayModal: React.FC<AddReplayModalProps> = ({
       const result = await replayService.createManyFromUrls(
         teamId,
         cleanUrls,
-        (current, total) => setProgress({ current, total })
+        (current, total) => setProgress({ current, total }),
+        markReviewed
       );
 
       if (result.failed.length > 0) {
@@ -198,6 +201,20 @@ const AddReplayModal: React.FC<AddReplayModalProps> = ({
             />
           </div>
 
+          {/* Mark as reviewed */}
+          <div>
+            <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+              <input
+                type="checkbox"
+                checked={markReviewed}
+                onChange={(e) => setMarkReviewed(e.target.checked)}
+                disabled={loading}
+                className="h-4 w-4 rounded border-gray-300 text-brand-500 focus:ring-brand-500/30 dark:border-gray-600 dark:bg-gray-800"
+              />
+              Mark as reviewed
+            </label>
+          </div>
+
           {/* Error */}
           {error && (
             <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-500/20 dark:bg-red-500/10">
@@ -255,6 +272,20 @@ const AddReplayModal: React.FC<AddReplayModalProps> = ({
             <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
               Enter one replay URL per line
             </p>
+          </div>
+
+          {/* Mark all as reviewed */}
+          <div>
+            <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+              <input
+                type="checkbox"
+                checked={markReviewed}
+                onChange={(e) => setMarkReviewed(e.target.checked)}
+                disabled={loading}
+                className="h-4 w-4 rounded border-gray-300 text-brand-500 focus:ring-brand-500/30 dark:border-gray-600 dark:bg-gray-800"
+              />
+              Mark all as reviewed
+            </label>
           </div>
 
           {/* Info Box */}

--- a/frontend/src/components/team/GameCard.tsx
+++ b/frontend/src/components/team/GameCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ExternalLink, ChevronDown, MessageSquare, Save } from "lucide-react";
+import { ExternalLink, ChevronDown, MessageSquare, Save, CheckCircle2, Circle } from "lucide-react";
 import PokemonSprite from "../pokemon/PokemonSprite";
 import { cleanPokemonName } from "../../utils/pokemonNameUtils";
 import { getResultDisplay } from "../../utils/resultUtils";
@@ -13,10 +13,12 @@ interface GameCardProps {
   noteText: string;
   /** When true, render Mega Evolution column instead of Terastallization. */
   showMega?: boolean;
+  isTogglingReviewed?: boolean;
   onStartEditNote: (replay: Replay) => void;
   onCancelEditNote: () => void;
   onSaveNote: (id: number) => void;
   onNoteTextChange: (text: string) => void;
+  onToggleReviewed?: (replay: Replay) => void;
 }
 
 const typeEmojis: Record<string, string> = {
@@ -66,10 +68,12 @@ export default function GameCard({
   isSavingNote,
   noteText,
   showMega = false,
+  isTogglingReviewed = false,
   onStartEditNote,
   onCancelEditNote,
   onSaveNote,
   onNoteTextChange,
+  onToggleReviewed,
 }: GameCardProps) {
   const [isNoteExpanded, setIsNoteExpanded] = useState(false);
 
@@ -161,6 +165,26 @@ export default function GameCard({
               <ExternalLink className="h-3 w-3" />
               Replay
             </a>
+            {onToggleReviewed && (
+              <button
+                type="button"
+                onClick={() => onToggleReviewed(replay)}
+                disabled={isTogglingReviewed}
+                title={replay.reviewed ? "Mark as unreviewed" : "Mark as reviewed"}
+                className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs transition-colors disabled:opacity-50 ${
+                  replay.reviewed
+                    ? "bg-green-100 text-green-700 hover:bg-green-200 dark:bg-green-500/20 dark:text-green-400 dark:hover:bg-green-500/30"
+                    : "border border-gray-300 text-gray-500 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-400 dark:hover:bg-gray-700"
+                }`}
+              >
+                {replay.reviewed ? (
+                  <CheckCircle2 className="h-3 w-3" />
+                ) : (
+                  <Circle className="h-3 w-3" />
+                )}
+                {replay.reviewed ? "Reviewed" : "Mark Reviewed"}
+              </button>
+            )}
           </div>
         </div>
 

--- a/frontend/src/components/team/GameCard.tsx
+++ b/frontend/src/components/team/GameCard.tsx
@@ -182,7 +182,7 @@ export default function GameCard({
                 ) : (
                   <Circle className="h-3 w-3" />
                 )}
-                {replay.reviewed ? "Reviewed" : "Mark Reviewed"}
+                Reviewed
               </button>
             )}
           </div>

--- a/frontend/src/data/announcements.json
+++ b/frontend/src/data/announcements.json
@@ -1,5 +1,11 @@
 [
   {
+    "id": "2026-05-15-reviewed-replays",
+    "date": "2026-05-15",
+    "title": "Mark Replays as Reviewed",
+    "message": "You can now mark replays as 'Reviewed' on the Game by Game page. Each replay has a per-card toggle, there's a new filter dropdown (Reviewed / Unreviewed) that combines with the result filter, and the Add Replay modal has a checkbox to preemptively mark imports. There are also bulk Mark/Reset buttons at the bottom that act on whatever is currently visible after filters."
+  },
+  {
     "id": "2026-05-14-misc-fixes",
     "date": "2026-05-14",
     "title": "Miscellaneous Fixes",

--- a/frontend/src/hooks/useTeamStats.ts
+++ b/frontend/src/hooks/useTeamStats.ts
@@ -69,6 +69,21 @@ export const useTeamStats = (teamId: number | null, options: UseTeamStatsOptions
     loadStats(teamId);
   };
 
+  const updateReplaysLocal = (
+    updates: { id: number; changes: Partial<Replay> }[]
+  ) => {
+    if (updates.length === 0) return;
+    setStats((prev) => {
+      const map = new Map(updates.map((u) => [u.id, u.changes]));
+      return {
+        ...prev,
+        replays: prev.replays.map((r) =>
+          map.has(r.id) ? { ...r, ...map.get(r.id)! } : r
+        ),
+      };
+    });
+  };
+
   const resetStats = () => {
     setStats(DEFAULT_STATS);
     setError(null);
@@ -101,6 +116,7 @@ export const useTeamStats = (teamId: number | null, options: UseTeamStatsOptions
     lastUpdated,
     loadStats,
     refreshStats,
+    updateReplaysLocal,
     resetStats,
     isLoading: loading,
     hasError: !!error,

--- a/frontend/src/pages/Team/GameByGamePage.tsx
+++ b/frontend/src/pages/Team/GameByGamePage.tsx
@@ -12,7 +12,7 @@ import type { Replay } from "../../types";
 
 export default function GameByGamePage() {
   const { team, statsVersion } = useActiveTeam();
-  const { replays, loading, refreshStats } = useTeamStats(team?.id ?? null);
+  const { replays, loading, refreshStats, updateReplaysLocal } = useTeamStats(team?.id ?? null);
 
   const prevVersion = useRef(statsVersion);
   useEffect(() => {
@@ -60,8 +60,9 @@ export default function GameByGamePage() {
   const toggleReviewed = async (replay: Replay) => {
     try {
       setTogglingReviewedId(replay.id);
-      await replayService.update(replay.id, { reviewed: !replay.reviewed });
-      refreshStats();
+      const next = !replay.reviewed;
+      await replayService.update(replay.id, { reviewed: next });
+      updateReplaysLocal([{ id: replay.id, changes: { reviewed: next } }]);
     } catch (error) {
       console.error("Error toggling reviewed status:", error);
     } finally {
@@ -91,10 +92,11 @@ export default function GameByGamePage() {
     if (filteredReplays.length === 0 || bulkUpdating) return;
     try {
       setBulkUpdating(true);
+      const targets = filteredReplays.map((r) => r.id);
       await Promise.all(
-        filteredReplays.map((r) => replayService.update(r.id, { reviewed }))
+        targets.map((id) => replayService.update(id, { reviewed }))
       );
-      refreshStats();
+      updateReplaysLocal(targets.map((id) => ({ id, changes: { reviewed } })));
     } catch (error) {
       console.error("Error bulk updating reviewed status:", error);
     } finally {

--- a/frontend/src/pages/Team/GameByGamePage.tsx
+++ b/frontend/src/pages/Team/GameByGamePage.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect, useRef } from "react";
-import { Calendar, Filter, SortAsc, SortDesc } from "lucide-react";
+import { Calendar, Filter, SortAsc, SortDesc, CheckCircle2, RotateCcw } from "lucide-react";
 import PageMeta from "../../components/common/PageMeta";
 import { useActiveTeam } from "../../context/ActiveTeamContext";
 import { useTeamStats } from "../../hooks/useTeamStats";
@@ -25,10 +25,13 @@ export default function GameByGamePage() {
   const [sortBy, setSortBy] = useState("date");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
   const [filterResult, setFilterResult] = useState("all");
+  const [filterReviewed, setFilterReviewed] = useState("all");
   const [searchTags, setSearchTags] = useState<string[]>([]);
   const [editingNoteId, setEditingNoteId] = useState<number | null>(null);
   const [noteText, setNoteText] = useState("");
   const [savingNoteId, setSavingNoteId] = useState<number | null>(null);
+  const [togglingReviewedId, setTogglingReviewedId] = useState<number | null>(null);
+  const [bulkUpdating, setBulkUpdating] = useState(false);
 
   const startEditingNote = (replay: Replay) => {
     setEditingNoteId(replay.id);
@@ -54,6 +57,18 @@ export default function GameByGamePage() {
     }
   };
 
+  const toggleReviewed = async (replay: Replay) => {
+    try {
+      setTogglingReviewedId(replay.id);
+      await replayService.update(replay.id, { reviewed: !replay.reviewed });
+      refreshStats();
+    } catch (error) {
+      console.error("Error toggling reviewed status:", error);
+    } finally {
+      setTogglingReviewedId(null);
+    }
+  };
+
   const filteredReplays = useMemo(() => {
     return replays.filter((replay) => {
       if (searchTags.length > 0 && !matchesPokemonTags(getOpponentPokemonFromReplay(replay), searchTags)) {
@@ -62,9 +77,30 @@ export default function GameByGamePage() {
       if (filterResult !== "all" && replay.result !== filterResult) {
         return false;
       }
+      if (filterReviewed === "reviewed" && !replay.reviewed) {
+        return false;
+      }
+      if (filterReviewed === "unreviewed" && replay.reviewed) {
+        return false;
+      }
       return true;
     });
-  }, [replays, searchTags, filterResult]);
+  }, [replays, searchTags, filterResult, filterReviewed]);
+
+  const bulkSetReviewed = async (reviewed: boolean) => {
+    if (filteredReplays.length === 0 || bulkUpdating) return;
+    try {
+      setBulkUpdating(true);
+      await Promise.all(
+        filteredReplays.map((r) => replayService.update(r.id, { reviewed }))
+      );
+      refreshStats();
+    } catch (error) {
+      console.error("Error bulk updating reviewed status:", error);
+    } finally {
+      setBulkUpdating(false);
+    }
+  };
 
   const sortedReplays = useMemo(() => {
     return [...filteredReplays].sort((a, b) => {
@@ -94,6 +130,7 @@ export default function GameByGamePage() {
 
   const clearFilters = () => {
     setFilterResult("all");
+    setFilterReviewed("all");
     setSortBy("date");
     setSortOrder("desc");
     setSearchTags([]);
@@ -162,6 +199,19 @@ export default function GameByGamePage() {
             </select>
           </div>
 
+          {/* Reviewed Filter */}
+          <div className="flex items-center gap-2">
+            <select
+              value={filterReviewed}
+              onChange={(e) => setFilterReviewed(e.target.value)}
+              className="rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-800 focus:border-brand-400 focus:outline-none dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            >
+              <option value="all">All Reviewed Status</option>
+              <option value="reviewed">Reviewed Only</option>
+              <option value="unreviewed">Unreviewed Only</option>
+            </select>
+          </div>
+
           {/* Sort Controls */}
           <div className="flex items-center gap-2">
             <select
@@ -213,10 +263,12 @@ export default function GameByGamePage() {
               isSavingNote={savingNoteId === replay.id}
               noteText={noteText}
               showMega={isMegaRegulation(team?.regulation)}
+              isTogglingReviewed={togglingReviewedId === replay.id}
               onStartEditNote={startEditingNote}
               onCancelEditNote={cancelEditingNote}
               onSaveNote={saveNote}
               onNoteTextChange={setNoteText}
+              onToggleReviewed={toggleReviewed}
             />
           ))}
         </div>
@@ -245,6 +297,38 @@ export default function GameByGamePage() {
               <p className="text-2xl font-bold text-brand-600 dark:text-brand-400">{winRate}%</p>
               <p className="text-sm text-gray-500 dark:text-gray-400">Win Rate</p>
             </div>
+          </div>
+        </div>
+      )}
+
+      {/* Bulk Reviewed Actions */}
+      {replays.length > 0 && (
+        <div className="mt-6 border-t border-gray-200 pt-6 dark:border-gray-700">
+          <h4 className="mb-1 text-base font-semibold text-gray-800 dark:text-white/90">
+            Bulk update reviewed status
+          </h4>
+          <p className="mb-3 text-xs text-gray-500 dark:text-gray-400">
+            Applies to the {filteredReplays.length} replay{filteredReplays.length === 1 ? "" : "s"} currently visible after filters above.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => bulkSetReviewed(true)}
+              disabled={bulkUpdating || filteredReplays.length === 0}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-brand-500 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-600 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <CheckCircle2 className="h-4 w-4" />
+              {bulkUpdating ? "Updating..." : "Mark visible as Reviewed"}
+            </button>
+            <button
+              type="button"
+              onClick={() => bulkSetReviewed(false)}
+              disabled={bulkUpdating || filteredReplays.length === 0}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+            >
+              <RotateCcw className="h-4 w-4" />
+              {bulkUpdating ? "Updating..." : "Reset visible to Unreviewed"}
+            </button>
           </div>
         </div>
       )}

--- a/frontend/src/services/api/replayApi.ts
+++ b/frontend/src/services/api/replayApi.ts
@@ -8,8 +8,8 @@ export const replayApi = {
   getByTeamId: (teamId: number) =>
     apiClient.get(`/api/replays?teamId=${teamId}`) as Promise<Replay[]>,
 
-  createFromUrl: (teamId: number, url: string, notes = "") =>
-    apiClient.post(`/api/replays/from-url?teamId=${teamId}`, { url, notes }) as Promise<Replay>,
+  createFromUrl: (teamId: number, url: string, notes = "", reviewed = false) =>
+    apiClient.post(`/api/replays/from-url?teamId=${teamId}`, { url, notes, reviewed }) as Promise<Replay>,
 
   create: (teamId: number, data: Partial<Replay>) =>
     apiClient.post(`/api/replays?teamId=${teamId}`, data) as Promise<Replay>,

--- a/frontend/src/services/replayService.ts
+++ b/frontend/src/services/replayService.ts
@@ -23,9 +23,10 @@ export async function getById(id: number): Promise<Replay | null> {
 export async function createFromUrl(
   teamId: number,
   url: string,
-  notes?: string
+  notes?: string,
+  reviewed?: boolean
 ): Promise<Replay> {
-  return await replayApi.createFromUrl(teamId, url, notes);
+  return await replayApi.createFromUrl(teamId, url, notes, reviewed);
 }
 
 /**
@@ -56,6 +57,7 @@ export async function update(
     result?: string;
     opponent?: string;
     notes?: string;
+    reviewed?: boolean;
   }
 ): Promise<Replay> {
   return await replayApi.update(id, updates);
@@ -138,14 +140,15 @@ export async function getCountByTeamId(teamId: number): Promise<number> {
 export async function createManyFromUrls(
   teamId: number,
   urls: string[],
-  progressCallback?: (current: number, total: number) => void
+  progressCallback?: (current: number, total: number) => void,
+  reviewed?: boolean
 ): Promise<{ success: Replay[]; failed: { url: string; error: string }[] }> {
   const success: Replay[] = [];
   const failed: { url: string; error: string }[] = [];
 
   for (let i = 0; i < urls.length; i++) {
     try {
-      const replay = await createFromUrl(teamId, urls[i]);
+      const replay = await createFromUrl(teamId, urls[i], undefined, reviewed);
       success.push(replay);
       if (progressCallback) {
         progressCallback(i + 1, urls.length);

--- a/frontend/src/types/replay.ts
+++ b/frontend/src/types/replay.ts
@@ -21,6 +21,7 @@ export interface Replay {
   gameNumber: number | null;
   matchId: number | null;
   notes: string;
+  reviewed: boolean;
   battleData: BattleData | null;
   battleLog: string | null;
   createdAt: string;


### PR DESCRIPTION
## Summary
- Add a persistent `reviewed` boolean to replays (default `false`) so users can triage their backlog ("show me losses I haven't reviewed yet").
- Surface it in four places: a per-card toggle on each `GameCard`, a new "Reviewed Only / Unreviewed Only" filter dropdown on the Game by Game page, a "Mark as reviewed" checkbox in the Add Replay modal (both single and bulk modes), and "Mark visible as Reviewed" / "Reset visible to Unreviewed" buttons at the bottom of the page that operate on the currently filtered list.

## Implementation notes
- Backend: new `Boolean reviewed` column on `Replay` with `@ColumnDefault("false")` so existing rows backfill cleanly. Threaded through `CreateFromUrlRequest`, `UpdateRequest`, `Response`, and `Summary` DTOs (MapStruct auto-maps). `ReplayService.updateReplay` gets a null-check block matching the existing partial-update pattern. `POST /from-url` applies `reviewed: true` via a follow-up `updateReplay` when the client opts in.
- Frontend: bulk actions fan out as `Promise.all` over the filtered list rather than introducing a new bulk endpoint, matching the existing pattern used elsewhere in the app.

## Test plan
- [ ] `mvn test` passes (137/137 locally).
- [ ] `npx tsc --noEmit` passes locally.
- [ ] Single-mode modal: tick "Mark as reviewed" -> new card shows the green Reviewed badge.
- [ ] Bulk-mode modal: tick "Mark all as reviewed" -> all imported cards show as Reviewed.
- [ ] Per-card toggle flips state and persists after a page refresh.
- [ ] Filter dropdown narrows the list correctly; combining with Result=Wins composes as expected.
- [ ] Bulk buttons act on the filtered/visible subset only; help text reflects the correct count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)