### PR TITLE
feat: accept VR Pastes URLs for team and matchup imports

### DIFF
--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/PokepasteService.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/PokepasteService.java
@@ -30,11 +30,16 @@ public class PokepasteService {
 
     private static final String POKEBIN_BASE = "https://pokebin.com";
 
+    private static final String VRPASTES_API_BASE = "https://vrpaste-backend.vercel.app/api/paste";
+
     private static final Pattern POKEPASTE_URL_PATTERN = Pattern.compile(
             "https://pokepast\\.es/([a-zA-Z0-9]+)(?:/raw)?"
     );
     private static final Pattern POKEBIN_URL_PATTERN = Pattern.compile(
             "https://pokebin\\.com/([a-zA-Z0-9]+)(?:/json)?"
+    );
+    private static final Pattern VRPASTES_URL_PATTERN = Pattern.compile(
+            "https?://(?:www\\.)?vrpastes\\.com/([a-zA-Z0-9]+)"
     );
 
 
@@ -48,6 +53,12 @@ public class PokepasteService {
     public PokepasteDTO.PasteData fetchPasteData(String url) {
         log.info("Fetching paste data from: {}", url);
 
+        // Check if it's a VR Pastes URL
+        Matcher vrpastesMatcher = VRPASTES_URL_PATTERN.matcher(url);
+        if (vrpastesMatcher.find()) {
+            return fetchVRPastesData(url, vrpastesMatcher.group(1));
+        }
+
         // Check if it's a Pokebin URL
         Matcher pokebinMatcher = POKEBIN_URL_PATTERN.matcher(url);
         if (pokebinMatcher.find()) {
@@ -60,7 +71,7 @@ public class PokepasteService {
             return fetchPokepasteData(url, pokepasteMatcher.group(1));
         }
 
-        throw new IllegalArgumentException("Invalid URL - must be a Pokepaste or Pokebin URL");
+        throw new IllegalArgumentException("Invalid URL - must be a Pokepaste, Pokebin, or VR Pastes URL");
     }
 
     /**
@@ -201,6 +212,92 @@ public class PokepasteService {
     }
 
     /**
+     * Fetch data from VR Pastes (vrpastes.com)
+     */
+    private PokepasteDTO.PasteData fetchVRPastesData(String originalUrl, String pasteId) {
+        log.info("Fetching from VR Pastes: {}", pasteId);
+        String apiUrl = VRPASTES_API_BASE + "/" + pasteId + "?lang=english";
+
+        try {
+            long startTime = System.currentTimeMillis();
+            log.debug("Fetching from: {}", apiUrl);
+            String jsonResponse = restTemplate.getForObject(apiUrl, String.class);
+            long fetchDuration = System.currentTimeMillis() - startTime;
+            log.info("Fetched VR Pastes data in {}ms", fetchDuration);
+
+            if (jsonResponse == null || jsonResponse.trim().isEmpty()) {
+                throw new IllegalArgumentException("Failed to fetch VR Pastes data or paste is empty");
+            }
+
+            JsonNode root = objectMapper.readTree(jsonResponse);
+
+            PokepasteDTO.PasteData pasteData = new PokepasteDTO.PasteData();
+            pasteData.setSource("vrpastes");
+            pasteData.setRawText(jsonResponse);
+
+            String title = root.path("title").asText(null);
+            if (title != null && !title.isEmpty()) {
+                pasteData.setTitle(title);
+            }
+
+            // VR Pastes calls this field "teams" but it's actually the list of Pokemon
+            JsonNode teamsNode = root.path("teams");
+            if (!teamsNode.isArray()) {
+                throw new IllegalArgumentException("Invalid VR Pastes response - missing 'teams' array");
+            }
+
+            for (JsonNode memberNode : teamsNode) {
+                PokepasteDTO.PokemonData pokemon = new PokepasteDTO.PokemonData();
+
+                String species = memberNode.path("species").asText(null);
+                if (species == null || species.isEmpty()) continue;
+                pokemon.setSpecies(species);
+
+                String name = memberNode.path("name").asText(null);
+                if (name != null && !name.isEmpty() && !name.equals(species)) {
+                    pokemon.setNickname(name);
+                }
+
+                String item = memberNode.path("item").asText(null);
+                if (item != null && !item.isEmpty()) {
+                    pokemon.setItem(item);
+                }
+
+                String ability = memberNode.path("ability").asText(null);
+                if (ability != null && !ability.isEmpty()) {
+                    pokemon.setAbility(ability);
+                }
+
+                String teraType = memberNode.path("teraType").asText(null);
+                if (teraType != null && !teraType.isEmpty()) {
+                    pokemon.setTeraType(teraType);
+                }
+
+                JsonNode movesNode = memberNode.path("moves");
+                if (movesNode.isArray()) {
+                    for (JsonNode move : movesNode) {
+                        String moveName = move.asText(null);
+                        if (moveName != null && !moveName.isEmpty()) {
+                            pokemon.getMoves().add(moveName);
+                        }
+                    }
+                }
+
+                pasteData.getPokemon().add(pokemon);
+            }
+
+            log.info("Successfully fetched VR Pastes with {} Pokemon", pasteData.getPokemon().size());
+            return pasteData;
+
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Error fetching VR Pastes data: {}", e.getMessage(), e);
+            throw new IllegalArgumentException("Failed to fetch or parse VR Pastes data: " + e.getMessage());
+        }
+    }
+
+    /**
      * Parse a single Pokemon section
      */
     private PokepasteDTO.PokemonData parsePokemonSection(String section) {
@@ -272,7 +369,8 @@ public class PokepasteService {
      */
     public boolean isValidPokepasteUrl(String url) {
         return POKEPASTE_URL_PATTERN.matcher(url).matches() ||
-                POKEBIN_URL_PATTERN.matcher(url).matches();
+                POKEBIN_URL_PATTERN.matcher(url).matches() ||
+                VRPASTES_URL_PATTERN.matcher(url).matches();
     }
 
     /**

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/TeamImportService.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/TeamImportService.java
@@ -36,7 +36,7 @@ public class TeamImportService {
 
     // Validation patterns
     private static final Pattern POKEPASTE_URL_PATTERN = Pattern.compile(
-            "^https://(pokepast\\.es|pokebin\\.com)/[a-zA-Z0-9]+$"
+            "^https://(pokepast\\.es|pokebin\\.com|(?:www\\.)?vrpastes\\.com)/[a-zA-Z0-9]+$"
     );
     private static final Pattern REPLAY_URL_PATTERN = Pattern.compile(
             "^https://replay\\.pokemonshowdown\\.com/[a-zA-Z0-9-]+$"

--- a/frontend/src/components/modals/AddOpponentTeamModal.tsx
+++ b/frontend/src/components/modals/AddOpponentTeamModal.tsx
@@ -43,13 +43,13 @@ const AddOpponentTeamModal: React.FC<AddOpponentTeamModalProps> = ({
     e.preventDefault();
 
     if (!formData.pokepaste.trim()) {
-      setError("Pokepaste or Pokebin URL is required");
+      setError("Team paste URL is required");
       return;
     }
 
     if (!pokepasteService.isValidPokepasteUrl(formData.pokepaste.trim())) {
       setError(
-        "Please enter a valid Pokepaste or Pokebin URL (e.g., https://pokepast.es/abc123 or https://pokebin.com/abc123)",
+        "Please enter a valid Pokepaste, Pokebin, or VR Pastes URL (e.g., https://pokepast.es/abc123 or https://vrpastes.com/abc123)",
       );
       return;
     }
@@ -91,19 +91,19 @@ const AddOpponentTeamModal: React.FC<AddOpponentTeamModalProps> = ({
           <div>
             <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
               <LinkIcon className="mr-1 inline h-4 w-4" />
-              Pokepaste / Pokebin URL *
+              Team Paste URL *
             </label>
             <input
               type="url"
               value={formData.pokepaste}
               onChange={(e) => handleInputChange("pokepaste", e.target.value)}
-              placeholder="https://pokepast.es/... or https://pokebin.com/..."
+              placeholder="https://pokepast.es/... or https://vrpastes.com/..."
               className="w-full rounded-lg border border-gray-300 bg-transparent px-3 py-2 text-sm text-gray-800 placeholder-gray-400 focus:border-brand-300 focus:outline-none focus:ring-3 focus:ring-brand-500/10 dark:border-gray-700 dark:text-white/90 dark:placeholder-gray-500"
               disabled={loading}
               required
             />
             <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              Link to the matchup team on Pokepaste or Pokebin
+              Link to the matchup team on Pokepaste, Pokebin, or VR Pastes
             </p>
           </div>
 

--- a/frontend/src/components/modals/NewTeamModal.tsx
+++ b/frontend/src/components/modals/NewTeamModal.tsx
@@ -125,13 +125,13 @@ const NewTeamModal: React.FC<NewTeamModalProps> = ({ isOpen, onClose, onCreated 
 
         {/* Pokepaste URL */}
         <div>
-          <Label htmlFor="pokepaste-url">Pokepaste URL</Label>
+          <Label htmlFor="pokepaste-url">Team Paste URL</Label>
           <input
             id="pokepaste-url"
             type="text"
             value={pokepaste}
             onChange={(e) => setPokepaste(e.target.value)}
-            placeholder="https://pokepast.es/..."
+            placeholder="https://pokepast.es/... or https://vrpastes.com/..."
             className={`h-11 w-full rounded-lg border bg-transparent px-4 py-2.5 text-sm shadow-theme-xs placeholder:text-gray-400 focus:outline-hidden focus:ring-3 dark:bg-white/[0.03] dark:text-white/90 dark:placeholder:text-white/30 ${
               !isValidUrl
                 ? "border-red-400 focus:border-red-400 focus:ring-red-500/10 dark:border-red-500"
@@ -139,7 +139,7 @@ const NewTeamModal: React.FC<NewTeamModalProps> = ({ isOpen, onClose, onCreated 
             }`}
           />
           {!isValidUrl && (
-            <p className="mt-1 text-xs text-red-500">Enter a valid pokepast.es or pokebin.com URL</p>
+            <p className="mt-1 text-xs text-red-500">Enter a valid pokepast.es, pokebin.com, or vrpastes.com URL</p>
           )}
           {previewNames && previewNames.length > 0 && (
             <div className="mt-3">

--- a/frontend/src/data/announcements.json
+++ b/frontend/src/data/announcements.json
@@ -1,5 +1,11 @@
 [
   {
+    "id": "2026-05-18-vrpastes-support",
+    "date": "2026-05-18",
+    "title": "New: VR Paste Support",
+    "message": "Added VR Paste support for creating teams and matchups."
+  },
+  {
     "id": "2026-05-17-speed-tiers",
     "date": "2026-05-17",
     "title": "New: Speed Tiers Page",

--- a/frontend/src/services/pokepasteService.ts
+++ b/frontend/src/services/pokepasteService.ts
@@ -1,5 +1,5 @@
 /**
- * Pokepaste service - fetches and parses Pokemon team pastes from pokepast.es and pokebin
+ * Pokepaste service - fetches and parses Pokemon team pastes from pokepast.es, pokebin, and vrpastes.com
  */
 
 import * as storageService from "./storageService";
@@ -8,13 +8,14 @@ import { apiClient } from "./api";
 // URL patterns
 const POKEPASTE_PATTERN = /^https?:\/\/(www\.)?pokepast\.es\/([a-zA-Z0-9]+)/;
 const POKEBIN_PATTERN = /^https?:\/\/(www\.)?pokebin\.com\/([a-zA-Z0-9]+)/;
+const VRPASTES_PATTERN = /^https?:\/\/(www\.)?vrpastes\.com\/([a-zA-Z0-9]+)/;
 
 // Cache configuration — v3 to invalidate old-format entries from original frontend
 const CACHE_KEY = "pokepaste_cache_v3";
 const CACHE_EXPIRY_HOURS = 24;
 
 interface PasteServiceType {
-  type: "pokepaste" | "pokebin";
+  type: "pokepaste" | "pokebin" | "vrpastes";
   pasteId: string;
 }
 
@@ -60,6 +61,11 @@ export function detectPasteService(url: string): PasteServiceType | null {
     return { type: "pokebin", pasteId: pokebinMatch[2] };
   }
 
+  const vrpastesMatch = url.match(VRPASTES_PATTERN);
+  if (vrpastesMatch) {
+    return { type: "vrpastes", pasteId: vrpastesMatch[2] };
+  }
+
   return null;
 }
 
@@ -86,7 +92,8 @@ export async function fetchAndParse(
   if (detected.type === "pokepaste") {
     pokemonData = await fetchPokepaste(detected.pasteId, pasteUrl, options?.maxPokemon);
   } else {
-    pokemonData = await fetchPokebin(detected.pasteId, pasteUrl, options?.maxPokemon);
+    // pokebin and vrpastes both proxy through the backend (CORS blocks direct browser fetch)
+    pokemonData = await fetchViaBackend(detected.pasteId, pasteUrl, options?.maxPokemon);
   }
 
   // Cache the result
@@ -121,9 +128,9 @@ async function fetchPokepaste(
 }
 
 /**
- * Fetch pokebin data via backend API
+ * Fetch via backend proxy — used for pokebin and vrpastes, since both block direct CORS
  */
-async function fetchPokebin(
+async function fetchViaBackend(
   _pasteId: string,
   originalUrl: string,
   maxPokemon?: number
@@ -150,10 +157,10 @@ async function fetchPokebin(
     } else if (data.rawText) {
       return parsePokepasteText(data.rawText as string, { maxPokemon });
     } else {
-      throw new Error("Invalid response from pokebin API");
+      throw new Error("Invalid response from paste API");
     }
   } catch (error) {
-    console.error("Error fetching pokebin:", error);
+    console.error("Error fetching paste via backend:", error);
     throw error;
   }
 }
@@ -395,12 +402,24 @@ export async function getCacheStats(): Promise<{
 }
 
 /**
- * Fetch the paste title from a pokepaste or pokebin URL.
- * Both services expose a /json endpoint with a title field.
+ * Fetch the paste title from a paste URL.
+ * Pokepaste and Pokebin expose a /json endpoint directly; VR Pastes goes through the backend
+ * proxy since its API blocks browser-origin CORS.
  */
 export async function fetchPasteTitle(pasteUrl: string): Promise<string | null> {
   const detected = detectPasteService(pasteUrl);
   if (!detected) return null;
+
+  if (detected.type === "vrpastes") {
+    try {
+      const data = await apiClient.get("/api/pokemon/pokepaste/parse", {
+        params: { url: pasteUrl },
+      }) as { title?: string | null };
+      return data.title || null;
+    } catch {
+      return null;
+    }
+  }
 
   const jsonUrl =
     detected.type === "pokepaste"


### PR DESCRIPTION
## Summary
- Adds `vrpastes.com` as a third supported paste host alongside Pokepaste and Pokebin.
- Works in both the new-team modal and the matchup planner's "Add Matchup Team" modal — same single URL field, just widened labels/placeholders/validation messages.
- VR Pastes' JSON API only allows its own origin via CORS, so the frontend routes VR Pastes URLs through the existing `/api/pokemon/pokepaste/fetch` backend proxy.

## Implementation notes
- `PokepasteService` gains a `VRPASTES_URL_PATTERN`, a third routing branch in `fetchPasteData`, and a `fetchVRPastesData` method that maps the VR Pastes JSON (`species`, `name`, `item`, `ability`, `teraType`, `moves`) onto the existing `PokepasteDTO.PokemonData` shape. No DTO changes.
- `teraType` is mapped when present (sibling of `level` / `type1` in the VR Pastes response), null otherwise — older pastes omit it.
- Frontend `pokepasteService.ts`: `detectPasteService` adds a `vrpastes` branch, `fetchPokebin` renamed to `fetchViaBackend` and is now shared between pokebin and vrpastes. `fetchPasteTitle` routes VR Pastes through the backend `pokepaste/parse` endpoint since the JSON endpoint is CORS-blocked from the browser.

## Test plan
- [ ] Backend: `curl 'http://localhost:8080/api/pokemon/pokepaste/parse?url=https%3A%2F%2Fwww.vrpastes.com%2Fk8n8vNVC'` returns `source: "vrpastes"`, `title: "test"`, and 6 Pokémon (Whimsicott, Charizard with `Charizardite Y`, …).
- [ ] Frontend "New Team" modal: pasting `https://www.vrpastes.com/k8n8vNVC` shows the 6-Pokémon preview and creates a team with the correct slots.
- [ ] Frontend "Add Matchup Team" modal (inside a game plan): same URL adds the opponent team and renders the Pokémon.
- [ ] Regression: existing Pokepaste and Pokebin URLs still work in both modals.
- [ ] Malformed URLs surface the updated "pokepast.es, pokebin.com, or vrpastes.com" validation message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)