### PR TITLE
fix: stack Matchup Planner toolbar below title on mobile

### DIFF
--- a/frontend/src/pages/Team/MatchupPlannerPage.tsx
+++ b/frontend/src/pages/Team/MatchupPlannerPage.tsx
@@ -212,7 +212,7 @@ export default function MatchupPlannerPage() {
       <PageMeta title="Matchup Planner | VS Recorder" description="Plan matchup strategies" />
       <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h2 className="flex items-center gap-2 text-2xl font-bold text-gray-800 dark:text-white/90">
             <Target className="h-6 w-6 text-brand-500" />
@@ -222,7 +222,7 @@ export default function MatchupPlannerPage() {
             Plan strategies for specific matchups
           </p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {groupByLeads ? (
             <button
               onClick={() => setGroupByLeads(false)}


### PR DESCRIPTION
## Summary

On narrow screens the Matchup Planner header was `flex justify-between`, which pushed the **Collapse All / Expand All / Group By Leads / Add Matchup Team** buttons off the right edge (screenshot in the originating thread).

Two-line change in `MatchupPlannerPage.tsx`:
- Parent container: `flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between` — stacks the toolbar below the title under the `sm` breakpoint, keeps the inline desktop layout above it.
- Button row: add `flex-wrap` so if a phone is still too narrow for all four buttons, they wrap to a second row instead of overflowing.

## Test plan

- [x] `npx tsc -p tsconfig.app.json --noEmit` clean
- [ ] Open the Matchup Planner on a phone-width viewport (DevTools 375px) — toolbar sits under the title; no horizontal overflow
- [ ] Resize past `sm` (640px) — toolbar returns to inline-right layout
- [ ] Group By Leads view also wraps cleanly (single "Back to Planner" button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)