### PR TITLE
feat: group bulk-imported replays by team before importing

### DIFF
--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/ReplayController.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/ReplayController.java
@@ -2,6 +2,7 @@ package com.yeskatronics.vs_recorder_backend.controllers;
 
 import com.yeskatronics.vs_recorder_backend.dto.ErrorResponse;
 import com.yeskatronics.vs_recorder_backend.dto.ReplayDTO;
+import com.yeskatronics.vs_recorder_backend.dto.ShowdownDTO;
 import com.yeskatronics.vs_recorder_backend.entities.Replay;
 import com.yeskatronics.vs_recorder_backend.mappers.ReplayMapper;
 import com.yeskatronics.vs_recorder_backend.security.CustomUserDetailsService;
@@ -90,6 +91,33 @@ public class ReplayController {
 
         ReplayDTO.Summary response = replayMapper.toSummaryDTO(savedReplay);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * Preview a replay from URL WITHOUT persisting it (bulk-import grouping step).
+     * POST /api/replays/preview?teamId={teamId}
+     *
+     * Returns the team-of-six the owner ran in this replay plus signal flags so the
+     * frontend can group replays by team before the user chooses what to import.
+     *
+     * @param teamId the team ID
+     * @param authentication the authenticated user
+     * @param request the replay URL
+     * @return the parsed (non-persisted) preview
+     */
+    @PostMapping("/preview")
+    public ResponseEntity<ShowdownDTO.ReplayPreview> previewReplayFromUrl(
+            @RequestParam Long teamId,
+            Authentication authentication,
+            @Valid @RequestBody ReplayDTO.CreateFromUrlRequest request) {
+
+        Long userId = getCurrentUserId(authentication);
+
+        // Verify team ownership
+        verifyTeamOwnership(teamId, userId);
+
+        ShowdownDTO.ReplayPreview preview = replayService.previewReplayFromUrl(teamId, request.getUrl());
+        return ResponseEntity.ok(preview);
     }
 
     /**

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/dto/ShowdownDTO.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/dto/ShowdownDTO.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * DTOs for Pokemon Showdown replay data.
@@ -25,5 +26,22 @@ public class ShowdownDTO {
         private String format;
         private String player1;
         private String player2;
+    }
+
+    /**
+     * DTO for a non-persisting bulk-import preview of a single replay. Carries the
+     * team-of-six the team owner ran in this battle so the frontend can group replays
+     * by team before importing.
+     */
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReplayPreview {
+        private String url;
+        private String opponent;
+        private String result; // "win" or "loss" from user pov
+        private List<String> userTeam; // raw Showdown species names of the user's side
+        private boolean matchesTeam; // user side's roster matches this team's registered roster
+        private boolean identified;  // a real username/roster signal pointed at one side
     }
 }

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/ReplayService.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/ReplayService.java
@@ -139,6 +139,19 @@ public class ReplayService {
     }
 
     /**
+     * Preview a replay from URL WITHOUT persisting it. Used by the bulk-import flow to
+     * detect the team-of-six the owner ran in each replay so the UI can group them.
+     */
+    public ShowdownDTO.ReplayPreview previewReplayFromUrl(Long teamId, String url) {
+        url = url.split("\\?")[0];
+
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new IllegalArgumentException("Team not found with ID: " + teamId));
+
+        return showdownService.previewReplay(url, team);
+    }
+
+    /**
      * Get a replay by ID
      *
      * @param id the replay ID

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/ShowdownService.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/ShowdownService.java
@@ -46,6 +46,114 @@ public class ShowdownService {
     public ShowdownDTO.ReplayData fetchReplayData(String replayUrl, Team team) {
         log.info("Fetching replay data from: {}", replayUrl);
 
+        try {
+            ParsedReplay parsed = fetchAndParse(replayUrl, team);
+
+            String userUsername = parsed.id.userUsername();
+            String opponentUsername = parsed.id.opponentUsername();
+            if (userUsername == null || userUsername.isBlank()) {
+                userUsername = parsed.player1;
+                opponentUsername = parsed.player2;
+            }
+
+            String result = determineResult(userUsername, parsed.winner);
+
+            log.info("Successfully fetched replay: {} vs {} ({})", userUsername, opponentUsername, result);
+
+            return new ShowdownDTO.ReplayData(
+                    parsed.battleLog, opponentUsername, result, parsed.date,
+                    parsed.format, parsed.player1, parsed.player2);
+
+        } catch (Exception e) {
+            log.error("Error fetching replay data: {}", e.getMessage(), e);
+            throw new IllegalArgumentException("Failed to fetch or parse replay data: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Fetch and parse a replay WITHOUT persisting anything, returning the team-of-six the
+     * team owner ran in this battle plus enough signal for the bulk-import preview to group
+     * replays. {@code matchesTeam} is true when the identified user side's revealed roster
+     * matches this team's registered roster; {@code identified} is false when no username or
+     * roster signal matched and {@link PlayerIdentifier} fell back to the default p1 side
+     * (i.e. the replay likely doesn't involve this team at all).
+     */
+    public ShowdownDTO.ReplayPreview previewReplay(String replayUrl, Team team) {
+        try {
+            ParsedReplay parsed = fetchAndParse(replayUrl, team);
+
+            String userPlayer = parsed.id.userPlayer();
+            List<String> userTeam = parsed.parsed.getTeams() == null
+                    ? Collections.emptyList()
+                    : parsed.parsed.getTeams().getOrDefault(userPlayer, Collections.emptyList());
+
+            boolean matchesTeam = PlayerIdentifier.teamMatches(
+                    userTeam, parsed.registeredRoster, pokemonService);
+
+            // "identified" means a real signal pointed at one side rather than the p1 default.
+            java.util.Map<String, String> players = parsed.parsed.getPlayers();
+            java.util.Map<String, List<String>> teams = parsed.parsed.getTeams();
+            boolean nameSignal = PlayerIdentifier.nameMatches(
+                        players == null ? null : players.get("p1"), parsed.registeredUsernames)
+                    || PlayerIdentifier.nameMatches(
+                        players == null ? null : players.get("p2"), parsed.registeredUsernames);
+            boolean teamSignal = PlayerIdentifier.teamMatches(
+                        teams == null ? null : teams.get("p1"), parsed.registeredRoster, pokemonService)
+                    || PlayerIdentifier.teamMatches(
+                        teams == null ? null : teams.get("p2"), parsed.registeredRoster, pokemonService);
+            boolean identified = nameSignal || teamSignal;
+
+            String userUsername = parsed.id.userUsername();
+            String opponentUsername = parsed.id.opponentUsername();
+            if (userUsername == null || userUsername.isBlank()) {
+                userUsername = parsed.player1;
+                opponentUsername = parsed.player2;
+            }
+            String result = determineResult(userUsername, parsed.winner);
+
+            return new ShowdownDTO.ReplayPreview(
+                    replayUrl, opponentUsername, result, userTeam, matchesTeam, identified);
+
+        } catch (Exception e) {
+            log.error("Error previewing replay data: {}", e.getMessage(), e);
+            throw new IllegalArgumentException("Failed to fetch or parse replay data: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Holder for the shared fetch → parse → identify pipeline reused by both
+     * {@link #fetchReplayData} and {@link #previewReplay}.
+     */
+    private static final class ParsedReplay {
+        final String battleLog;
+        final String player1;
+        final String player2;
+        final String format;
+        final String winner;
+        final LocalDateTime date;
+        final ReplayMatcher.BattleData parsed;
+        final PlayerIdentifier.Identification id;
+        final List<String> registeredUsernames;
+        final List<String> registeredRoster;
+
+        ParsedReplay(String battleLog, String player1, String player2, String format,
+                     String winner, LocalDateTime date, ReplayMatcher.BattleData parsed,
+                     PlayerIdentifier.Identification id, List<String> registeredUsernames,
+                     List<String> registeredRoster) {
+            this.battleLog = battleLog;
+            this.player1 = player1;
+            this.player2 = player2;
+            this.format = format;
+            this.winner = winner;
+            this.date = date;
+            this.parsed = parsed;
+            this.id = id;
+            this.registeredUsernames = registeredUsernames;
+            this.registeredRoster = registeredRoster;
+        }
+    }
+
+    private ParsedReplay fetchAndParse(String replayUrl, Team team) throws Exception {
         Matcher matcher = REPLAY_URL_PATTERN.matcher(replayUrl);
         if (!matcher.find()) {
             throw new IllegalArgumentException("Invalid Pokemon Showdown replay URL");
@@ -54,66 +162,49 @@ public class ShowdownService {
         String battleId = matcher.group(1);
         String jsonUrl = SHOWDOWN_REPLAY_BASE + "/" + battleId + ".json";
 
-        try {
-            long startTime = System.currentTimeMillis();
-            log.debug("Fetching from: {}", jsonUrl);
-            String jsonResponse = restTemplate.getForObject(jsonUrl, String.class);
-            long fetchDuration = System.currentTimeMillis() - startTime;
-            log.info("Fetched replay JSON from Showdown in {}ms", fetchDuration);
+        long startTime = System.currentTimeMillis();
+        log.debug("Fetching from: {}", jsonUrl);
+        String jsonResponse = restTemplate.getForObject(jsonUrl, String.class);
+        long fetchDuration = System.currentTimeMillis() - startTime;
+        log.info("Fetched replay JSON from Showdown in {}ms", fetchDuration);
 
-            if (jsonResponse == null || jsonResponse.isEmpty()) {
-                throw new IllegalArgumentException("Failed to fetch replay data");
-            }
-
-            JsonNode root = objectMapper.readTree(jsonResponse);
-            String battleLog = jsonResponse;
-
-            String player1 = root.get("players").get(0).asText();
-            String player2 = root.get("players").get(1).asText();
-            String format = root.path("format").asText();
-
-            String logText = root.path("log").asText();
-            String winner = extractWinner(logText);
-
-            List<String> registeredUsernames = team.getShowdownUsernames() == null
-                    ? Collections.emptyList()
-                    : team.getShowdownUsernames();
-            List<String> registeredRoster = team.getTeamMembers() == null
-                    ? Collections.emptyList()
-                    : team.getTeamMembers().stream()
-                        .map(TeamMember::getPokemonName)
-                        .collect(Collectors.toList());
-
-            ReplayMatcher.BattleData parsed = ReplayMatcher.extractBattleData(
-                    battleLog, registeredUsernames);
-
-            PlayerIdentifier.Identification id = PlayerIdentifier.identify(
-                    registeredUsernames,
-                    registeredRoster,
-                    parsed.getPlayers(),
-                    parsed.getTeams(),
-                    pokemonService
-            );
-
-            String userUsername = id.userUsername();
-            String opponentUsername = id.opponentUsername();
-            if (userUsername == null || userUsername.isBlank()) {
-                userUsername = player1;
-                opponentUsername = player2;
-            }
-
-            String result = determineResult(userUsername, winner);
-            LocalDateTime date = extractTimestamp(root);
-
-            log.info("Successfully fetched replay: {} vs {} ({})", userUsername, opponentUsername, result);
-
-            return new ShowdownDTO.ReplayData(
-                    battleLog, opponentUsername, result, date, format, player1, player2);
-
-        } catch (Exception e) {
-            log.error("Error fetching replay data: {}", e.getMessage(), e);
-            throw new IllegalArgumentException("Failed to fetch or parse replay data: " + e.getMessage());
+        if (jsonResponse == null || jsonResponse.isEmpty()) {
+            throw new IllegalArgumentException("Failed to fetch replay data");
         }
+
+        JsonNode root = objectMapper.readTree(jsonResponse);
+        String battleLog = jsonResponse;
+
+        String player1 = root.get("players").get(0).asText();
+        String player2 = root.get("players").get(1).asText();
+        String format = root.path("format").asText();
+
+        String logText = root.path("log").asText();
+        String winner = extractWinner(logText);
+        LocalDateTime date = extractTimestamp(root);
+
+        List<String> registeredUsernames = team.getShowdownUsernames() == null
+                ? Collections.emptyList()
+                : team.getShowdownUsernames();
+        List<String> registeredRoster = team.getTeamMembers() == null
+                ? Collections.emptyList()
+                : team.getTeamMembers().stream()
+                    .map(TeamMember::getPokemonName)
+                    .collect(Collectors.toList());
+
+        ReplayMatcher.BattleData parsed = ReplayMatcher.extractBattleData(
+                battleLog, registeredUsernames);
+
+        PlayerIdentifier.Identification id = PlayerIdentifier.identify(
+                registeredUsernames,
+                registeredRoster,
+                parsed.getPlayers(),
+                parsed.getTeams(),
+                pokemonService
+        );
+
+        return new ParsedReplay(battleLog, player1, player2, format, winner, date,
+                parsed, id, registeredUsernames, registeredRoster);
     }
 
     /**

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/utils/PlayerIdentifier.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/utils/PlayerIdentifier.java
@@ -77,14 +77,14 @@ public final class PlayerIdentifier {
         return new Identification(userSide, opp, userName, oppName);
     }
 
-    private static boolean nameMatches(String username, List<String> registered) {
+    public static boolean nameMatches(String username, List<String> registered) {
         if (username == null || username.isBlank() || registered == null) {
             return false;
         }
         return registered.stream().anyMatch(u -> u != null && u.equalsIgnoreCase(username));
     }
 
-    private static boolean teamMatches(
+    public static boolean teamMatches(
             List<String> revealed,
             List<String> registeredRoster,
             PokemonService pokemonService

--- a/frontend/src/components/modals/AddReplayModal.tsx
+++ b/frontend/src/components/modals/AddReplayModal.tsx
@@ -1,8 +1,20 @@
 import React, { useState, useEffect } from "react";
-import { Link as LinkIcon, Plus, AlertCircle, FileText } from "lucide-react";
+import {
+  Link as LinkIcon,
+  Plus,
+  AlertCircle,
+  FileText,
+  Copy,
+  Check,
+  ArrowLeft,
+  Download,
+  HelpCircle,
+} from "lucide-react";
 import { Modal } from "../ui/modal";
 import Label from "../form/Label";
+import PokemonTeam from "../pokemon/PokemonTeam";
 import * as replayService from "../../services/replayService";
+import { resolveAnalyticsKey } from "../../utils/pokemonNameUtils";
 
 interface AddReplayModalProps {
   isOpen: boolean;
@@ -12,6 +24,79 @@ interface AddReplayModalProps {
 }
 
 const REPLAY_URL_PATTERN = /^https?:\/\/replay\.pokemonshowdown\.com\/.+$/;
+
+/**
+ * A bucket of replays that share the same team-of-six (or the catch-all bucket of
+ * replays whose side couldn't be identified). `unidentified` rows have no meaningful
+ * representative team and only ever get a copy action.
+ */
+interface TeamGroup {
+  key: string;
+  teamNames: string[];
+  urls: string[];
+  matchesTeam: boolean;
+  unidentified: boolean;
+}
+
+const UNIDENTIFIED_KEY = "__unidentified__";
+
+/**
+ * Group previews by the team-of-six the owner ran (collapsing forme noise via
+ * resolveAnalyticsKey so the same team always lands together). Mirrors sort_replays.py:
+ * the active team's group is pinned first, then remaining groups by replay count desc,
+ * with the unidentified bucket last.
+ */
+function buildGroups(previews: replayService.ReplayPreview[]): TeamGroup[] {
+  const byKey = new Map<string, TeamGroup>();
+
+  for (const preview of previews) {
+    if (!preview.identified) {
+      const existing = byKey.get(UNIDENTIFIED_KEY);
+      if (existing) {
+        existing.urls.push(preview.url);
+      } else {
+        byKey.set(UNIDENTIFIED_KEY, {
+          key: UNIDENTIFIED_KEY,
+          teamNames: [],
+          urls: [preview.url],
+          matchesTeam: false,
+          unidentified: true,
+        });
+      }
+      continue;
+    }
+
+    const key = (preview.userTeam || [])
+      .map((name) => resolveAnalyticsKey(name))
+      .sort()
+      .join("|");
+
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.urls.push(preview.url);
+      existing.matchesTeam = existing.matchesTeam || preview.matchesTeam;
+    } else {
+      byKey.set(key, {
+        key,
+        teamNames: preview.userTeam || [],
+        urls: [preview.url],
+        matchesTeam: preview.matchesTeam,
+        unidentified: false,
+      });
+    }
+  }
+
+  const groups = Array.from(byKey.values());
+  groups.sort((a, b) => {
+    // Unidentified bucket always last.
+    if (a.unidentified !== b.unidentified) return a.unidentified ? 1 : -1;
+    // Matching team pinned to the top.
+    if (a.matchesTeam !== b.matchesTeam) return a.matchesTeam ? -1 : 1;
+    // Otherwise by replay count descending.
+    return b.urls.length - a.urls.length;
+  });
+  return groups;
+}
 
 const AddReplayModal: React.FC<AddReplayModalProps> = ({
   isOpen,
@@ -28,16 +113,30 @@ const AddReplayModal: React.FC<AddReplayModalProps> = ({
   const [error, setError] = useState("");
   const [progress, setProgress] = useState<{ current: number; total: number } | null>(null);
 
+  // Bulk preview/grouping step
+  const [bulkPhase, setBulkPhase] = useState<"input" | "preview">("input");
+  const [groups, setGroups] = useState<TeamGroup[]>([]);
+  const [failedCount, setFailedCount] = useState(0);
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
+
+  const resetState = () => {
+    setReplayUrl("");
+    setNotes("");
+    setMarkReviewed(false);
+    setBulkMode(false);
+    setBulkUrls("");
+    setError("");
+    setProgress(null);
+    setBulkPhase("input");
+    setGroups([]);
+    setFailedCount(0);
+    setCopiedKey(null);
+  };
+
   // Reset form when modal opens
   useEffect(() => {
     if (isOpen) {
-      setReplayUrl("");
-      setNotes("");
-      setMarkReviewed(false);
-      setBulkMode(false);
-      setBulkUrls("");
-      setError("");
-      setProgress(null);
+      resetState();
     }
   }, [isOpen]);
 
@@ -73,6 +172,7 @@ const AddReplayModal: React.FC<AddReplayModalProps> = ({
     }
   };
 
+  // Step 1 of bulk import: parse (without saving) and group by team.
   const handleBulkSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -99,9 +199,51 @@ const AddReplayModal: React.FC<AddReplayModalProps> = ({
       setError("");
 
       const cleanUrls = urls.map((url) => url.split("?")[0]);
-      const result = await replayService.createManyFromUrls(
+      const result = await replayService.previewManyFromUrls(
         teamId,
         cleanUrls,
+        (current, total) => setProgress({ current, total })
+      );
+
+      if (result.previews.length === 0) {
+        setError(
+          result.failed.length > 0
+            ? `Couldn't load any replays: ${result.failed[0].error}`
+            : "No replays could be parsed."
+        );
+        return;
+      }
+
+      setGroups(buildGroups(result.previews));
+      setFailedCount(result.failed.length);
+      setBulkPhase("preview");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to parse replays. Please try again.");
+    } finally {
+      setLoading(false);
+      setProgress(null);
+    }
+  };
+
+  const handleCopyGroup = async (group: TeamGroup) => {
+    try {
+      await navigator.clipboard.writeText(group.urls.join("\n"));
+      setCopiedKey(group.key);
+      setTimeout(() => setCopiedKey((k) => (k === group.key ? null : k)), 2000);
+    } catch (err) {
+      console.error("Failed to copy replay URLs:", err);
+    }
+  };
+
+  // Step 2 of bulk import: actually persist the chosen group.
+  const handleImportGroup = async (group: TeamGroup) => {
+    try {
+      setLoading(true);
+      setError("");
+
+      const result = await replayService.createManyFromUrls(
+        teamId,
+        group.urls,
         (current, total) => setProgress({ current, total }),
         markReviewed
       );
@@ -122,6 +264,8 @@ const AddReplayModal: React.FC<AddReplayModalProps> = ({
       setProgress(null);
     }
   };
+
+  const hasMatchingGroup = groups.some((g) => g.matchesTeam);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} className="max-w-lg p-6 sm:p-8">
@@ -252,7 +396,7 @@ const AddReplayModal: React.FC<AddReplayModalProps> = ({
             </button>
           </div>
         </form>
-      ) : (
+      ) : bulkPhase === "input" ? (
         <form onSubmit={handleBulkSubmit} className="space-y-5">
           {/* Bulk URLs */}
           <div>
@@ -274,20 +418,6 @@ const AddReplayModal: React.FC<AddReplayModalProps> = ({
             </p>
           </div>
 
-          {/* Mark all as reviewed */}
-          <div>
-            <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
-              <input
-                type="checkbox"
-                checked={markReviewed}
-                onChange={(e) => setMarkReviewed(e.target.checked)}
-                disabled={loading}
-                className="h-4 w-4 rounded border-gray-300 text-brand-500 focus:ring-brand-500/30 dark:border-gray-600 dark:bg-gray-800"
-              />
-              Mark all as reviewed
-            </label>
-          </div>
-
           {/* Info Box */}
           <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-500/20 dark:bg-blue-500/10">
             <div className="flex items-start gap-2">
@@ -295,8 +425,8 @@ const AddReplayModal: React.FC<AddReplayModalProps> = ({
               <div className="text-sm">
                 <p className="font-medium text-blue-700 dark:text-blue-400">Bulk Import</p>
                 <p className="mt-1 text-blue-600 dark:text-gray-300">
-                  This will import multiple replays at once. Each replay will be processed
-                  individually, so if some fail, others may still succeed.
+                  We'll parse each replay and group them by the team you ran, so you can
+                  import only the group that belongs to this team (and copy the others).
                 </p>
               </div>
             </div>
@@ -305,7 +435,7 @@ const AddReplayModal: React.FC<AddReplayModalProps> = ({
           {/* Progress */}
           {progress && (
             <div className="text-sm text-gray-600 dark:text-gray-400">
-              Processing {progress.current} of {progress.total}...
+              Parsing {progress.current} of {progress.total}...
             </div>
           )}
 
@@ -335,17 +465,155 @@ const AddReplayModal: React.FC<AddReplayModalProps> = ({
               {loading ? (
                 <>
                   <div className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
-                  Importing Replays...
+                  Parsing Replays...
                 </>
               ) : (
                 <>
-                  <Plus className="h-4 w-4" />
-                  Import All
+                  <FileText className="h-4 w-4" />
+                  Sort by Team
                 </>
               )}
             </button>
           </div>
         </form>
+      ) : (
+        /* Bulk preview: grouped teams */
+        <div className="space-y-5">
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Found {groups.filter((g) => !g.unidentified).length} team
+              {groups.filter((g) => !g.unidentified).length === 1 ? "" : "s"} across your replays.
+            </p>
+            <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+              <input
+                type="checkbox"
+                checked={markReviewed}
+                onChange={(e) => setMarkReviewed(e.target.checked)}
+                disabled={loading}
+                className="h-4 w-4 rounded border-gray-300 text-brand-500 focus:ring-brand-500/30 dark:border-gray-600 dark:bg-gray-800"
+              />
+              Mark as reviewed
+            </label>
+          </div>
+
+          {!hasMatchingGroup && (
+            <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-500/20 dark:bg-amber-500/10">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+              <p className="text-sm text-amber-700 dark:text-amber-400">
+                None of these groups match this team's roster. You can copy any group to use
+                elsewhere.
+              </p>
+            </div>
+          )}
+
+          <div className="max-h-[22rem] space-y-3 overflow-y-auto pr-1">
+            {groups.map((group) => (
+              <div
+                key={group.key}
+                className={`rounded-lg border p-3 ${
+                  group.matchesTeam
+                    ? "border-brand-400 bg-brand-50 dark:border-brand-500/40 dark:bg-brand-500/10"
+                    : "border-gray-200 dark:border-gray-700"
+                }`}
+              >
+                <div className="flex items-center justify-between gap-3">
+                  {group.unidentified ? (
+                    <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+                      <HelpCircle className="h-4 w-4 shrink-0" />
+                      <span>Unidentified ({group.urls.length})</span>
+                    </div>
+                  ) : (
+                    <PokemonTeam pokemonNames={group.teamNames} size="sm" />
+                  )}
+
+                  <div className="flex shrink-0 items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleCopyGroup(group)}
+                      disabled={loading}
+                      title="Copy these replay URLs"
+                      className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-2.5 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+                    >
+                      {copiedKey === group.key ? (
+                        <>
+                          <Check className="h-3.5 w-3.5" />
+                          Copied
+                        </>
+                      ) : (
+                        <>
+                          <Copy className="h-3.5 w-3.5" />
+                          Copy
+                        </>
+                      )}
+                    </button>
+                    {group.matchesTeam && (
+                      <button
+                        type="button"
+                        onClick={() => handleImportGroup(group)}
+                        disabled={loading}
+                        title="Import these replays into this team"
+                        className="inline-flex items-center gap-1.5 rounded-lg bg-brand-500 px-2.5 py-1.5 text-xs font-medium text-white hover:bg-brand-600 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        <Download className="h-3.5 w-3.5" />
+                        Import
+                      </button>
+                    )}
+                  </div>
+                </div>
+                <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
+                  {group.urls.length} replay{group.urls.length === 1 ? "" : "s"}
+                  {group.matchesTeam ? " · matches this team" : ""}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          {failedCount > 0 && (
+            <p className="text-xs text-gray-400 dark:text-gray-500">
+              {failedCount} replay{failedCount === 1 ? "" : "s"} failed to load and were skipped.
+            </p>
+          )}
+
+          {/* Progress */}
+          {progress && (
+            <div className="text-sm text-gray-600 dark:text-gray-400">
+              Importing {progress.current} of {progress.total}...
+            </div>
+          )}
+
+          {/* Error */}
+          {error && (
+            <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-500/20 dark:bg-red-500/10">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-600 dark:text-red-400" />
+              <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="flex justify-between gap-3 pt-2">
+            <button
+              type="button"
+              onClick={() => {
+                setBulkPhase("input");
+                setError("");
+                setProgress(null);
+              }}
+              disabled={loading}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Back
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={loading}
+              className="rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+            >
+              Done
+            </button>
+          </div>
+        </div>
       )}
     </Modal>
   );

--- a/frontend/src/services/api/replayApi.ts
+++ b/frontend/src/services/api/replayApi.ts
@@ -1,6 +1,19 @@
 import apiClient from "./client";
 import type { Replay } from "../../types";
 
+/**
+ * Non-persisting parse of a single replay, used by the bulk-import grouping step.
+ * Mirrors backend ShowdownDTO.ReplayPreview.
+ */
+export interface ReplayPreview {
+  url: string;
+  opponent: string;
+  result: string;
+  userTeam: string[];
+  matchesTeam: boolean;
+  identified: boolean;
+}
+
 export const replayApi = {
   getById: (id: number) =>
     apiClient.get(`/api/replays/${id}`) as Promise<Replay>,
@@ -10,6 +23,9 @@ export const replayApi = {
 
   createFromUrl: (teamId: number, url: string, notes = "", reviewed = false) =>
     apiClient.post(`/api/replays/from-url?teamId=${teamId}`, { url, notes, reviewed }) as Promise<Replay>,
+
+  previewFromUrl: (teamId: number, url: string) =>
+    apiClient.post(`/api/replays/preview?teamId=${teamId}`, { url }) as Promise<ReplayPreview>,
 
   create: (teamId: number, data: Partial<Replay>) =>
     apiClient.post(`/api/replays?teamId=${teamId}`, data) as Promise<Replay>,

--- a/frontend/src/services/replayService.ts
+++ b/frontend/src/services/replayService.ts
@@ -3,7 +3,10 @@
  */
 
 import { replayApi } from "./api";
+import type { ReplayPreview } from "./api/replayApi";
 import type { Replay, Match } from "../types";
+
+export type { ReplayPreview } from "./api/replayApi";
 
 /**
  * Get a replay by ID
@@ -167,6 +170,39 @@ export async function createManyFromUrls(
   }
 
   return { success, failed };
+}
+
+/**
+ * Preview multiple replays from URLs WITHOUT persisting them, with progress callback.
+ * Used by the bulk-import flow to detect the team-of-six the owner ran in each replay
+ * so the UI can group them before the user chooses what to import.
+ */
+export async function previewManyFromUrls(
+  teamId: number,
+  urls: string[],
+  progressCallback?: (current: number, total: number) => void
+): Promise<{ previews: ReplayPreview[]; failed: { url: string; error: string }[] }> {
+  const previews: ReplayPreview[] = [];
+  const failed: { url: string; error: string }[] = [];
+
+  for (let i = 0; i < urls.length; i++) {
+    try {
+      const preview = await replayApi.previewFromUrl(teamId, urls[i]);
+      previews.push(preview);
+    } catch (error) {
+      failed.push({
+        url: urls[i],
+        error: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+    if (progressCallback) {
+      progressCallback(i + 1, urls.length);
+    }
+    // Add small delay between requests
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  return { previews, failed };
 }
 
 /**


### PR DESCRIPTION
Bulk import now parses each submitted replay *without persisting it*, groups them by the team-of-six the owner ran, and lets the user import only the group matching the active team — copying the others for use elsewhere.

## Backend
- `ShowdownService.previewReplay` parses + identifies a replay without saving (shared `fetchAndParse` pipeline extracted from `fetchReplayData`, which is behavior-unchanged); returns the user-side team plus `matchesTeam`/`identified` flags.
- `POST /api/replays/preview` (non-persisting) + `ReplayService.previewReplayFromUrl`.
- `ShowdownDTO.ReplayPreview`; `PlayerIdentifier` name/team matchers made public.

## Frontend
- `replayApi.previewFromUrl` + `replayService.previewManyFromUrls` (with progress).
- `AddReplayModal` bulk flow is now two phases: **Sort by Team** parses + groups, then a preview pins the matching group (Import + Copy) above other groups (Copy only), with an Unidentified bucket and a failed-to-load count.

## Testing
- 72 backend tests pass (`ShowdownServiceTest`, `ReplayServiceTest`, `PlayerIdentifier*`, `PokemonServiceTest`, `ReplayMatcherTest`).
- Frontend not type-checked locally (no `node_modules` in this env) — needs `npm install && npm run build`.

## Note
Importing the matching group re-fetches each replay from Showdown (preview fetch + import fetch = two calls per imported replay) — the agreed "keep simple" tradeoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)