### PR TITLE
feat: reorder + collapse opponent team cards in Matchup Planner

### DIFF
--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/GamePlanController.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/GamePlanController.java
@@ -245,6 +245,27 @@ public class GamePlanController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "Reorder teams in game plan",
+               description = "Set the manual display order of all opponent teams. The request body must contain every team ID in the plan exactly once.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Teams reordered successfully"),
+            @ApiResponse(responseCode = "400", description = "ID list does not match the teams in this game plan"),
+            @ApiResponse(responseCode = "404", description = "Game plan not found"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    @PutMapping("/{gamePlanId}/teams/reorder")
+    public ResponseEntity<Void> reorderTeams(
+            @PathVariable Long gamePlanId,
+            Authentication authentication,
+            @Valid @RequestBody GamePlanDTO.ReorderTeamsRequest request) {
+
+        Long userId = getCurrentUserId(authentication);
+        log.info("Reordering teams in game plan: {}", gamePlanId);
+
+        gamePlanService.reorderTeams(gamePlanId, userId, request.getOrderedIds());
+        return ResponseEntity.noContent().build();
+    }
+
     @Operation(summary = "Update team", description = "Update team pokepaste and/or notes")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Team updated successfully",

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/dto/GamePlanDTO.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/dto/GamePlanDTO.java
@@ -114,6 +114,18 @@ public class GamePlanDTO {
     }
 
     /**
+     * Request DTO for reordering all teams in a game plan.
+     * The list must contain every team ID currently in the plan exactly once.
+     */
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReorderTeamsRequest {
+        @NotNull(message = "orderedIds is required")
+        private List<Long> orderedIds;
+    }
+
+    /**
      * Response DTO for a game plan team
      */
     @Data
@@ -125,6 +137,7 @@ public class GamePlanDTO {
         private String pokepaste;
         private String notes;
         private String color;
+        private Integer position;
         private List<TeamCompositionDTO> compositions;
         private LocalDateTime createdAt;
     }

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/entities/GamePlan.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/entities/GamePlan.java
@@ -50,6 +50,7 @@ public class GamePlan {
     private String notes;
 
     @OneToMany(mappedBy = "gamePlan", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("position ASC, id ASC")
     private List<GamePlanTeam> teams = new ArrayList<>();
 
     @CreationTimestamp

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/entities/GamePlanTeam.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/entities/GamePlanTeam.java
@@ -42,6 +42,9 @@ public class GamePlanTeam {
     @Column(length = 20)
     private String color;
 
+    @Column(nullable = false, columnDefinition = "integer default 0")
+    private Integer position = 0;
+
     /**
      * Team compositions stored as JSON array.
      * Each composition contains: lead1, lead2, back1, back2, notes

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/repositories/GamePlanTeamRepository.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/repositories/GamePlanTeamRepository.java
@@ -14,11 +14,12 @@ import java.util.Optional;
 public interface GamePlanTeamRepository extends JpaRepository<GamePlanTeam, Long> {
 
     /**
-     * Find all teams for a specific game plan
+     * Find all teams for a specific game plan, ordered by manual position
+     * (ascending) with id as tiebreak for stability.
      * @param gamePlanId the game plan ID
      * @return list of game plan teams
      */
-    List<GamePlanTeam> findByGamePlanId(Long gamePlanId);
+    List<GamePlanTeam> findByGamePlanIdOrderByPositionAscIdAsc(Long gamePlanId);
 
     /**
      * Find a team by ID and game plan ID (for verification)

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/GamePlanService.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/GamePlanService.java
@@ -12,7 +12,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Service class for GamePlan business logic.
@@ -210,7 +212,18 @@ public class GamePlanService {
         GamePlan gamePlan = gamePlanRepository.findByIdAndUserId(gamePlanId, userId)
                 .orElseThrow(() -> new IllegalArgumentException("Game plan not found or not owned by user"));
 
+        // New teams go to position 0; shift existing teams down by 1.
+        List<GamePlanTeam> existing = gamePlanTeamRepository.findByGamePlanIdOrderByPositionAscIdAsc(gamePlanId);
+        for (GamePlanTeam existingTeam : existing) {
+            Integer pos = existingTeam.getPosition();
+            existingTeam.setPosition((pos == null ? 0 : pos) + 1);
+        }
+        if (!existing.isEmpty()) {
+            gamePlanTeamRepository.saveAll(existing);
+        }
+
         team.setGamePlan(gamePlan);
+        team.setPosition(0);
 
         GamePlanTeam savedTeam = gamePlanTeamRepository.save(team);
         log.info("Team added successfully with ID: {}", savedTeam.getId());
@@ -239,7 +252,43 @@ public class GamePlanService {
     @Transactional(readOnly = true)
     public List<GamePlanTeam> getTeamsByGamePlanId(Long gamePlanId) {
         log.debug("Fetching teams for game plan ID: {}", gamePlanId);
-        return gamePlanTeamRepository.findByGamePlanId(gamePlanId);
+        return gamePlanTeamRepository.findByGamePlanIdOrderByPositionAscIdAsc(gamePlanId);
+    }
+
+    /**
+     * Reorder all teams in a game plan to match the given ID order.
+     * Assigns position 0..N-1 according to the order of {@code orderedIds}.
+     *
+     * @param gamePlanId the game plan ID
+     * @param userId the user ID (for ownership verification)
+     * @param orderedIds the desired team order
+     * @throws IllegalArgumentException if game plan not owned, count mismatches, or an ID doesn't belong to the plan
+     */
+    public void reorderTeams(Long gamePlanId, Long userId, List<Long> orderedIds) {
+        log.info("Reordering {} teams for game plan ID: {}", orderedIds.size(), gamePlanId);
+
+        if (!gamePlanRepository.existsByIdAndUserId(gamePlanId, userId)) {
+            throw new IllegalArgumentException("Game plan not found or not owned by user");
+        }
+
+        List<GamePlanTeam> teams = gamePlanTeamRepository.findByGamePlanIdOrderByPositionAscIdAsc(gamePlanId);
+        if (teams.size() != orderedIds.size()) {
+            throw new IllegalArgumentException("Team count mismatch: expected " + teams.size() + ", got " + orderedIds.size());
+        }
+
+        Map<Long, GamePlanTeam> byId = teams.stream()
+                .collect(Collectors.toMap(GamePlanTeam::getId, t -> t));
+
+        for (int i = 0; i < orderedIds.size(); i++) {
+            GamePlanTeam team = byId.get(orderedIds.get(i));
+            if (team == null) {
+                throw new IllegalArgumentException("Team ID " + orderedIds.get(i) + " not found in game plan: " + gamePlanId);
+            }
+            team.setPosition(i);
+        }
+
+        gamePlanTeamRepository.saveAll(teams);
+        log.info("Reordered teams for game plan ID: {}", gamePlanId);
     }
 
     /**

--- a/backend/src/test/java/com/yeskatronics/vs_recorder_backend/services/GamePlanServiceTest.java
+++ b/backend/src/test/java/com/yeskatronics/vs_recorder_backend/services/GamePlanServiceTest.java
@@ -245,6 +245,112 @@ class GamePlanServiceTest {
     }
 
     @Test
+    void testAddTeamToGamePlan_PlacesNewTeamAtTopAndShiftsOthers() {
+        GamePlan plan = new GamePlan();
+        plan.setName("Order Plan");
+        GamePlan savedPlan = gamePlanService.createGamePlan(plan, testUser1.getId());
+
+        GamePlanTeam t1 = new GamePlanTeam();
+        t1.setPokepaste("paste-1");
+        GamePlanTeam saved1 = gamePlanService.addTeamToGamePlan(savedPlan.getId(), testUser1.getId(), t1);
+
+        GamePlanTeam t2 = new GamePlanTeam();
+        t2.setPokepaste("paste-2");
+        GamePlanTeam saved2 = gamePlanService.addTeamToGamePlan(savedPlan.getId(), testUser1.getId(), t2);
+
+        GamePlanTeam t3 = new GamePlanTeam();
+        t3.setPokepaste("paste-3");
+        GamePlanTeam saved3 = gamePlanService.addTeamToGamePlan(savedPlan.getId(), testUser1.getId(), t3);
+
+        List<GamePlanTeam> teams = gamePlanService.getTeamsByGamePlanId(savedPlan.getId());
+
+        assertEquals(3, teams.size());
+        assertEquals(saved3.getId(), teams.get(0).getId());
+        assertEquals(saved2.getId(), teams.get(1).getId());
+        assertEquals(saved1.getId(), teams.get(2).getId());
+        assertEquals(0, teams.get(0).getPosition());
+        assertEquals(1, teams.get(1).getPosition());
+        assertEquals(2, teams.get(2).getPosition());
+    }
+
+    @Test
+    void testReorderTeams_AssignsPositionsInGivenOrder() {
+        GamePlan plan = new GamePlan();
+        plan.setName("Reorder Plan");
+        GamePlan savedPlan = gamePlanService.createGamePlan(plan, testUser1.getId());
+
+        GamePlanTeam t1 = new GamePlanTeam();
+        t1.setPokepaste("paste-1");
+        GamePlanTeam saved1 = gamePlanService.addTeamToGamePlan(savedPlan.getId(), testUser1.getId(), t1);
+
+        GamePlanTeam t2 = new GamePlanTeam();
+        t2.setPokepaste("paste-2");
+        GamePlanTeam saved2 = gamePlanService.addTeamToGamePlan(savedPlan.getId(), testUser1.getId(), t2);
+
+        GamePlanTeam t3 = new GamePlanTeam();
+        t3.setPokepaste("paste-3");
+        GamePlanTeam saved3 = gamePlanService.addTeamToGamePlan(savedPlan.getId(), testUser1.getId(), t3);
+
+        // Reorder to: t1, t2, t3 (i.e. reverse of insertion-driven top-stack order)
+        gamePlanService.reorderTeams(
+                savedPlan.getId(),
+                testUser1.getId(),
+                List.of(saved1.getId(), saved2.getId(), saved3.getId()));
+
+        List<GamePlanTeam> reordered = gamePlanService.getTeamsByGamePlanId(savedPlan.getId());
+        assertEquals(3, reordered.size());
+        assertEquals(saved1.getId(), reordered.get(0).getId());
+        assertEquals(saved2.getId(), reordered.get(1).getId());
+        assertEquals(saved3.getId(), reordered.get(2).getId());
+        assertEquals(0, reordered.get(0).getPosition());
+        assertEquals(1, reordered.get(1).getPosition());
+        assertEquals(2, reordered.get(2).getPosition());
+    }
+
+    @Test
+    void testReorderTeams_RejectsCountMismatch() {
+        GamePlan plan = new GamePlan();
+        plan.setName("Mismatch Plan");
+        GamePlan savedPlan = gamePlanService.createGamePlan(plan, testUser1.getId());
+
+        GamePlanTeam t1 = new GamePlanTeam();
+        t1.setPokepaste("paste-1");
+        GamePlanTeam saved1 = gamePlanService.addTeamToGamePlan(savedPlan.getId(), testUser1.getId(), t1);
+
+        GamePlanTeam t2 = new GamePlanTeam();
+        t2.setPokepaste("paste-2");
+        gamePlanService.addTeamToGamePlan(savedPlan.getId(), testUser1.getId(), t2);
+
+        assertThrows(IllegalArgumentException.class, () ->
+                gamePlanService.reorderTeams(
+                        savedPlan.getId(),
+                        testUser1.getId(),
+                        List.of(saved1.getId())));
+    }
+
+    @Test
+    void testReorderTeams_RejectsForeignTeamId() {
+        GamePlan plan = new GamePlan();
+        plan.setName("Foreign ID Plan");
+        GamePlan savedPlan = gamePlanService.createGamePlan(plan, testUser1.getId());
+
+        GamePlanTeam t1 = new GamePlanTeam();
+        t1.setPokepaste("paste-1");
+        GamePlanTeam saved1 = gamePlanService.addTeamToGamePlan(savedPlan.getId(), testUser1.getId(), t1);
+
+        GamePlanTeam t2 = new GamePlanTeam();
+        t2.setPokepaste("paste-2");
+        gamePlanService.addTeamToGamePlan(savedPlan.getId(), testUser1.getId(), t2);
+
+        long bogusId = saved1.getId() + 9999;
+        assertThrows(IllegalArgumentException.class, () ->
+                gamePlanService.reorderTeams(
+                        savedPlan.getId(),
+                        testUser1.getId(),
+                        List.of(saved1.getId(), bogusId)));
+    }
+
+    @Test
     void testDeleteGamePlanTeam() {
         GamePlan gamePlan = new GamePlan();
         gamePlan.setName("Test Plan");
@@ -505,7 +611,11 @@ class GamePlanServiceTest {
         List<GamePlanTeam> teams = gamePlanService.getTeamsByGamePlanId(finalPlan.getId());
 
         assertEquals(2, teams.size());
-        assertEquals(1, teams.get(0).getCompositions().size());
-        assertEquals(2, teams.get(1).getCompositions().size());
+        // New teams are placed at position 0 (top) and push existing teams down,
+        // so team2 (added last, 2 compositions) precedes team1 (added first, 1 composition).
+        assertEquals(2, teams.get(0).getCompositions().size());
+        assertEquals(1, teams.get(1).getCompositions().size());
+        assertEquals(0, teams.get(0).getPosition());
+        assertEquals(1, teams.get(1).getPosition());
     }
 }

--- a/frontend/src/components/team/OpponentTeamCard.tsx
+++ b/frontend/src/components/team/OpponentTeamCard.tsx
@@ -6,7 +6,13 @@ import {
   Save,
   X as XIcon,
   ExternalLink,
+  GripVertical,
+  ChevronDown,
 } from "lucide-react";
+import type {
+  DraggableAttributes,
+  DraggableSyntheticListeners,
+} from "@dnd-kit/core";
 import PokemonTeam from "../pokemon/PokemonTeam";
 import PokemonSprite from "../pokemon/PokemonSprite";
 import PokemonDropdown from "../form/PokemonDropdown";
@@ -52,6 +58,12 @@ interface OpponentTeamCardProps {
   ) => Promise<unknown>;
   onDeleteComposition: (id: number, index: number) => Promise<unknown>;
   onDeleteTeam: (id: number) => Promise<unknown>;
+  dragHandleProps?: {
+    attributes: DraggableAttributes;
+    listeners: DraggableSyntheticListeners;
+  };
+  isExpanded?: boolean;
+  onToggleExpand?: (id: number) => void;
 }
 
 const OpponentTeamCard: React.FC<OpponentTeamCardProps> = ({
@@ -62,6 +74,9 @@ const OpponentTeamCard: React.FC<OpponentTeamCardProps> = ({
   onUpdateComposition,
   onDeleteComposition,
   onDeleteTeam,
+  dragHandleProps,
+  isExpanded = true,
+  onToggleExpand,
 }) => {
   const [isEditingNotes, setIsEditingNotes] = useState(false);
   const [editedNotes, setEditedNotes] = useState(opponentTeam.notes || "");
@@ -149,12 +164,28 @@ const OpponentTeamCard: React.FC<OpponentTeamCardProps> = ({
 
   return (
     <div
-      className="rounded-lg border border-l-4 border-gray-200 dark:border-gray-700"
+      className="flex overflow-hidden rounded-lg border border-l-4 border-gray-200 dark:border-gray-700"
       style={{ borderLeftColor: teamColor.border }}
     >
+      {dragHandleProps && (
+        <div
+          {...dragHandleProps.attributes}
+          {...dragHandleProps.listeners}
+          className="flex w-7 flex-shrink-0 cursor-grab touch-none items-start justify-center border-r border-gray-200 bg-gray-50 pt-5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 active:cursor-grabbing dark:border-gray-700 dark:bg-white/[0.02] dark:hover:bg-white/[0.04] dark:hover:text-gray-300"
+          title="Drag to reorder"
+          aria-label="Drag to reorder matchup team"
+        >
+          <GripVertical className="h-4 w-4" />
+        </div>
+      )}
+      <div className="min-w-0 flex-1">
       {/* Header */}
-      <div className="rounded-t-lg border-b border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-white/[0.02]">
-        {/* Top row: Team name + delete button */}
+      <div
+        className={`bg-gray-50 p-4 dark:bg-white/[0.02] ${
+          isExpanded ? "border-b border-gray-200 dark:border-gray-700" : ""
+        }`}
+      >
+        {/* Top row: Team name + collapse + delete */}
         <div className="flex items-center justify-between gap-2">
           <div className="flex min-w-0 items-center gap-2">
             <h3
@@ -178,14 +209,34 @@ const OpponentTeamCard: React.FC<OpponentTeamCardProps> = ({
             )}
           </div>
 
-          {/* Delete Team Button */}
-          <button
-            onClick={() => setShowDeleteTeamModal(true)}
-            className="flex-shrink-0 rounded p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-500/10 dark:hover:text-red-400"
-            title="Delete matchup team"
-          >
-            <Trash2 className="h-3 w-3" />
-          </button>
+          <div className="flex flex-shrink-0 items-center gap-1">
+            {onToggleExpand && (
+              <button
+                onClick={() => onToggleExpand(opponentTeam.id)}
+                className="rounded p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-white/[0.05] dark:hover:text-gray-300"
+                title={isExpanded ? "Collapse" : "Expand"}
+                aria-label={
+                  isExpanded ? "Collapse matchup team" : "Expand matchup team"
+                }
+                aria-expanded={isExpanded}
+              >
+                <ChevronDown
+                  className={`h-3 w-3 transition-transform ${
+                    isExpanded ? "rotate-180" : ""
+                  }`}
+                />
+              </button>
+            )}
+
+            {/* Delete Team Button */}
+            <button
+              onClick={() => setShowDeleteTeamModal(true)}
+              className="rounded p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-500/10 dark:hover:text-red-400"
+              title="Delete matchup team"
+            >
+              <Trash2 className="h-3 w-3" />
+            </button>
+          </div>
         </div>
 
         {/* Sprites row */}
@@ -196,6 +247,7 @@ const OpponentTeamCard: React.FC<OpponentTeamCardProps> = ({
         )}
 
         {/* Bottom row: Notes */}
+        {isExpanded && (
         <div className="mt-3">
           <div className="mb-2 flex items-center justify-between">
             <h4 className="text-sm font-semibold text-gray-800 dark:text-white/90">
@@ -282,9 +334,11 @@ const OpponentTeamCard: React.FC<OpponentTeamCardProps> = ({
             </p>
           )}
         </div>
+        )}
       </div>
 
       {/* Strategy Plans Section */}
+      {isExpanded && (
       <div className="p-4">
         <div className="mb-3 flex items-center justify-between">
           <h4 className="text-sm font-semibold text-gray-800 dark:text-white/90">
@@ -327,6 +381,7 @@ const OpponentTeamCard: React.FC<OpponentTeamCardProps> = ({
           ))}
         </div>
       </div>
+      )}
 
       {/* Delete Plan Modal */}
       <ConfirmationModal
@@ -366,6 +421,7 @@ const OpponentTeamCard: React.FC<OpponentTeamCardProps> = ({
         confirmText="Delete Team"
         variant="danger"
       />
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/team/SortableOpponentTeamCard.tsx
+++ b/frontend/src/components/team/SortableOpponentTeamCard.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical } from "lucide-react";
+import OpponentTeamCard from "./OpponentTeamCard";
+import PokemonTeam from "../pokemon/PokemonTeam";
+import type { Composition } from "../../types";
+
+interface OpponentTeam {
+  id: number;
+  teamId: number;
+  gamePlanId: number;
+  pokepaste: string;
+  notes: string;
+  color: string;
+  position: number;
+  compositions: Composition[];
+  createdAt: string;
+}
+
+interface SortableOpponentTeamCardProps {
+  opponentTeam: OpponentTeam;
+  myTeamPokemon: string[];
+  dragDisabled?: boolean;
+  isExpanded?: boolean;
+  onToggleExpand?: (id: number) => void;
+  onUpdateNotes: (
+    id: number,
+    updates: { pokepaste?: string; notes?: string; color?: string },
+  ) => Promise<void>;
+  onAddComposition: (id: number, composition: Composition) => Promise<unknown>;
+  onUpdateComposition: (
+    id: number,
+    index: number,
+    composition: Composition,
+  ) => Promise<unknown>;
+  onDeleteComposition: (id: number, index: number) => Promise<unknown>;
+  onDeleteTeam: (id: number) => Promise<unknown>;
+}
+
+const SortableOpponentTeamCard: React.FC<SortableOpponentTeamCardProps> = ({
+  dragDisabled,
+  ...props
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: props.opponentTeam.id, disabled: dragDisabled });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : undefined,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <OpponentTeamCard
+        {...props}
+        dragHandleProps={
+          dragDisabled ? undefined : { attributes, listeners }
+        }
+      />
+    </div>
+  );
+};
+
+export default SortableOpponentTeamCard;
+
+const COLOR_BORDERS: Record<string, string> = {
+  blue: "#3b82f6",
+  red: "#ef4444",
+  green: "#22c55e",
+  yellow: "#eab308",
+  purple: "#a855f7",
+  pink: "#ec4899",
+  orange: "#f97316",
+  teal: "#14b8a6",
+  gray: "#6b7280",
+};
+
+interface OpponentTeamDragPreviewProps {
+  team: OpponentTeam;
+  title?: string | null;
+}
+
+/**
+ * Compact one-row preview rendered inside DragOverlay while dragging an
+ * OpponentTeamCard. Avoids dragging the full (often 200px+) card.
+ */
+export const OpponentTeamDragPreview: React.FC<OpponentTeamDragPreviewProps> = ({
+  team,
+  title,
+}) => {
+  const borderColor = COLOR_BORDERS[team.color] || COLOR_BORDERS.blue;
+  const planCount = team.compositions?.length ?? 0;
+  const label = title || "Matchup Team";
+
+  return (
+    <div
+      className="flex items-center gap-3 rounded-lg border border-l-4 border-gray-200 bg-white px-3 py-2 shadow-lg dark:border-gray-700 dark:bg-gray-900"
+      style={{ borderLeftColor: borderColor }}
+    >
+      <GripVertical className="h-4 w-4 flex-shrink-0 text-gray-400" />
+      <span className="truncate text-sm font-semibold text-gray-800 dark:text-white/90">
+        {label}
+      </span>
+      {team.pokepaste && (
+        <div className="flex-shrink-0">
+          <PokemonTeam pokepasteUrl={team.pokepaste} size="sm" />
+        </div>
+      )}
+      <span className="flex-shrink-0 text-xs text-gray-500 dark:text-gray-400">
+        · {planCount} {planCount === 1 ? "plan" : "plans"}
+      </span>
+    </div>
+  );
+};

--- a/frontend/src/data/announcements.json
+++ b/frontend/src/data/announcements.json
@@ -1,5 +1,11 @@
 [
   {
+    "id": "2026-05-17-matchup-planner-enhancements",
+    "date": "2026-05-17",
+    "title": "Matchup Planner Enhancements",
+    "message": "The matchup planner has been enhanced to let you expand and collapse the cards and allow you to re-order them. In the future we'll add VR Paste functionality and let you import teams from the latest tournaments."
+  },
+  {
     "id": "2026-05-16-champions-calc-and-notes",
     "date": "2026-05-16",
     "title": "Pokemon Champions in the Calculator + Color-Coded Notes",

--- a/frontend/src/hooks/useCollapsedOpponentTeams.ts
+++ b/frontend/src/hooks/useCollapsedOpponentTeams.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useState } from "react";
+
+const storageKey = (gamePlanId: number | null): string | null =>
+  gamePlanId == null ? null : `matchupPlanner.collapsedTeams.${gamePlanId}`;
+
+const loadInitial = (gamePlanId: number | null): Set<number> => {
+  const key = storageKey(gamePlanId);
+  if (!key) return new Set();
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? new Set(parsed.filter((n): n is number => typeof n === "number"))
+      : new Set();
+  } catch {
+    return new Set();
+  }
+};
+
+export function useCollapsedOpponentTeams(gamePlanId: number | null) {
+  const [collapsedIds, setCollapsedIds] = useState<Set<number>>(() =>
+    loadInitial(gamePlanId),
+  );
+
+  useEffect(() => {
+    setCollapsedIds(loadInitial(gamePlanId));
+  }, [gamePlanId]);
+
+  useEffect(() => {
+    const key = storageKey(gamePlanId);
+    if (!key) return;
+    try {
+      localStorage.setItem(key, JSON.stringify([...collapsedIds]));
+    } catch {
+      // Storage unavailable (quota / private mode) — in-memory state still works.
+    }
+  }, [collapsedIds, gamePlanId]);
+
+  const isExpanded = useCallback(
+    (id: number) => !collapsedIds.has(id),
+    [collapsedIds],
+  );
+
+  const toggle = useCallback((id: number) => {
+    setCollapsedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const collapseAll = useCallback((ids: number[]) => {
+    setCollapsedIds(new Set(ids));
+  }, []);
+
+  const expandAll = useCallback(() => {
+    setCollapsedIds(new Set());
+  }, []);
+
+  return { isExpanded, toggle, collapseAll, expandAll };
+}
+
+export default useCollapsedOpponentTeams;

--- a/frontend/src/hooks/useOpponentTeams.ts
+++ b/frontend/src/hooks/useOpponentTeams.ts
@@ -9,6 +9,7 @@ interface OpponentTeam {
   pokepaste: string;
   notes: string;
   color: string;
+  position: number;
   compositions: Composition[];
   createdAt: string;
 }
@@ -38,6 +39,7 @@ export const useOpponentTeams = (
     pokepaste: team.pokepaste,
     notes: team.notes || "",
     color: team.color || "blue",
+    position: team.position ?? 0,
     compositions: team.compositions || [],
     createdAt: team.createdAt,
   });
@@ -164,6 +166,33 @@ export const useOpponentTeams = (
     return transformedTeam;
   };
 
+  const reorderOpponentTeams = useCallback(
+    async (orderedIds: number[]) => {
+      if (!gamePlanId) {
+        throw new Error("Game plan not initialized");
+      }
+
+      setOpponentTeams((prev) => {
+        const byId = new Map(prev.map((t) => [t.id, t]));
+        return orderedIds
+          .map((id, i) => {
+            const team = byId.get(id);
+            return team ? { ...team, position: i } : null;
+          })
+          .filter((t): t is OpponentTeam => t !== null);
+      });
+      setLastUpdated(new Date());
+
+      try {
+        await gamePlanApi.reorderTeams(gamePlanId, orderedIds);
+      } catch (err) {
+        console.error("Failed to reorder opponent teams:", err);
+        await loadOpponentTeams(teamId);
+      }
+    },
+    [gamePlanId, teamId, loadOpponentTeams],
+  );
+
   const deleteComposition = async (opponentTeamId: number, index: number) => {
     if (!gamePlanId) {
       throw new Error("Game plan not initialized");
@@ -220,6 +249,7 @@ export const useOpponentTeams = (
     addComposition,
     updateComposition,
     deleteComposition,
+    reorderOpponentTeams,
     refresh,
     getOpponentTeamById,
     resetState,

--- a/frontend/src/pages/Team/MatchupPlannerPage.tsx
+++ b/frontend/src/pages/Team/MatchupPlannerPage.tsx
@@ -1,12 +1,38 @@
 import { useState, useEffect, useMemo } from "react";
-import { Plus, Target, AlertTriangle, Layers, ArrowLeft } from "lucide-react";
+import {
+  Plus,
+  Target,
+  AlertTriangle,
+  Layers,
+  ArrowLeft,
+  ChevronsUp,
+  ChevronsDown,
+} from "lucide-react";
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 import PageMeta from "../../components/common/PageMeta";
-import OpponentTeamCard from "../../components/team/OpponentTeamCard";
+import SortableOpponentTeamCard, {
+  OpponentTeamDragPreview,
+} from "../../components/team/SortableOpponentTeamCard";
 import LeadGroupCard from "../../components/team/LeadGroupCard";
 import AddOpponentTeamModal from "../../components/modals/AddOpponentTeamModal";
 import TagInput from "../../components/form/TagInput";
 import { useActiveTeam } from "../../context/ActiveTeamContext";
 import { useOpponentTeams } from "../../hooks/useOpponentTeams";
+import { useCollapsedOpponentTeams } from "../../hooks/useCollapsedOpponentTeams";
 import useTeamPokemon from "../../hooks/useTeamPokemon";
 import * as pokepasteService from "../../services/pokepasteService";
 import { matchesPokemonTags } from "../../utils/pokemonNameUtils";
@@ -19,9 +45,11 @@ export default function MatchupPlannerPage() {
   const [showAddTeamModal, setShowAddTeamModal] = useState(false);
   const [searchTags, setSearchTags] = useState<string[]>([]);
   const [groupByLeads, setGroupByLeads] = useState(false);
+  const [activeDragId, setActiveDragId] = useState<number | null>(null);
 
   const {
     opponentTeams,
+    gamePlanId,
     loading,
     error,
     createOpponentTeam,
@@ -30,9 +58,46 @@ export default function MatchupPlannerPage() {
     addComposition,
     updateComposition,
     deleteComposition,
+    reorderOpponentTeams,
     refresh,
     isEmpty,
   } = useOpponentTeams(team?.id ?? null);
+
+  const {
+    isExpanded: isCardExpanded,
+    toggle: toggleCardExpanded,
+    collapseAll,
+    expandAll,
+  } = useCollapsedOpponentTeams(gamePlanId);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+  );
+
+  const isReorderable = searchTags.length === 0;
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveDragId(event.active.id as number);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setActiveDragId(null);
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = opponentTeams.findIndex((t) => t.id === active.id);
+    const newIndex = opponentTeams.findIndex((t) => t.id === over.id);
+    if (oldIndex < 0 || newIndex < 0) return;
+    const newOrder = arrayMove(opponentTeams, oldIndex, newIndex);
+    reorderOpponentTeams(newOrder.map((t) => t.id));
+  };
+
+  const activeDragTeam = useMemo(
+    () =>
+      activeDragId != null
+        ? opponentTeams.find((t) => t.id === activeDragId) ?? null
+        : null,
+    [activeDragId, opponentTeams],
+  );
 
   const { teamPokemon } = useTeamPokemon(opponentTeams);
 
@@ -168,6 +233,28 @@ export default function MatchupPlannerPage() {
             </button>
           ) : (
             <>
+              {!isEmpty && (
+                <>
+                  <button
+                    onClick={() =>
+                      collapseAll(opponentTeams.map((t) => t.id))
+                    }
+                    className="flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+                    title="Collapse all matchup teams"
+                  >
+                    <ChevronsUp className="h-4 w-4" />
+                    Collapse All
+                  </button>
+                  <button
+                    onClick={expandAll}
+                    className="flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+                    title="Expand all matchup teams"
+                  >
+                    <ChevronsDown className="h-4 w-4" />
+                    Expand All
+                  </button>
+                </>
+              )}
               <button
                 onClick={() => setGroupByLeads(true)}
                 className="flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
@@ -318,20 +405,49 @@ export default function MatchupPlannerPage() {
             </div>
           ) : (
             !isEmpty && (
-              <div className="space-y-6">
-                {filteredOpponentTeams.map((opponentTeam) => (
-                  <OpponentTeamCard
-                    key={opponentTeam.id}
-                    opponentTeam={opponentTeam}
-                    myTeamPokemon={myTeamPokemon}
-                    onUpdateNotes={handleUpdateNotes}
-                    onAddComposition={addComposition}
-                    onUpdateComposition={updateComposition}
-                    onDeleteComposition={deleteComposition}
-                    onDeleteTeam={handleDeleteOpponentTeam}
-                  />
-                ))}
-              </div>
+              <>
+                {!isReorderable && (
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    Clear filters to reorder matchup teams.
+                  </p>
+                )}
+                <DndContext
+                  sensors={sensors}
+                  collisionDetection={closestCenter}
+                  onDragStart={handleDragStart}
+                  onDragEnd={handleDragEnd}
+                  onDragCancel={() => setActiveDragId(null)}
+                >
+                  <SortableContext
+                    items={filteredOpponentTeams.map((t) => t.id)}
+                    strategy={verticalListSortingStrategy}
+                    disabled={!isReorderable}
+                  >
+                    <div className="space-y-6">
+                      {filteredOpponentTeams.map((opponentTeam) => (
+                        <SortableOpponentTeamCard
+                          key={opponentTeam.id}
+                          opponentTeam={opponentTeam}
+                          myTeamPokemon={myTeamPokemon}
+                          dragDisabled={!isReorderable}
+                          isExpanded={isCardExpanded(opponentTeam.id)}
+                          onToggleExpand={toggleCardExpanded}
+                          onUpdateNotes={handleUpdateNotes}
+                          onAddComposition={addComposition}
+                          onUpdateComposition={updateComposition}
+                          onDeleteComposition={deleteComposition}
+                          onDeleteTeam={handleDeleteOpponentTeam}
+                        />
+                      ))}
+                    </div>
+                  </SortableContext>
+                  <DragOverlay>
+                    {activeDragTeam ? (
+                      <OpponentTeamDragPreview team={activeDragTeam} />
+                    ) : null}
+                  </DragOverlay>
+                </DndContext>
+              </>
             )
           )}
         </>

--- a/frontend/src/services/api/gamePlanApi.ts
+++ b/frontend/src/services/api/gamePlanApi.ts
@@ -47,6 +47,11 @@ export const gamePlanApi = {
   deleteTeam: (gamePlanId: number, teamId: number) =>
     apiClient.delete(`/api/game-plans/${gamePlanId}/teams/${teamId}`) as Promise<void>,
 
+  reorderTeams: (gamePlanId: number, orderedIds: number[]) =>
+    apiClient.put(`/api/game-plans/${gamePlanId}/teams/reorder`, {
+      orderedIds,
+    }) as Promise<void>,
+
   // Compositions
   addComposition: (gamePlanId: number, teamId: number, composition: Composition) =>
     apiClient.post(`/api/game-plans/${gamePlanId}/teams/${teamId}/compositions`, {

--- a/frontend/src/types/gamePlan.ts
+++ b/frontend/src/types/gamePlan.ts
@@ -13,6 +13,7 @@ export interface GamePlanTeam {
   playerName: string;
   notes: string;
   color?: string;
+  position?: number;
   compositions: Composition[];
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary

Two related UX improvements for the Matchup Planner that ship together.

### Drag-to-reorder
- New `position` column on `GamePlanTeam` + `@OrderBy` on the `GamePlan.teams` collection so order is honored on both the explicit teams endpoint and the eager `GamePlan` load.
- `PUT /api/game-plans/{id}/teams/reorder` endpoint backed by `GamePlanService.reorderTeams` (count + ownership validation, ignores foreign IDs with a clear error).
- New matchup teams insert at position 0; existing teams shift down.
- Frontend uses `@dnd-kit/sortable` with a slim left-edge grip handle and a compact `DragOverlay` preview (header-only row), so dragging tall cards stays smooth.
- Reorder is disabled while a tag filter is active, with an inline hint ("Clear filters to reorder matchup teams").

### Collapse / expand
- Per-card chevron toggles a collapsed view that hides notes + Strategy Plans, leaving only the team title, sprites, drag handle, and delete button.
- **Collapse All** / **Expand All** buttons in the page toolbar (default Planner view only, hidden when empty or in Group By Leads view).
- Collapsed-team-id set persisted in `localStorage` scoped per `gamePlanId`, so layout survives refresh and switching teams. New teams default to expanded (no persisted entry).

## Test plan

Backend:
- [x] `mvn test -Dtest=GamePlanServiceTest` — adds 4 new tests (reorder happy-path, count mismatch, foreign ID rejection, new-team-shifts-others). Full suite: **141 passing**.

Frontend:
- [x] `npx tsc -p tsconfig.app.json --noEmit` clean
- [x] `npm run build` clean
- [ ] Open a team's Matchup Planner with ≥ 3 opponent teams
- [ ] Drag a middle card by its grip handle to the top — list reorders smoothly; compact preview follows the cursor
- [ ] Refresh — order persists
- [ ] Add a new opponent team — appears at the top (position 0), expanded
- [ ] Click a card's chevron — body collapses; refresh — stays collapsed
- [ ] Collapse All / Expand All — affects every card; survives refresh
- [ ] Apply a tag filter — drag handles hidden, hint appears
- [ ] Switch to Group By Leads view — no drag UI, no Collapse All/Expand All; lead groups still sort by size
- [ ] Switch teams and back — per-game-plan collapse state is isolated

🤖 Generated with [Claude Code](https://claude.com/claude-code)