### PR TITLE
feat: Champions (Gen 10) calc support + KO-colored notes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@smogon/calc": "^0.10.0",
+        "@smogon/calc": "^0.11.0",
         "axios": "^1.7.9",
         "clsx": "^2.1.1",
         "lucide-react": "^0.468.0",
@@ -1672,9 +1672,9 @@
       ]
     },
     "node_modules/@smogon/calc": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@smogon/calc/-/calc-0.10.0.tgz",
-      "integrity": "sha512-VmtTDVjF4z1Yzx1QN7NbsEcRLBAZGv/NVlb1ZK1//uppNmIg3Iqp7hDERGSM0FlmdogPEqw7iqY/3RuMSYPkmw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@smogon/calc/-/calc-0.11.0.tgz",
+      "integrity": "sha512-ixP+IgQhI12R68FXxyt8+f4EZM/jdqBXZ2oCKu5zuUWXls4kYbIVdgE7t6+pkn/y6VxU+cXJhRgMkiU7wG8JHQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.14.2"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@smogon/calc": "^0.10.0",
+    "@smogon/calc": "^0.11.0",
     "axios": "^1.7.9",
     "clsx": "^2.1.1",
     "lucide-react": "^0.468.0",

--- a/frontend/src/components/calc/GenerationPicker.tsx
+++ b/frontend/src/components/calc/GenerationPicker.tsx
@@ -1,10 +1,5 @@
 const GENS = [
-  { num: 3, label: "III" },
-  { num: 4, label: "IV" },
-  { num: 5, label: "V" },
-  { num: 6, label: "VI" },
-  { num: 7, label: "VII" },
-  { num: 8, label: "VIII" },
+  { num: 10, label: "Champions" },
   { num: 9, label: "IX" },
 ];
 
@@ -13,26 +8,22 @@ interface GenerationPickerProps {
   onChange: (gen: number) => void;
 }
 
-const GenerationPicker: React.FC<GenerationPickerProps> = ({ value = 9, onChange }) => {
+const GenerationPicker: React.FC<GenerationPickerProps> = ({ value = 10, onChange }) => {
   return (
     <div className="flex items-center gap-1">
       <span className="text-xs text-gray-400 mr-1">Gen:</span>
       {GENS.map((g) => {
         const isActive = g.num === value;
-        const isDisabled = g.num !== 9;
         return (
           <button
             key={g.num}
-            onClick={() => !isDisabled && onChange(g.num)}
-            disabled={isDisabled}
+            onClick={() => onChange(g.num)}
             className={`px-2 py-0.5 text-xs rounded transition-colors ${
               isActive
                 ? "bg-emerald-600 text-white"
-                : isDisabled
-                  ? "bg-slate-800 text-slate-600 cursor-not-allowed"
-                  : "bg-slate-700 text-gray-300 hover:bg-slate-600"
+                : "bg-slate-700 text-gray-300 hover:bg-slate-600"
             }`}
-            title={isDisabled ? "Coming soon" : `Generation ${g.label}`}
+            title={`Generation ${g.label}`}
           >
             {g.label}
           </button>

--- a/frontend/src/components/calc/MoveResults.tsx
+++ b/frontend/src/components/calc/MoveResults.tsx
@@ -20,21 +20,24 @@ const MoveResults: React.FC<MoveResultsProps> = ({
   onSelectIndex,
   isActive = true,
 }) => {
-  if (!results || results.length === 0) {
-    return (
-      <div className="space-y-1">
-        {[0, 1, 2, 3].map((i) => (
-          <div key={i} className="flex items-center gap-2 px-2 py-1 rounded bg-gray-100 dark:bg-slate-800/50">
-            <span className="text-gray-400 dark:text-gray-600 text-xs">-</span>
-          </div>
-        ))}
-      </div>
-    );
+  // Always render move names, even when calc failed (e.g. Mega forms not in
+  // Smogon's Gen 9 dex). The damage range just stays blank in that case.
+  const filledMoves = [...moves];
+  while (filledMoves.length < 4) {
+    filledMoves.push({ name: "", crit: false, bpOverride: null });
   }
+
+  // Map move index (in full state.moves) to its result index (results only
+  // contains entries for moves with names — see useDamageCalc filter).
+  let resultCursor = 0;
+  const resultByMoveIndex: (ReturnType<typeof calculate> | null)[] = filledMoves.map((m) => {
+    if (!m.name) return null;
+    return results?.[resultCursor++] ?? null;
+  });
 
   return (
     <div className="space-y-1">
-      {moves.map((move, i) => {
+      {filledMoves.map((move, i) => {
         if (!move.name) {
           return (
             <div key={i} className="flex items-center gap-2 px-2 py-1 rounded bg-gray-100 dark:bg-slate-800/50">
@@ -43,7 +46,7 @@ const MoveResults: React.FC<MoveResultsProps> = ({
           );
         }
 
-        const result = results[i];
+        const result = resultByMoveIndex[i];
         const range = result ? formatDamageRange(result) : "";
         const colorClass = getDamageColor(result);
         const isSelected = selectedIndex === i && isActive;

--- a/frontend/src/components/calc/PokemonPanel.tsx
+++ b/frontend/src/components/calc/PokemonPanel.tsx
@@ -21,6 +21,7 @@ import {
   applyTeraFormeChange,
   hasLockedTeraType,
   CHAMPIONS_GEN,
+  getFormeGroup,
 } from "../../utils/calcUtils";
 import { useTheme } from "../../context/ThemeContext";
 import { SETDEX_GEN9 } from "../../data/setdex-gen9";
@@ -324,6 +325,30 @@ const PokemonPanel: React.FC<PokemonPanelProps> = ({
         }}
         menuPlacement="auto"
       />
+
+      {/* Forme selector (only for species with ability-driven in-battle forme changes) */}
+      {(() => {
+        const formeGroup = getFormeGroup(state.species);
+        if (!formeGroup) return null;
+        const current = formeGroup.find((f) => f.species === state.species) ?? formeGroup[0];
+        return (
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-gray-500">Forme:</span>
+            <div className="flex-1">
+              <Select<SelectOption>
+                value={{ value: current.species, label: current.label }}
+                onChange={(opt: SingleValue<SelectOption>) => {
+                  if (opt) onChange({ species: opt.value });
+                }}
+                options={formeGroup.map((f) => ({ value: f.species, label: f.label }))}
+                styles={compactStyles as any}
+                isSearchable={false}
+                menuPlacement="auto"
+              />
+            </div>
+          </div>
+        );
+      })()}
 
       {/* Types display */}
       {speciesInfo && (

--- a/frontend/src/components/calc/PokemonPanel.tsx
+++ b/frontend/src/components/calc/PokemonPanel.tsx
@@ -12,6 +12,7 @@ import {
   NATURES_LIST,
   STATUS_OPTIONS,
   setdexToState,
+  setdex10ToState,
   getSelectStyles,
   getCompactSelectStyles,
   normalizeSpeciesName,
@@ -19,9 +20,11 @@ import {
   getTeraDefaults,
   applyTeraFormeChange,
   hasLockedTeraType,
+  CHAMPIONS_GEN,
 } from "../../utils/calcUtils";
 import { useTheme } from "../../context/ThemeContext";
 import { SETDEX_GEN9 } from "../../data/setdex-gen9";
+import { SETDEX_GEN10 } from "../../data/setdex-gen10";
 import type { PokemonState, MoveState } from "../../types";
 import type { PokemonData as PokemonFromPaste } from "../../services/pokepasteService";
 
@@ -51,6 +54,7 @@ interface PokemonPanelProps {
   side: "p1" | "p2";
   weather?: string;
   terrain?: string;
+  gen: number;
 }
 
 const PokemonPanel: React.FC<PokemonPanelProps> = ({
@@ -61,7 +65,9 @@ const PokemonPanel: React.FC<PokemonPanelProps> = ({
   side,
   weather = "",
   terrain = "",
+  gen,
 }) => {
+  const isChampions = gen === CHAMPIONS_GEN;
   const { theme } = useTheme();
   const dark = theme === "dark";
   const selectStyles = useMemo(() => getSelectStyles(dark), [dark]);
@@ -70,7 +76,7 @@ const PokemonPanel: React.FC<PokemonPanelProps> = ({
   // Build species + set options: setdex Pokemon with sets, then all remaining species
   const speciesOptions = useMemo((): SetdexGroup[] => {
     const allSpecies = getSpeciesList();
-    const setdexEntries = SETDEX_GEN9 as Record<string, Record<string, Record<string, unknown>>>;
+    const setdexEntries = (isChampions ? SETDEX_GEN10 : SETDEX_GEN9) as Record<string, Record<string, Record<string, unknown>>>;
     const setdexNames = new Set(Object.keys(setdexEntries));
 
     // Pokemon with setdex entries (grouped by Pokemon, each set is an option)
@@ -97,7 +103,7 @@ const PokemonPanel: React.FC<PokemonPanelProps> = ({
       }));
 
     return [...withSets, { label: "Other Pokemon", options: withoutSets }];
-  }, []);
+  }, [isChampions]);
 
   // Current selected value for species select
   const selectedSpeciesOption = useMemo(() => {
@@ -180,7 +186,9 @@ const PokemonPanel: React.FC<PokemonPanelProps> = ({
 
     // If it's a setdex entry (has set data)
     if (option.set) {
-      const setData = setdexToState(option.set as Parameters<typeof setdexToState>[0]);
+      const setData = isChampions
+        ? setdex10ToState(option.set as Parameters<typeof setdex10ToState>[0])
+        : setdexToState(option.set as Parameters<typeof setdexToState>[0]);
       const species = normalizeSpeciesName(option.pokemon);
       // Default to first ability if setdex doesn't specify one
       if (!setData.ability) {
@@ -440,9 +448,11 @@ const PokemonPanel: React.FC<PokemonPanelProps> = ({
         species={state.species}
         evs={state.evs}
         ivs={state.ivs}
+        sps={state.sps}
         boosts={state.boosts}
         nature={state.nature}
         level={state.level}
+        gen={gen}
         boostedStat={state.boostedStat}
         onChange={onChange}
       />

--- a/frontend/src/components/calc/PokemonPanel.tsx
+++ b/frontend/src/components/calc/PokemonPanel.tsx
@@ -253,7 +253,8 @@ const PokemonPanel: React.FC<PokemonPanelProps> = ({
       changes.moves!.push({ name: "", crit: false, bpOverride: null });
     }
 
-    changes.evs = {
+    // Pokepaste still labels the line "EVs:" in Champions, but the numbers are SPs.
+    const pasteStatValues = {
       hp: mon.evs?.HP ?? mon.evs?.hp ?? 0,
       atk: mon.evs?.Atk ?? mon.evs?.atk ?? 0,
       def: mon.evs?.Def ?? mon.evs?.def ?? 0,
@@ -262,14 +263,22 @@ const PokemonPanel: React.FC<PokemonPanelProps> = ({
       spe: mon.evs?.Spe ?? mon.evs?.spe ?? 0,
     };
 
-    changes.ivs = {
-      hp: mon.ivs?.HP ?? mon.ivs?.hp ?? 31,
-      atk: mon.ivs?.Atk ?? mon.ivs?.atk ?? 31,
-      def: mon.ivs?.Def ?? mon.ivs?.def ?? 31,
-      spa: mon.ivs?.SpA ?? mon.ivs?.spa ?? 31,
-      spd: mon.ivs?.SpD ?? mon.ivs?.spd ?? 31,
-      spe: mon.ivs?.Spe ?? mon.ivs?.spe ?? 31,
-    };
+    if (isChampions) {
+      changes.evs = { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0 };
+      changes.ivs = { hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31 };
+      changes.sps = pasteStatValues;
+    } else {
+      changes.evs = pasteStatValues;
+      changes.ivs = {
+        hp: mon.ivs?.HP ?? mon.ivs?.hp ?? 31,
+        atk: mon.ivs?.Atk ?? mon.ivs?.atk ?? 31,
+        def: mon.ivs?.Def ?? mon.ivs?.def ?? 31,
+        spa: mon.ivs?.SpA ?? mon.ivs?.spa ?? 31,
+        spd: mon.ivs?.SpD ?? mon.ivs?.spd ?? 31,
+        spe: mon.ivs?.Spe ?? mon.ivs?.spe ?? 31,
+      };
+      changes.sps = { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0 };
+    }
 
     // Auto-compute boostedStat if Booster Energy + Proto/Quark
     const ability = changes.ability || "";

--- a/frontend/src/components/calc/StatTable.tsx
+++ b/frontend/src/components/calc/StatTable.tsx
@@ -4,28 +4,43 @@ import {
   calcFinalStat,
   getNatureInfo,
   getBaseStats,
+  spsToEvs,
+  CHAMPIONS_GEN,
 } from "../../utils/calcUtils";
 import type { StatSpread, BoostSpread } from "../../types";
 import type { BoostedStat } from "../../utils/calcUtils";
 
 const BOOST_OPTIONS = [-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6];
 
+const SP_MAX_PER_STAT = 32;
+const SP_TOTAL_MAX = 66;
+
 interface StatTableProps {
   species: string;
   evs: StatSpread;
   ivs: StatSpread;
+  sps: StatSpread;
   boosts: BoostSpread;
   nature: string;
   level: number;
+  gen: number;
   boostedStat: BoostedStat | null;
-  onChange: (changes: Partial<{ evs: StatSpread; ivs: StatSpread; boosts: BoostSpread; boostedStat: BoostedStat | null }>) => void;
+  onChange: (changes: Partial<{ evs: StatSpread; ivs: StatSpread; sps: StatSpread; boosts: BoostSpread; boostedStat: BoostedStat | null }>) => void;
 }
 
-const StatTable: React.FC<StatTableProps> = ({ species, evs, ivs, boosts, nature, level, boostedStat, onChange }) => {
+const StatTable: React.FC<StatTableProps> = ({ species, evs, ivs, sps, boosts, nature, level, gen, boostedStat, onChange }) => {
   const baseStats = getBaseStats(species);
   const natureInfo = getNatureInfo(nature);
+  const isChampions = gen === CHAMPIONS_GEN;
   const evTotal = Object.values(evs).reduce((sum, v) => sum + v, 0);
   const evRemaining = 510 - evTotal;
+  const spTotal = Object.values(sps).reduce((sum, v) => sum + v, 0);
+  const spRemaining = SP_TOTAL_MAX - spTotal;
+
+  // For stat-display math in Champions mode, project SPs -> EV-equivalents
+  // and pin IVs to 31 (the engine ignores the editable IV inputs in this mode).
+  const displayEvs = isChampions ? spsToEvs(sps) : evs;
+  const displayIvs = isChampions ? { hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31 } : ivs;
 
   const handleEvChange = (stat: keyof StatSpread, val: string) => {
     const num = Math.min(252, Math.max(0, parseInt(val) || 0));
@@ -37,18 +52,27 @@ const StatTable: React.FC<StatTableProps> = ({ species, evs, ivs, boosts, nature
     onChange({ ivs: { ...ivs, [stat]: num } });
   };
 
+  const handleSpChange = (stat: keyof StatSpread, val: string) => {
+    const num = Math.min(SP_MAX_PER_STAT, Math.max(0, parseInt(val) || 0));
+    onChange({ sps: { ...sps, [stat]: num } });
+  };
+
   const handleBoostChange = (stat: keyof BoostSpread, val: string) => {
     onChange({ boosts: { ...boosts, [stat]: parseInt(val) } });
   };
 
+  const gridCols = isChampions
+    ? "grid-cols-[3rem_2.5rem_3rem_3rem_1.5rem_3rem]"
+    : "grid-cols-[3rem_2.5rem_2.5rem_3rem_3rem_1.5rem_3rem]";
+
   return (
     <div className="text-xs">
       {/* Header */}
-      <div className="grid grid-cols-[3rem_2.5rem_2.5rem_3rem_3rem_1.5rem_3rem] gap-0.5 mb-0.5">
+      <div className={`grid ${gridCols} gap-0.5 mb-0.5`}>
         <div className="text-gray-500 font-medium"></div>
         <div className="text-gray-500 font-medium text-center">Base</div>
-        <div className="text-gray-500 font-medium text-center">IV</div>
-        <div className="text-gray-500 font-medium text-center">EV</div>
+        {!isChampions && <div className="text-gray-500 font-medium text-center">IV</div>}
+        <div className="text-gray-500 font-medium text-center">{isChampions ? "SP" : "EV"}</div>
         <div className="text-gray-500 font-medium text-center">+/-</div>
         <div className="text-gray-500 font-medium text-center" title="Booster Energy / Proto / Quark">BE</div>
         <div className="text-gray-500 font-medium text-center">Total</div>
@@ -58,7 +82,7 @@ const StatTable: React.FC<StatTableProps> = ({ species, evs, ivs, boosts, nature
       {STAT_NAMES.map((stat) => {
         const base = baseStats ? baseStats[stat] : 0;
         const finalStat = baseStats
-          ? calcFinalStat(stat, base, ivs[stat], evs[stat], level, nature)
+          ? calcFinalStat(stat, base, displayIvs[stat], displayEvs[stat], level, nature)
           : 0;
 
         const isNaturePlus = natureInfo.plus === stat;
@@ -68,7 +92,7 @@ const StatTable: React.FC<StatTableProps> = ({ species, evs, ivs, boosts, nature
         return (
           <div
             key={stat}
-            className="grid grid-cols-[3rem_2.5rem_2.5rem_3rem_3rem_1.5rem_3rem] gap-0.5 mb-0.5"
+            className={`grid ${gridCols} gap-0.5 mb-0.5`}
           >
             {/* Stat label */}
             <div
@@ -86,26 +110,39 @@ const StatTable: React.FC<StatTableProps> = ({ species, evs, ivs, boosts, nature
               {base || "-"}
             </div>
 
-            {/* IV */}
-            <input
-              type="number"
-              min={0}
-              max={31}
-              value={ivs[stat]}
-              onChange={(e) => handleIvChange(stat, e.target.value)}
-              className="bg-white border border-gray-300 text-gray-800 dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200 rounded text-center w-full px-0.5 py-0.5 focus:border-emerald-500 focus:outline-none"
-            />
+            {/* IV (hidden in Champions) */}
+            {!isChampions && (
+              <input
+                type="number"
+                min={0}
+                max={31}
+                value={ivs[stat]}
+                onChange={(e) => handleIvChange(stat, e.target.value)}
+                className="bg-white border border-gray-300 text-gray-800 dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200 rounded text-center w-full px-0.5 py-0.5 focus:border-emerald-500 focus:outline-none"
+              />
+            )}
 
-            {/* EV */}
-            <input
-              type="number"
-              min={0}
-              max={252}
-              step={4}
-              value={evs[stat]}
-              onChange={(e) => handleEvChange(stat, e.target.value)}
-              className="bg-white border border-gray-300 text-gray-800 dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200 rounded text-center w-full px-0.5 py-0.5 focus:border-emerald-500 focus:outline-none"
-            />
+            {/* EV / SP */}
+            {isChampions ? (
+              <input
+                type="number"
+                min={0}
+                max={SP_MAX_PER_STAT}
+                value={sps[stat]}
+                onChange={(e) => handleSpChange(stat, e.target.value)}
+                className="bg-white border border-gray-300 text-gray-800 dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200 rounded text-center w-full px-0.5 py-0.5 focus:border-emerald-500 focus:outline-none"
+              />
+            ) : (
+              <input
+                type="number"
+                min={0}
+                max={252}
+                step={4}
+                value={evs[stat]}
+                onChange={(e) => handleEvChange(stat, e.target.value)}
+                className="bg-white border border-gray-300 text-gray-800 dark:bg-slate-700 dark:border-slate-600 dark:text-gray-200 rounded text-center w-full px-0.5 py-0.5 focus:border-emerald-500 focus:outline-none"
+              />
+            )}
 
             {/* Boost */}
             {hasBoost ? (
@@ -149,12 +186,18 @@ const StatTable: React.FC<StatTableProps> = ({ species, evs, ivs, boosts, nature
         );
       })}
 
-      {/* EV total */}
+      {/* Total counter */}
       <div className="flex justify-between mt-1 pt-1 border-t border-gray-200 dark:border-slate-700">
-        <span className="text-gray-500">EVs:</span>
-        <span className={evTotal > 510 ? "text-red-400" : "text-gray-500 dark:text-gray-400"}>
-          {evTotal}/510 ({evRemaining >= 0 ? evRemaining : 0} left)
-        </span>
+        <span className="text-gray-500">{isChampions ? "SPs:" : "EVs:"}</span>
+        {isChampions ? (
+          <span className={spTotal > SP_TOTAL_MAX ? "text-red-400" : "text-gray-500 dark:text-gray-400"}>
+            {spTotal}/{SP_TOTAL_MAX} ({spRemaining >= 0 ? spRemaining : 0} left)
+          </span>
+        ) : (
+          <span className={evTotal > 510 ? "text-red-400" : "text-gray-500 dark:text-gray-400"}>
+            {evTotal}/510 ({evRemaining >= 0 ? evRemaining : 0} left)
+          </span>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/team/PokemonNoteCard.tsx
+++ b/frontend/src/components/team/PokemonNoteCard.tsx
@@ -3,6 +3,21 @@ import { Save, MessageSquare, ChevronDown, X } from "lucide-react";
 import PokemonSprite from "../pokemon/PokemonSprite";
 import type { TeamMember } from "../../types";
 
+const CALC_BG_DEFAULT =
+  "border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-white/[0.03]";
+const CALC_BG_BY_KO: Record<string, string> = {
+  ohko: "border-red-300 bg-red-50 dark:border-red-500/40 dark:bg-red-500/10",
+  "2hko": "border-yellow-300 bg-yellow-50 dark:border-yellow-500/40 dark:bg-yellow-500/10",
+  "3hko": "border-green-300 bg-green-50 dark:border-green-500/40 dark:bg-green-500/10",
+};
+
+function calcBg(calc: string): string {
+  if (/\bOHKO\b/.test(calc)) return CALC_BG_BY_KO.ohko;
+  if (/\b2HKO\b/.test(calc)) return CALC_BG_BY_KO["2hko"];
+  if (/\b3HKO\b/.test(calc)) return CALC_BG_BY_KO["3hko"];
+  return CALC_BG_DEFAULT;
+}
+
 interface PokemonNoteCardProps {
   member: TeamMember;
   isEditingNote: boolean;
@@ -163,7 +178,7 @@ const PokemonNoteCard: React.FC<PokemonNoteCardProps> = ({
             {member.calcs?.map((calc, index) => (
               <div
                 key={index}
-                className="group/calc flex items-start gap-2 rounded border border-gray-200 bg-gray-50 px-2 py-1.5 dark:border-gray-700 dark:bg-white/[0.03]"
+                className={`group/calc flex items-start gap-2 rounded border px-2 py-1.5 ${calcBg(calc)}`}
               >
                 <span className="flex-1 break-words text-sm text-gray-700 dark:text-gray-300">
                   {calc}

--- a/frontend/src/context/CalcStateContext.tsx
+++ b/frontend/src/context/CalcStateContext.tsx
@@ -10,6 +10,7 @@ interface CalcSnapshot {
   selectedP2Move: number;
   activeSide: "p1" | "p2";
   teamPokemon: PokemonFromPaste[];
+  gen: number;
 }
 
 interface CalcStateContextType {

--- a/frontend/src/data/announcements.json
+++ b/frontend/src/data/announcements.json
@@ -1,5 +1,11 @@
 [
   {
+    "id": "2026-05-16-champions-calc-and-notes",
+    "date": "2026-05-16",
+    "title": "Pokemon Champions in the Calculator + Color-Coded Notes",
+    "message": "The calculator now supports Pokemon Champions! Champions is the new default gen — IVs are locked at 31 and the EV column is replaced with Stat Points (max 32 per stat, 66 total). The Champions setdex is pulled from Nerd of Now's latest update, so picking a team mon from your paste in Champions auto-loads the SPs the same way EVs do in Gen IX. There's also a new Forme dropdown that appears for Aegislash, Mimikyu, Palafin, Eiscue, Morpeko, Wishiwashi, Cramorant, and Minior — flip between formes without re-searching. Lastly: saved calcs on the Pokemon Notes page are now color-coded by KO chance (red OHKO / yellow 2HKO / green 3HKO) so you can scan them faster."
+  },
+  {
     "id": "2026-05-15-reviewed-replays",
     "date": "2026-05-15",
     "title": "Mark Replays as Reviewed",

--- a/frontend/src/data/setdex-gen10.ts
+++ b/frontend/src/data/setdex-gen10.ts
@@ -1,0 +1,1475 @@
+export const SETDEX_GEN10 = {
+    "Venusaur": {
+        "Sun Sleep Offense": {
+            "sps": {
+                "hp": 2,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32
+            },
+            "nature": "Modest",
+            "ability": "Chlorophyll",
+            "item": "Focus Sash",
+            "moves": [
+                "Leaf Storm",
+                "Sludge Bomb",
+                "Earth Power",
+                "Sleep Powder"
+            ]
+        },
+        "Bulky Mega Offense": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 2
+            },
+            "nature": "Modest",
+            "ability": "Chlorophyll",
+            "item": "Venusaurite",
+            "moves": [
+                "Energy Ball",
+                "Sludge Bomb",
+                "Earth Power",
+                "Leaf Storm"
+            ]
+        },
+    },
+    "Charizard": {
+        "Fast Offense Mega Y": {
+            "sps": {
+                "hp": 2,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32
+            },
+            "nature": "Modest",
+            "ability": "Solar Power",
+            "item": "Charizardite Y",
+            "moves": [
+                "Heat Wave",
+                "Weather Ball",
+                "Solar Beam",
+                "Air Slash"
+            ]
+        },
+        "DD Mega X": {
+            "sps": {
+                "hp": 2,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 32
+            },
+            "nature": "Adamant",
+            "ability": "Blaze",
+            "item": "Charizardite X",
+            "moves": [
+                "Flare Blitz",
+                "Dragon Claw",
+                "Thunder Punch",
+                "Dragon Dance"
+            ]
+        },
+    },
+    "Blastoise": {
+        "Mega Attacker under Tailwind": {
+            "sps": {
+                "hp": 2,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32
+            },
+            "nature": "Modest",
+            "ability": "Rain Dish",
+            "item": "Blastoisinite",
+            "moves": [
+                "Water Spout",
+                "Aura Sphere",
+                "Dark Pulse",
+                "Ice Beam"
+            ]
+        },
+    },
+    "Clefable": {
+        "Physically Defensive Sitrus": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 32,
+                "sa": 0,
+                "sd": 2,
+                "sp": 0
+            },
+            "nature": "Bold",
+            "ability": "Unaware",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Moonblast",
+                "Icy Wind",
+                "Follow Me",
+                "Helping Hand"
+            ]
+        },
+    },
+    "Gengar": {
+        "Offensive Mega": {
+            "sps": {
+                "hp": 2,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32
+            },
+            "nature": "Timid",
+            "item": "Gengarite",
+            "moves": [
+                "Shadow Ball",
+                "Sludge Bomb",
+                "Icy Wind",
+                "Protect"
+            ]
+        },
+        "Bulkier Perish Mega": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 9,
+                "sa": 1,
+                "sd": 1,
+                "sp": 23
+            },
+            "nature": "Timid",
+            "item": "Gengarite",
+            "moves": [
+                "Shadow Ball",
+                "Sludge Bomb",
+                "Perish Song",
+                "Disable"
+            ]
+        },
+        "Sash Offense": {
+            "sps": {
+                "hp": 2,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32
+            },
+            "nature": "Timid",
+            "item": "Focus Sash",
+            "moves": [
+                "Shadow Ball",
+                "Sludge Bomb",
+                "Icy Wind",
+                "Protect"
+            ]
+        },
+    },
+    "Kangaskhan": {
+        "Fast Mega": {
+            "sps": {
+                "hp": 2,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 32
+            },
+            "nature": "Jolly",
+            "item": "Kangaskhanite",
+            "moves": [
+                "Fake Out",
+                "Double-Edge",
+                "Sucker Punch",
+                "Drain Punch"
+            ]
+        },
+        "Bulky Max Attack Mega": {
+            "sps": {
+                "hp": 32,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 2
+            },
+            "nature": "Adamant",
+            "item": "Kangaskhanite",
+            "moves": [
+                "Fake Out",
+                "Double-Edge",
+                "Sucker Punch",
+                "Drain Punch"
+            ]
+        },
+    },
+    "Starmie": {
+        "Rain Offense Mega": {
+            "sps": {
+                "hp": 2,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 32
+            },
+            "nature": "Jolly",
+            "ability": "Natural Cure",
+            "item": "Starminite",
+            "moves": [
+                "Liquidation",
+                "Zen Headbutt",
+                "Ice Spinner",
+                "Aqua Jet"
+            ]
+        },
+    },
+    "Gyarados": {
+        "Max Speed DD Mega": {
+            "sps": {
+                "hp": 2,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 32
+            },
+            "nature": "Jolly",
+            "item": "Gyaradosite",
+            "moves": [
+                "Waterfall",
+                "Crunch",
+                "Earthquake",
+                "Dragon Dance"
+            ]
+        },
+        "Sitrus Disruption": {
+            "sps": {
+                "hp": 32,
+                "at": 32,
+                "df": 2,
+                "sa": 0,
+                "sd": 0,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Waterfall",
+                "Ice Fang",
+                "Taunt",
+                "Thunder Wave"
+            ]
+        },
+    },
+    "Aerodactyl": {
+        "Sash Tailwind Support": {
+            "sps": {
+                "hp": 2,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 32
+            },
+            "nature": "Jolly",
+            "item": "Focus Sash",
+            "moves": [
+                "Rock Slide",
+                "Dual Wingbeat",
+                "Tailwind",
+                "Taunt"
+            ]
+        },
+        "Offensive Mega": {
+            "sps": {
+                "hp": 2,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 32
+            },
+            "nature": "Jolly",
+            "item": "Aerodactylite",
+            "moves": [
+                "Rock Slide",
+                "Dual Wingbeat",
+                "Ice Fang",
+                "Iron Head"
+            ]
+        },
+    },
+    "Dragonite": {
+        "Special Rain Mega": {
+            "sps": {
+                "hp": 2,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32
+            },
+            "nature": "Modest",
+            "item": "Dragoninite",
+            "moves": [
+                "Draco Meteor",
+                "Hurricane",
+                "Extreme Speed",
+                "Thunder"
+            ]
+        },
+    },
+    "Meganium": {
+        "Bulky Offense Mega": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 2
+            },
+            "nature": "Modest",
+            "item": "Meganiumite",
+            "moves": [
+                "Solar Beam",
+                "Dazzling Gleam",
+                "Weather Ball",
+                "Earth Power"
+            ]
+        },
+    },
+    "Politoed": {
+        "Scarf Offense": {
+            "sps": {
+                "hp": 2,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32
+            },
+            "nature": "Timid",
+            "item": "Choice Scarf",
+            "moves": [
+                "Weather Ball",
+                "Icy Wind",
+                "Muddy Water",
+                "Ice Beam"
+            ]
+        },
+        "Bulky Support": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 32,
+                "sa": 0,
+                "sd": 2,
+                "sp": 0
+            },
+            "nature": "Calm",
+            "item": "Leftovers",
+            "moves": [
+                "Weather Ball",
+                "Icy Wind",
+                "Helping Hand",
+                "Perish Song"
+            ]
+        },
+    },
+    "Scizor": {
+        "Offense Mega on Rain": {
+            "sps": {
+                "hp": 32,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 2,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "item": "Scizorite",
+            "moves": [
+                "Bullet Punch",
+                "Bug Bite",
+                "Close Combat",
+                "Swords Dance"
+            ]
+        },
+    },
+    "Tyranitar": {
+        "Scarf Offense": {
+            "sps": {
+                "hp": 2,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 32
+            },
+            "nature": "Jolly",
+            "item": "Choice Scarf",
+            "moves": [
+                "Rock Slide",
+                "Knock Off",
+                "Ice Punch",
+                "Low Kick"
+            ]
+        },
+        "Bulky Max Attack Mega": {
+            "sps": {
+                "hp": 32,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 2,
+                "sp": 0
+            },
+            "nature": "Adamant",
+            "item": "Tyranitarite",
+            "moves": [
+                "Rock Slide",
+                "Knock Off",
+                "High Horsepower",
+                "Low Kick"
+            ]
+        },
+        "DD Max Speed Mega": {
+            "sps": {
+                "hp": 2,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 32
+            },
+            "nature": "Jolly",
+            "item": "Tyranitarite",
+            "moves": [
+                "Rock Slide",
+                "Knock Off",
+                "Dragon Dance",
+                "Protect"
+            ]
+        },
+    },
+    "Pelipper": {
+        "Sash Tailwind Offense": {
+            "level": 50,
+            "sps": {
+                "hp": 2,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32
+            },
+            "nature": "Modest",
+            "item": "Focus Sash",
+            "moves": [
+                "Weather Ball",
+                "Hurricane",
+                "Muddy Water",
+                "Tailwind",
+            ],
+        },
+        "Max Speed Scarf": {
+            "sps": {
+                "hp": 2,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Timid",
+            "item": "Choice Scarf",
+            "moves": [
+                "Weather Ball",
+                "Hurricane",
+                "Icy Wind",
+                "Muddy Water",
+            ],
+        },
+    },
+    "Gardevoir": {
+        "Bulky TR Mega": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 2,
+                "sa": 32,
+                "sd": 0,
+                "sp": 0,
+            },
+            "nature": "Modest",
+            "item": "Gardevoirite",
+            "moves": [
+                "Hyper Voice",
+                "Psyshock",
+                "Psychic",
+                "Trick Room",
+            ],
+        },
+        "Timid Scarf": {
+            "sps": {
+                "hp": 0,
+                "at": 0,
+                "df": 2,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Timid",
+            "item": "Choice Scarf",
+            "moves": [
+                "Moonblast",
+                "Psyshock",
+                "Dazzling Gleam",
+                "Icy Wind",
+            ],
+        },
+    },
+    "Sableye": {
+        "Roseli Disruption": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 2,
+                "sa": 0,
+                "sd": 32,
+                "sp": 0,
+            },
+            "nature": "Careful",
+            "item": "Roseli Berry",
+            "moves": [
+                "Foul Play",
+                "Fake Out",
+                "Encore",
+                "Will-O-Wisp",
+            ],
+        },
+    },
+    "Torkoal": {
+        "TR Sun Offense": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 2,
+                "sp": 0,
+            },
+            "nature": "Quiet",
+            "item": "Charcoal",
+            "moves": [
+                "Eruption",
+                "Heat Wave",
+                "Weather Ball",
+                "Earth Power",
+            ],
+        },
+    },
+    "Milotic": {
+        "Lefties Bulk": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 32,
+                "sa": 0,
+                "sd": 2,
+                "sp": 0,
+            },
+            "nature": "Bold",
+            "item": "Leftovers",
+            "moves": [
+                "Scald",
+                "Icy Wind",
+                "Ice Beam",
+                "Recover",
+            ],
+        },
+    },
+    "Garchomp": {
+        "Scarf Offense": {
+            "sps": {
+                "hp": 2,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Adamant",
+            "item": "Choice Scarf",
+            "moves": [
+                "Earthquake",
+                "Dragon Claw",
+                "Rock Slide",
+                "Stomping Tantrum",
+            ],
+        },
+        "Max Speed Lum": {
+            "sps": {
+                "hp": 2,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Jolly",
+            "item": "Lum Berry",
+            "moves": [
+                "Earthquake",
+                "Dragon Claw",
+                "Rock Slide",
+                "Stomping Tantrum",
+            ],
+        },
+    },
+    "Froslass": {
+        "Offensive Veil Mega": {
+            "sps": {
+                "hp": 2,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Timid",
+            "ability": "Cursed Body",
+            "item": "Froslassite",
+            "moves": [
+                "Blizzard",
+                "Shadow Ball",
+                "Thunderbolt",
+                "Aurora Veil",
+            ],
+        },
+    },
+    "Rotom-Wash": {
+        "Wisp Support": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 2,
+            },
+            "nature": "Modest",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Hydro Pump",
+                "Thunderbolt",
+                "Volt Switch",
+                "Will-O-Wisp",
+            ],
+        },
+        "Scarf Electroweb": {
+            "sps": {
+                "hp": 2,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Modest",
+            "item": "Choice Scarf",
+            "moves": [
+                "Hydro Pump",
+                "Electroweb",
+                "Volt Switch",
+                "Trick",
+            ],
+        },
+    },
+    "Rotom-Heat": {
+        "Scarf Electroweb": {
+            "sps": {
+                "hp": 2,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Modest",
+            "item": "Choice Scarf",
+            "moves": [
+                "Overheat",
+                "Electroweb",
+                "Volt Switch",
+                "Trick",
+            ],
+        },
+        "Wisp Support": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 2,
+            },
+            "nature": "Modest",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Overheat",
+                "Thunderbolt",
+                "Volt Switch",
+                "Will-O-Wisp",
+            ],
+        },
+    },
+    "Excadrill": {
+        "Max Attack Sand Offense": {
+            "sps": {
+                "hp": 0,
+                "at": 32,
+                "df": 2,
+                "sa": 0,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Adamant",
+            "item": "Focus Sash",
+            "moves": [
+                "High Horsepower",
+                "Iron Head",
+                "Rock Slide",
+                "Earthquake",
+            ],
+        },
+        "Max Speed Mega Option": {
+            "sps": {
+                "hp": 0,
+                "at": 32,
+                "df": 2,
+                "sa": 0,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Jolly",
+            "item": "Excadrite",
+            "moves": [
+                "High Horsepower",
+                "Iron Head",
+                "Rock Slide",
+                "Earthquake",
+            ],
+        },
+    },
+    "Whimsicott": {
+        "Sash Tailwind Support": {
+            "sps": {
+                "hp": 2,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Timid",
+            "item": "Focus Sash",
+            "moves": [
+                "Moonblast",
+                "Tailwind",
+                "Encore",
+                "Protect",
+            ],
+        },
+    },
+    "Golurk": {
+        "TR Offense Mega": {
+            "sps": {
+                "hp": 32,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 2,
+                "sp": 0,
+            },
+            "nature": "Brave",
+            "ability": "No Guard",
+            "item": "Golurkite",
+            "moves": [
+                "Headlong Rush",
+                "Poltergeist",
+                "Ice Punch",
+                "Drain Punch",
+            ],
+        },
+    },
+    "Hydreigon": {
+        "Scarf Coverage Offense": {
+            "sps": {
+                "hp": 2,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Modest",
+            "item": "Choice Scarf",
+            "moves": [
+                "Dark Pulse",
+                "Draco Meteor",
+                "Earth Power",
+                "Flamethrower",
+            ],
+        },
+    },
+    "Delphox": {
+        "Fast Offensive Mega": {
+            "sps": {
+                "hp": 1,
+                "at": 0,
+                "df": 1,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Timid",
+            "ability": "Blaze",
+            "item": "Delphoxite",
+            "moves": [
+                "Heat Wave",
+                "Psychic",
+                "Psyshock",
+                "Dazzling Gleam",
+            ],
+        },
+    },
+    "Talonflame": {
+        "Sharp Beak TW Offense": {
+            "sps": {
+                "hp": 2,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Jolly",
+            "item": "Sharp Beak",
+            "moves": [
+                "Flare Blitz",
+                "Brave Bird",
+                "Dual Wingbeat",
+                "Tailwind",
+            ],
+        },
+    },
+    "Floette-Eternal": {
+        "Max Speed Mega Attacker": {
+            "sps": {
+                "hp": 2,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Timid",
+            "item": "Floettite",
+            "moves": [
+                "Moonblast",
+                "Dazzling Gleam",
+                "Light of Ruin",
+                "Protect",
+            ],
+        },
+        "Calm Mind Mega Sweeper": {
+            "sps": {
+                "hp": 26,
+                "at": 0,
+                "df": 2,
+                "sa": 25,
+                "sd": 0,
+                "sp": 13,
+            },
+            "nature": "Modest",
+            "item": "Floettite",
+            "moves": [
+                "Moonblast",
+                "Dazzling Gleam",
+                "Draining Kiss",
+                "Calm Mind",
+            ],
+        },
+    },
+    "Aegislash": {
+        "Spell Tag Physical": {
+            "sps": {
+                "hp": 32,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 2,
+                "sp": 0,
+            },
+            "nature": "Brave",
+            "item": "Spell Tag",
+            "moves": [
+                "Poltergeist",
+                "Shadow Sneak",
+                "Iron Head",
+                "Sacred Sword",
+            ],
+        },
+        "Lefties Wide Guard Special": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 2,
+                "sp": 0,
+            },
+            "nature": "Quiet",
+            "item": "Leftovers",
+            "moves": [
+                "Shadow Ball",
+                "Flash Cannon",
+                "Wide Guard",
+                "King's Shield",
+            ],
+        },
+    },
+    "Sylveon": {
+        "Fairy Feather Offense": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 2,
+            },
+            "nature": "Modest",
+            "item": "Fairy Feather",
+            "moves": [
+                "Hyper Voice",
+                "Hyper Beam",
+                "Quick Attack",
+                "Mystical Fire",
+            ],
+        },
+    },
+    "Incineroar": {
+        "Balanced Bulk Sitrus": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 14,
+                "sa": 0,
+                "sd": 20,
+                "sp": 0,
+            },
+            "nature": "Careful",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Flare Blitz",
+                "Darkest Lariat",
+                "Fake Out",
+                "Parting Shot",
+            ],
+        },
+    },
+    "Primarina": {
+        "Mystic Water Offense": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 2,
+            },
+            "nature": "Modest",
+            "item": "Mystic Water",
+            "moves": [
+                "Hyper Voice",
+                "Moonblast",
+                "Dazzling Gleam",
+                "Ice Beam",
+            ],
+        },
+    },
+    "Kommo-o": {
+        "Omni Boost Lefties Sweeper": {
+            "sps": {
+                "hp": 2,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Modest",
+            "item": "Leftovers",
+            "moves": [
+                "Clanging Scales",
+                "Aura Sphere",
+                "Vacuum Wave",
+                "Clangorous Soul",
+            ],
+        },
+        "Iron Defense Body Press": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 32,
+                "sa": 0,
+                "sd": 0,
+                "sp": 2,
+            },
+            "nature": "Bold",
+            "item": "Leftovers",
+            "moves": [
+                "Body Press",
+                "Flamethrower",
+                "Draco Meteor",
+                "Iron Defense",
+            ],
+        },
+    },
+    "Corviknight": {
+        "Full Bulk TW Support": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 32,
+                "sa": 0,
+                "sd": 2,
+                "sp": 0,
+            },
+            "nature": "Impish",
+            "item": "Leftovers",
+            "moves": [
+                "Brave Bird",
+                "Body Press",
+                "Roost",
+                "Tailwind",
+            ],
+        },
+        "Bulk Up Sitrus": {
+            "sps": {
+                "hp": 20,
+                "at": 24,
+                "df": 3,
+                "sa": 0,
+                "sd": 1,
+                "sp": 18,
+            },
+            "nature": "Adamant",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Brave Bird",
+                "Body Press",
+                "Iron Head",
+                "Bulk Up",
+            ],
+        },
+    },
+    "Dragapult": {
+        "Physical Sash Wisp": {
+            "sps": {
+                "hp": 2,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Jolly",
+            "item": "Focus Sash",
+            "moves": [
+                "Dragon Darts",
+                "Phantom Force",
+                "Psychic Fangs",
+                "Will-O-Wisp",
+            ],
+        },
+    },
+    "Basculegion": {
+        "Scarf Adaptability": {
+            "sps": {
+                "hp": 2,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Adamant",
+            "ability": "Adaptability",
+            "item": "Choice Scarf",
+            "moves": [
+                "Last Respects",
+                "Wave Crash",
+                "Flip Turn",
+                "Aqua Jet",
+            ],
+        },
+        "Mystic Water Swift Swim": {
+            "sps": {
+                "hp": 2,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Adamant",
+            "item": "Mystic Water",
+            "moves": [
+                "Last Respects",
+                "Wave Crash",
+                "Flip Turn",
+                "Aqua Jet",
+            ],
+        },
+    },
+    "Sneasler": {
+        "Offensive White Herb Unburden": {
+            "sps": {
+                "hp": 2,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Jolly",
+            "item": "White Herb",
+            "moves": [
+                "Close Combat",
+                "Dire Claw",
+                "Fake Out",
+                "Rock Slide",
+            ],
+        },
+    },
+    "Maushold": {
+        "Chople Support": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 2,
+                "sa": 0,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Jolly",
+            "ability": "Friend Guard",
+            "item": "Chople Berry",
+            "moves": [
+                "Super Fang",
+                "Feint",
+                "Follow Me",
+                "Taunt",
+            ],
+        },
+    },
+    "Maushold-Four": {
+        "Chople Support": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 2,
+                "sa": 0,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Jolly",
+            "ability": "Friend Guard",
+            "item": "Chople Berry",
+            "moves": [
+                "Super Fang",
+                "Feint",
+                "Follow Me",
+                "Taunt",
+            ],
+        },
+    },
+    "Palafin": {
+        "Mystic Water Offense": {
+            "sps": {
+                "hp": 32,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 0,
+                "sp": 2,
+            },
+            "nature": "Adamant",
+            "item": "Mystic Water",
+            "moves": [
+                "Wave Crash",
+                "Jet Punch",
+                "Flip Turn",
+                "Close Combat",
+            ],
+        },
+    },
+    "Glimmora": {
+        "Fast Offense Mega": {
+            "sps": {
+                "hp": 1,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 1,
+                "sp": 32,
+            },
+            "nature": "Timid",
+            "item": "Glimmoranite",
+            "moves": [
+                "Power Gem",
+                "Sludge Bomb",
+                "Sludge Wave",
+                "Earth Power",
+            ],
+        },
+    },
+    "Farigiraf": {
+        "Offensive TR Setter": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 2,
+                "sa": 32,
+                "sd": 0,
+                "sp": 0,
+            },
+            "nature": "Quiet",
+            "ability": "Armor Tail",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Psychic",
+                "Hyper Voice",
+                "Dazzling Gleam",
+                "Trick Room",
+            ],
+        },
+    },
+    "Kingambit": {
+        "Black Glasses Offense": {
+            "sps": {
+                "hp": 32,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 2,
+                "sp": 0,
+            },
+            "nature": "Adamant",
+            "item": "Black Glasses",
+            "moves": [
+                "Kowtow Cleave",
+                "Iron Head",
+                "Sucker Punch",
+                "Low Kick",
+            ],
+        },
+    },
+    "Sinistcha": {
+        "Sitrus TR Redirect": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 14,
+                "sa": 0,
+                "sd": 20,
+                "sp": 0,
+            },
+            "nature": "Bold",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Matcha Gotcha",
+                "Shadow Ball",
+                "Rage Powder",
+                "Trick Room",
+            ],
+        },
+    },
+    "Archaludon": {
+        "Bulky Stamina Lefties": {
+            "sps": {
+                "hp": 32,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 2,
+                "sp": 0,
+            },
+            "nature": "Modest",
+            "item": "Leftovers",
+            "moves": [
+                "Electro Shot",
+                "Flash Cannon",
+                "Draco Meteor",
+                "Dragon Pulse",
+            ],
+        },
+        "Fast Stamina Sitrus": {
+            "sps": {
+                "hp": 2,
+                "at": 0,
+                "df": 0,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Modest",
+            "item": "Sitrus Berry",
+            "moves": [
+                "Electro Shot",
+                "Flash Cannon",
+                "Draco Meteor",
+                "Aura Sphere",
+            ],
+        },
+    },
+    "Ninetales-Alola": {
+        "Ice Offense": {
+            "sps": {
+                "hp": 1,
+                "at": 0,
+                "df": 1,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Timid",
+            "item": "Never-Melt Ice",
+            "moves": [
+                "Blizzard",
+                "Freeze-Dry",
+                "Icy Wind",
+                "Moonblast",
+            ],
+        },
+        "Sash Veil Encore": {
+            "sps": {
+                "hp": 1,
+                "at": 0,
+                "df": 1,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Timid",
+            "item": "Focus Sash",
+            "moves": [
+                "Blizzard",
+                "Icy Wind",
+                "Aurora Veil",
+                "Encore",
+            ],
+        },
+    },
+    "Arcanine-Hisui": {
+        "Scarf Full Offense": {
+            "sps": {
+                "hp": 1,
+                "at": 32,
+                "df": 0,
+                "sa": 0,
+                "sd": 1,
+                "sp": 32,
+            },
+            "nature": "Adamant",
+            "item": "Choice Scarf",
+            "moves": [
+                "Flare Blitz",
+                "Rock Slide",
+                "Extreme Speed",
+                "Head Smash",
+            ],
+        },
+    },
+    "Typhlosion-Hisui": {
+        "Scarf Eruption": {
+            "sps": {
+                "hp": 1,
+                "at": 0,
+                "df": 1,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Modest",
+            "item": "Choice Scarf",
+            "moves": [
+                "Eruption",
+                "Shadow Ball",
+                "Heat Wave",
+                "Overheat",
+            ],
+        },
+    },
+    "Zoroark-Hisui": {
+        "Sash Support/Offense": {
+            "sps": {
+                "hp": 1,
+                "at": 0,
+                "df": 1,
+                "sa": 32,
+                "sd": 0,
+                "sp": 32,
+            },
+            "nature": "Timid",
+            "item": "Focus Sash",
+            "moves": [
+                "Hyper Voice",
+                "Bitter Malice",
+                "Icy Wind",
+                "Psychic",
+            ],
+        },
+    },
+
+    //base
+
+    //"": {
+    //    "": {
+    //        "sps": {
+    //            "hp": 0,
+    //            "at": 0,
+    //            "df": 0,
+    //            "sa": 0,
+    //            "sd": 0,
+    //            "sp": 0
+    //        },
+    //        "nature": "",
+    //        "ability": "",
+    //        "item": "",
+    //        "moves": [
+    //            "",
+    //            "",
+    //            "",
+    //            ""
+    //        ]
+    //    },
+    //},
+}

--- a/frontend/src/hooks/useDamageCalc.ts
+++ b/frontend/src/hooks/useDamageCalc.ts
@@ -98,12 +98,20 @@ export function useDamageCalc(
   selectedGen: number,
 ): CalcResults | null {
   return useMemo(() => {
-    if (!p1State.species || !p2State.species) return null;
+    if (!p1State.species || !p2State.species) {
+      console.log("[calc] skip: missing species", { p1: p1State.species, p2: p2State.species });
+      return null;
+    }
 
     try {
+      console.log("[calc] building", { gen: selectedGen, p1: p1State.species, p2: p2State.species, p1sps: p1State.sps, p2sps: p2State.sps });
       const p1 = buildPokemon(p1State, selectedGen);
       const p2 = buildPokemon(p2State, selectedGen);
-      if (!p1 || !p2) return null;
+      if (!p1 || !p2) {
+        console.log("[calc] build returned null");
+        return null;
+      }
+      console.log("[calc] built", p1.species.name, p2.species.name);
 
       const field = buildField(fieldState);
       const reverseField = buildField({
@@ -132,9 +140,10 @@ export function useDamageCalc(
           }
         });
 
+      console.log("[calc] results", { p1: p1Results.length, p2: p2Results.length, p1null: p1Results.filter((r) => !r).length });
       return { p1Results, p2Results };
     } catch (e) {
-      console.error("Calc error:", e);
+      console.error("[calc] threw:", e);
       return null;
     }
   }, [p1State, p2State, fieldState, selectedGen]);

--- a/frontend/src/hooks/useDamageCalc.ts
+++ b/frontend/src/hooks/useDamageCalc.ts
@@ -1,11 +1,16 @@
 import { useMemo } from "react";
 import { calculate, Generations, Pokemon, Move, Field } from "@smogon/calc";
+import { CHAMPIONS_GEN, DEFAULT_IVS, spsToEvs } from "../utils/calcUtils";
 import type { PokemonState, FieldState, MoveState } from "../types";
 
+// Champions damage math reuses the Gen 9 engine (the Smogon calc lib has no
+// Gen 10 yet); SPs are remapped to EVs and IVs locked to 31 at build time.
 const gen = Generations.get(9);
 
-function buildPokemon(state: PokemonState): Pokemon | null {
+function buildPokemon(state: PokemonState, selectedGen: number): Pokemon | null {
   if (!state.species) return null;
+
+  const isChampions = selectedGen === CHAMPIONS_GEN;
 
   const opts: Record<string, unknown> = {
     level: 50,
@@ -13,8 +18,8 @@ function buildPokemon(state: PokemonState): Pokemon | null {
     ability: state.ability || undefined,
     item: state.item || undefined,
     status: state.status || undefined,
-    evs: { ...state.evs },
-    ivs: { ...state.ivs },
+    evs: isChampions ? spsToEvs(state.sps) : { ...state.evs },
+    ivs: isChampions ? { ...DEFAULT_IVS } : { ...state.ivs },
     boosts: { ...state.boosts },
   };
 
@@ -90,13 +95,14 @@ export function useDamageCalc(
   p1State: PokemonState,
   p2State: PokemonState,
   fieldState: FieldState,
+  selectedGen: number,
 ): CalcResults | null {
   return useMemo(() => {
     if (!p1State.species || !p2State.species) return null;
 
     try {
-      const p1 = buildPokemon(p1State);
-      const p2 = buildPokemon(p2State);
+      const p1 = buildPokemon(p1State, selectedGen);
+      const p2 = buildPokemon(p2State, selectedGen);
       if (!p1 || !p2) return null;
 
       const field = buildField(fieldState);
@@ -131,5 +137,5 @@ export function useDamageCalc(
       console.error("Calc error:", e);
       return null;
     }
-  }, [p1State, p2State, fieldState]);
+  }, [p1State, p2State, fieldState, selectedGen]);
 }

--- a/frontend/src/hooks/useDamageCalc.ts
+++ b/frontend/src/hooks/useDamageCalc.ts
@@ -31,7 +31,16 @@ function buildPokemon(state: PokemonState, selectedGen: number): Pokemon | null 
     opts.boostedStat = state.boostedStat;
   }
 
-  const pokemon = new Pokemon(gen, state.species, opts);
+  let pokemon: Pokemon;
+  try {
+    pokemon = new Pokemon(gen, state.species, opts);
+  } catch (e) {
+    // Species (or item/ability) doesn't resolve in Smogon's Gen 9 dex.
+    // Return null so the calc bails on this side without killing the other,
+    // letting move names still render via MoveResults.
+    console.warn(`[calc] failed to build ${state.species}:`, (e as Error).message);
+    return null;
+  }
 
   if (state.curHP < 100) {
     pokemon.originalCurHP = Math.round((state.curHP / 100) * pokemon.maxHP());

--- a/frontend/src/hooks/useDamageCalc.ts
+++ b/frontend/src/hooks/useDamageCalc.ts
@@ -98,20 +98,12 @@ export function useDamageCalc(
   selectedGen: number,
 ): CalcResults | null {
   return useMemo(() => {
-    if (!p1State.species || !p2State.species) {
-      console.log("[calc] skip: missing species", { p1: p1State.species, p2: p2State.species });
-      return null;
-    }
+    if (!p1State.species || !p2State.species) return null;
 
     try {
-      console.log("[calc] building", { gen: selectedGen, p1: p1State.species, p2: p2State.species, p1sps: p1State.sps, p2sps: p2State.sps });
       const p1 = buildPokemon(p1State, selectedGen);
       const p2 = buildPokemon(p2State, selectedGen);
-      if (!p1 || !p2) {
-        console.log("[calc] build returned null");
-        return null;
-      }
-      console.log("[calc] built", p1.species.name, p2.species.name);
+      if (!p1 || !p2) return null;
 
       const field = buildField(fieldState);
       const reverseField = buildField({
@@ -140,10 +132,9 @@ export function useDamageCalc(
           }
         });
 
-      console.log("[calc] results", { p1: p1Results.length, p2: p2Results.length, p1null: p1Results.filter((r) => !r).length });
       return { p1Results, p2Results };
     } catch (e) {
-      console.error("[calc] threw:", e);
+      console.error("Calc error:", e);
       return null;
     }
   }, [p1State, p2State, fieldState, selectedGen]);

--- a/frontend/src/pages/Team/CalculatorPage.tsx
+++ b/frontend/src/pages/Team/CalculatorPage.tsx
@@ -26,12 +26,13 @@ export default function CalculatorPage() {
   const [selectedP2Move, setSelectedP2Move] = useState(snapshot?.selectedP2Move ?? 0);
   const [activeSide, setActiveSide] = useState<"p1" | "p2">(snapshot?.activeSide ?? "p1");
   const [teamPokemon, setTeamPokemon] = useState<PokemonFromPaste[]>(snapshot?.teamPokemon ?? []);
+  const [gen, setGen] = useState<number>(snapshot?.gen ?? 10);
   const [saving, setSaving] = useState(false);
   const [saveMessage, setSaveMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
 
   // Keep refs in sync for the unmount save
-  const stateRef = useRef({ p1, p2, field, selectedP1Move, selectedP2Move, activeSide, teamPokemon });
-  stateRef.current = { p1, p2, field, selectedP1Move, selectedP2Move, activeSide, teamPokemon };
+  const stateRef = useRef({ p1, p2, field, selectedP1Move, selectedP2Move, activeSide, teamPokemon, gen });
+  stateRef.current = { p1, p2, field, selectedP1Move, selectedP2Move, activeSide, teamPokemon, gen };
 
   // Save state to context on unmount
   useEffect(() => {
@@ -43,7 +44,7 @@ export default function CalculatorPage() {
   }, [teamId, calcStore]);
 
   const { teamMembers, updateMemberCalcs } = useTeamMembers(teamId, team?.pokepaste);
-  const calcResults = useDamageCalc(p1, p2, field);
+  const calcResults = useDamageCalc(p1, p2, field, gen);
 
   // Load team paste on mount (skip if we already have it from snapshot)
   useEffect(() => {
@@ -128,7 +129,7 @@ export default function CalculatorPage() {
       <div className="space-y-3">
       {/* Header row */}
       <div className="flex items-center justify-between">
-        <GenerationPicker value={9} onChange={() => {}} />
+        <GenerationPicker value={gen} onChange={setGen} />
         <a
           href="https://nerd-of-now.github.io/NCP-VGC-Damage-Calculator/"
           target="_blank"
@@ -199,6 +200,7 @@ export default function CalculatorPage() {
             side="p1"
             weather={field.weather}
             terrain={field.terrain}
+            gen={gen}
           />
         </div>
 
@@ -219,6 +221,7 @@ export default function CalculatorPage() {
             side="p2"
             weather={field.weather}
             terrain={field.terrain}
+            gen={gen}
           />
         </div>
       </div>

--- a/frontend/src/types/pokemon.ts
+++ b/frontend/src/types/pokemon.ts
@@ -32,6 +32,7 @@ export interface PokemonState {
   status: string;
   evs: StatSpread;
   ivs: StatSpread;
+  sps: StatSpread;
   boosts: BoostSpread;
   curHP: number;
   moves: MoveState[];

--- a/frontend/src/utils/calcUtils.ts
+++ b/frontend/src/utils/calcUtils.ts
@@ -26,7 +26,21 @@ export const STAT_LABELS: Record<keyof StatSpread, string> = {
 
 export const DEFAULT_EVS: StatSpread = { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0 };
 export const DEFAULT_IVS: StatSpread = { hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31 };
+export const DEFAULT_SPS: StatSpread = { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0 };
 export const DEFAULT_BOOSTS: BoostSpread = { atk: 0, def: 0, spa: 0, spd: 0, spe: 0 };
+
+export const CHAMPIONS_GEN = 10;
+
+// Convert Champions Stat Points to legacy EVs for the Gen 9 calc engine.
+// Formula from Nerd of Now's damage_MASTER.js: max(0, sps * 8 - 4).
+export const spsToEvs = (sps: StatSpread): StatSpread => ({
+  hp: Math.max(0, sps.hp * 8 - 4),
+  atk: Math.max(0, sps.atk * 8 - 4),
+  def: Math.max(0, sps.def * 8 - 4),
+  spa: Math.max(0, sps.spa * 8 - 4),
+  spd: Math.max(0, sps.spd * 8 - 4),
+  spe: Math.max(0, sps.spe * 8 - 4),
+});
 
 export const NATURES_LIST: string[] = Object.keys(NATURES).sort();
 
@@ -48,6 +62,16 @@ interface SetdexEntry {
   tera_type?: string;
   evs?: Record<string, number>;
   ivs?: Record<string, number>;
+  moves?: string[];
+}
+
+interface Setdex10Entry {
+  level?: number;
+  nature?: string;
+  ability?: string;
+  item?: string;
+  tera_type?: string;
+  sps?: Record<string, number>;
   moves?: string[];
 }
 
@@ -80,6 +104,36 @@ export function setdexToState(setdexEntry: SetdexEntry): PokemonState {
     status: "",
     evs,
     ivs,
+    sps: { ...DEFAULT_SPS },
+    boosts: { ...DEFAULT_BOOSTS },
+    curHP: 100,
+    moves: (setdexEntry.moves || []).map((name) => ({ name, crit: false, bpOverride: null })),
+    boostedStat: null,
+  };
+}
+
+export function setdex10ToState(setdexEntry: Setdex10Entry): PokemonState {
+  const sps: StatSpread = { ...DEFAULT_SPS };
+
+  if (setdexEntry.sps) {
+    for (const [ncpKey, val] of Object.entries(setdexEntry.sps)) {
+      const ourKey = NCP_STAT_MAP[ncpKey];
+      if (ourKey) sps[ourKey] = val;
+    }
+  }
+
+  return {
+    species: "",
+    level: 50,
+    nature: setdexEntry.nature || "Hardy",
+    ability: setdexEntry.ability || "",
+    item: setdexEntry.item || "",
+    teraType: setdexEntry.tera_type || null,
+    isTera: false,
+    status: "",
+    evs: { ...DEFAULT_EVS },
+    ivs: { ...DEFAULT_IVS },
+    sps,
     boosts: { ...DEFAULT_BOOSTS },
     curHP: 100,
     moves: (setdexEntry.moves || []).map((name) => ({ name, crit: false, bpOverride: null })),
@@ -326,6 +380,7 @@ export function createDefaultPokemonState(species = ""): PokemonState {
     status: "",
     evs: { ...DEFAULT_EVS },
     ivs: { ...DEFAULT_IVS },
+    sps: { ...DEFAULT_SPS },
     boosts: { ...DEFAULT_BOOSTS },
     curHP: 100,
     moves: [

--- a/frontend/src/utils/calcUtils.ts
+++ b/frontend/src/utils/calcUtils.ts
@@ -33,14 +33,18 @@ export const CHAMPIONS_GEN = 10;
 
 // Convert Champions Stat Points to legacy EVs for the Gen 9 calc engine.
 // Formula from Nerd of Now's damage_MASTER.js: max(0, sps * 8 - 4).
-export const spsToEvs = (sps: StatSpread): StatSpread => ({
-  hp: Math.max(0, sps.hp * 8 - 4),
-  atk: Math.max(0, sps.atk * 8 - 4),
-  def: Math.max(0, sps.def * 8 - 4),
-  spa: Math.max(0, sps.spa * 8 - 4),
-  spd: Math.max(0, sps.spd * 8 - 4),
-  spe: Math.max(0, sps.spe * 8 - 4),
-});
+// Accepts a possibly-undefined input — older snapshots may lack `sps`.
+export const spsToEvs = (sps: StatSpread | undefined): StatSpread => {
+  const s = sps ?? DEFAULT_SPS;
+  return {
+    hp: Math.max(0, (s.hp ?? 0) * 8 - 4),
+    atk: Math.max(0, (s.atk ?? 0) * 8 - 4),
+    def: Math.max(0, (s.def ?? 0) * 8 - 4),
+    spa: Math.max(0, (s.spa ?? 0) * 8 - 4),
+    spd: Math.max(0, (s.spd ?? 0) * 8 - 4),
+    spe: Math.max(0, (s.spe ?? 0) * 8 - 4),
+  };
+};
 
 export const NATURES_LIST: string[] = Object.keys(NATURES).sort();
 

--- a/frontend/src/utils/calcUtils.ts
+++ b/frontend/src/utils/calcUtils.ts
@@ -253,6 +253,58 @@ export function normalizeSpeciesName(name: string): string {
   return SPECIES_NAME_MAP[name] || name;
 }
 
+// In-battle forme-change groups (ability-driven only). Megas, Primals, and
+// permanent forme distinctions (Calyrex-Ice/Shadow, Urshifu styles, etc.)
+// are not here — those are picked directly from the species picker.
+const FORME_GROUPS: ReadonlyArray<ReadonlyArray<{ species: string; label: string }>> = [
+  [
+    { species: "Aegislash-Shield", label: "Shield" },
+    { species: "Aegislash-Blade", label: "Blade" },
+  ],
+  [
+    { species: "Mimikyu", label: "Disguised" },
+    { species: "Mimikyu-Busted", label: "Busted" },
+  ],
+  [
+    { species: "Palafin", label: "Zero" },
+    { species: "Palafin-Hero", label: "Hero" },
+  ],
+  [
+    { species: "Eiscue", label: "Ice" },
+    { species: "Eiscue-Noice", label: "Noice" },
+  ],
+  [
+    { species: "Morpeko", label: "Full Belly" },
+    { species: "Morpeko-Hangry", label: "Hangry" },
+  ],
+  [
+    { species: "Wishiwashi", label: "Solo" },
+    { species: "Wishiwashi-School", label: "School" },
+  ],
+  [
+    { species: "Cramorant", label: "Base" },
+    { species: "Cramorant-Gulping", label: "Gulping" },
+    { species: "Cramorant-Gorging", label: "Gorging" },
+  ],
+  [
+    { species: "Minior", label: "Core" },
+    { species: "Minior-Meteor", label: "Meteor" },
+  ],
+];
+
+export interface FormeOption {
+  species: string;
+  label: string;
+}
+
+export function getFormeGroup(species: string): ReadonlyArray<FormeOption> | null {
+  if (!species) return null;
+  for (const group of FORME_GROUPS) {
+    if (group.some((f) => f.species === species)) return group;
+  }
+  return null;
+}
+
 export function getBaseStats(species: string): StatsTable | null {
   if (!species) return null;
   for (const s of gen.species) {

--- a/frontend/src/utils/calcUtils.ts
+++ b/frontend/src/utils/calcUtils.ts
@@ -152,6 +152,9 @@ const SPECIES_NAME_MAP: Record<string, string> = {
   "Calyrex-Shadow Rider": "Calyrex-Shadow",
   "Lycanroc-Midday": "Lycanroc",
   "Terapagos": "Terapagos-Terastal",
+  // Smogon's Gen 9 dex only lists Aegislash-Shield / -Blade, not a base form;
+  // the Champions setdex uses the unsuffixed name.
+  "Aegislash": "Aegislash-Shield",
 };
 
 // --- Terapagos & Ogerpon tera forme handling ---


### PR DESCRIPTION
## Summary
- **Champions gen**: replaces the dead gens 3-8 buttons with a single `Champions` button (new default; Gen IX stays). Stat table hides the IV column and renames EV -> SP with new bounds (32/stat, 66 total). Damage math reuses `@smogon/calc`'s Gen 9 engine — SPs are projected to EVs via `max(0, sps*8 - 4)` and IVs locked to 31 inside `buildPokemon`.
- **New setdex**: ports `setdex_ncp-g10.js` from [Nerd-of-Now/NCP-VGC-Damage-Calculator](https://github.com/Nerd-of-Now/NCP-VGC-Damage-Calculator) as `setdex-gen10.ts`. The setdex picker now switches between Gen 9 and Gen 10 dictionaries based on the selected gen.
- **Color-coded calcs**: saved calcs on the Pokemon Notes page color by KO outcome (red OHKO / yellow 2HKO / green 3HKO) via word-boundary match; everything else keeps the old gray.
- **`@smogon/calc` bumped** from `^0.10.0` to `^0.11.0`.

### Known limitation
Mega items (Venusaurite, Charizardite Y, …) and pre-Gen-9 forms referenced in the Champions setdex won't fully resolve through `@smogon/calc`'s Gen 9 species/item lists until upstream ships Gen 10 data. Damage still computes; item/forme effects may no-op.

## Test plan
- [ ] `cd frontend && npm install` installs `@smogon/calc@0.11.x` cleanly
- [ ] `npm run build` passes
- [ ] Calculator page: only `Champions` and `IX` render in the gen picker; Champions is selected by default and highlighted
- [ ] Champions stat table has no IV column; SP inputs cap at 32; total counter shows `X/66` and turns red over 66
- [ ] Toggling to IX restores the IV column and 252/510 EV bounds; snapshot persists across nav
- [ ] Setdex dropdown shows Venusaur/Charizard/etc. in Champions; Meowscarada/Skeledirge/etc. in IX
- [ ] Save a calc from each gen and confirm it lands on Pokemon Notes
- [ ] Pokemon Notes: `... -- guaranteed OHKO` -> red, `... -- guaranteed 2HKO after Sandstorm damage` -> yellow, `... -- guaranteed 3HKO` -> green, `... -- 4HKO` / no clause -> default gray

🤖 Generated with [Claude Code](https://claude.com/claude-code)