### PR TITLE
feat: Recent Tour modal — browse and import popular tournament teams

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "generate:speed-tiers": "node ../scripts/generate-speed-tiers.js"
+    "generate:speed-tiers": "node ../scripts/generate-speed-tiers.js",
+    "generate:tournament-teams": "node ../scripts/generate-tournament-teams.js"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/frontend/src/components/modals/RecentTourModal.tsx
+++ b/frontend/src/components/modals/RecentTourModal.tsx
@@ -1,0 +1,324 @@
+import React, { useMemo, useState } from "react";
+import {
+  Trophy,
+  ChevronDown,
+  ChevronUp,
+  ExternalLink,
+  Check,
+  Info,
+} from "lucide-react";
+import { Modal } from "../ui/modal";
+import PokemonSprite from "../pokemon/PokemonSprite";
+import {
+  getTournamentTeamsForRegulation,
+  type TournamentCluster,
+  type TournamentInnerTeam,
+} from "../../data/tournamentTeamsByRegulation";
+
+interface RecentTourModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  teamRegulation: string | null | undefined;
+  onImport: (pokepasteUrl: string, notes: string) => Promise<void>;
+}
+
+const COMP_SIZES = [6, 5, 4] as const;
+type CompSize = (typeof COMP_SIZES)[number];
+
+function formatWinRate(wins: number, losses: number): string {
+  const total = wins + losses;
+  if (total === 0) return "—";
+  return `${Math.round((wins / total) * 100)}%`;
+}
+
+function buildImportNotes(team: TournamentInnerTeam): string {
+  const parts: string[] = [];
+  if (team.name) parts.push(team.name);
+  if (team.tournamentName) parts.push(team.tournamentName);
+  if (team.placement) parts.push(`#${team.placement}`);
+  if (team.record) parts.push(team.record);
+  return parts.join(" · ");
+}
+
+const SpriteRow: React.FC<{ names: string[]; size?: "sm" | "md" }> = ({
+  names,
+  size = "sm",
+}) => (
+  <div className="flex flex-wrap items-center gap-0.5">
+    {names.map((n, i) => (
+      <PokemonSprite key={`${n}-${i}`} name={n} size={size} />
+    ))}
+  </div>
+);
+
+const InnerTeamRow: React.FC<{
+  team: TournamentInnerTeam;
+  imported: boolean;
+  importing: boolean;
+  onImport: () => void;
+}> = ({ team, imported, importing, onImport }) => {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-900">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
+        <span className="font-medium text-gray-800 dark:text-white/90">
+          {team.name || "Unnamed"}
+        </span>
+        {team.placement != null && (
+          <span className="rounded-full bg-brand-50 px-2 py-0.5 text-xs font-medium text-brand-700 dark:bg-brand-500/20 dark:text-brand-300">
+            #{team.placement}
+          </span>
+        )}
+        {team.record && (
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {team.record}
+          </span>
+        )}
+        {team.tournamentName && (
+          <span
+            className="truncate text-xs text-gray-500 dark:text-gray-400"
+            title={team.tournamentName}
+          >
+            {team.tournamentName}
+          </span>
+        )}
+      </div>
+
+      <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <SpriteRow names={team.pokemonNames} size="sm" />
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <a
+            href={team.pokepasteUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center justify-center gap-1.5 rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+            View Paste
+          </a>
+          <button
+            type="button"
+            onClick={onImport}
+            disabled={imported || importing}
+            className="flex items-center justify-center gap-1.5 rounded-lg bg-brand-500 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-brand-600 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {imported ? (
+              <>
+                <Check className="h-3.5 w-3.5" />
+                Imported
+              </>
+            ) : importing ? (
+              "Importing…"
+            ) : (
+              "Import"
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const ClusterCard: React.FC<{
+  cluster: TournamentCluster;
+  expanded: boolean;
+  onToggle: () => void;
+  importedUrls: Set<string>;
+  importingUrl: string | null;
+  onImport: (team: TournamentInnerTeam) => void;
+}> = ({ cluster, expanded, onToggle, importedUrls, importingUrl, onImport }) => {
+  const winRate = formatWinRate(cluster.wins, cluster.losses);
+  return (
+    <div className="rounded-lg border border-gray-200 bg-gray-50/50 dark:border-gray-700 dark:bg-white/[0.02]">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center justify-between gap-3 p-3 text-left transition-colors hover:bg-gray-100/60 dark:hover:bg-white/[0.04]"
+      >
+        <SpriteRow names={cluster.pokemonNames} size="sm" />
+        <div className="flex items-center gap-3 text-xs sm:text-sm">
+          <div className="text-right">
+            <div className="font-semibold text-gray-800 dark:text-white/90">
+              {winRate}
+            </div>
+            <div className="text-gray-500 dark:text-gray-400">
+              {cluster.wins}-{cluster.losses}
+            </div>
+          </div>
+          <div className="hidden sm:block text-right text-gray-500 dark:text-gray-400">
+            {cluster.teams.length} teams
+          </div>
+          {expanded ? (
+            <ChevronUp className="h-4 w-4 text-gray-400" />
+          ) : (
+            <ChevronDown className="h-4 w-4 text-gray-400" />
+          )}
+        </div>
+      </button>
+
+      {expanded && (
+        <div className="space-y-2 border-t border-gray-200 p-3 dark:border-gray-700">
+          {cluster.teams.length === 0 ? (
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              No individual teams available.
+            </p>
+          ) : (
+            cluster.teams.map((team, i) => (
+              <InnerTeamRow
+                key={`${team.pokepasteUrl}-${i}`}
+                team={team}
+                imported={importedUrls.has(team.pokepasteUrl)}
+                importing={importingUrl === team.pokepasteUrl}
+                onImport={() => onImport(team)}
+              />
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const RecentTourModal: React.FC<RecentTourModalProps> = ({
+  isOpen,
+  onClose,
+  teamRegulation,
+  onImport,
+}) => {
+  const data = useMemo(
+    () => getTournamentTeamsForRegulation(teamRegulation),
+    [teamRegulation],
+  );
+  const [activeSize, setActiveSize] = useState<CompSize>(6);
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
+  const [importedUrls, setImportedUrls] = useState<Set<string>>(new Set());
+  const [importingUrl, setImportingUrl] = useState<string | null>(null);
+
+  const composition = useMemo(
+    () => data?.compositions.find((c) => c.size === activeSize) ?? null,
+    [data, activeSize],
+  );
+
+  const handleImport = async (team: TournamentInnerTeam) => {
+    if (importedUrls.has(team.pokepasteUrl) || importingUrl) return;
+    setImportingUrl(team.pokepasteUrl);
+    try {
+      await onImport(team.pokepasteUrl, buildImportNotes(team));
+      setImportedUrls((prev) => new Set(prev).add(team.pokepasteUrl));
+    } finally {
+      setImportingUrl(null);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      className="mx-2 my-4 flex max-h-[90vh] w-[calc(100vw-1rem)] max-w-4xl flex-col sm:mx-auto"
+    >
+      <div className="flex flex-col overflow-hidden">
+        {/* Header */}
+        <div className="border-b border-gray-200 px-5 pb-4 pt-5 dark:border-gray-700 sm:px-7 sm:pt-7">
+          <h2 className="flex items-center gap-2 pr-10 text-lg font-semibold text-gray-800 dark:text-white/90 sm:text-xl">
+            <Trophy className="h-5 w-5 text-brand-500" />
+            Recent Tournament Teams
+          </h2>
+          {data ? (
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400 sm:text-sm">
+              Regulation {data.regulation} · {data.dateRange.from} – {data.dateRange.to} ·{" "}
+              <span>
+                Sourced from{" "}
+                <a
+                  href="https://labmaus.net"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-brand-500"
+                >
+                  labmaus.net
+                </a>
+              </span>
+            </p>
+          ) : (
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400 sm:text-sm">
+              Browse top tournament teams from the last 2 months.
+            </p>
+          )}
+        </div>
+
+        {data ? (
+          <>
+            {/* Tab bar */}
+            <div className="flex gap-1 border-b border-gray-200 px-5 pt-3 dark:border-gray-700 sm:px-7">
+              {COMP_SIZES.map((size) => {
+                const isActive = size === activeSize;
+                return (
+                  <button
+                    key={size}
+                    type="button"
+                    onClick={() => {
+                      setActiveSize(size);
+                      setExpandedKey(null);
+                    }}
+                    className={`rounded-t-lg px-3 py-2 text-sm font-medium transition-colors ${
+                      isActive
+                        ? "border-b-2 border-brand-500 text-brand-600 dark:text-brand-400"
+                        : "border-b-2 border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                    }`}
+                  >
+                    <span className="sm:hidden">{size}</span>
+                    <span className="hidden sm:inline">{size} Pokémon</span>
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* Cluster list */}
+            <div className="flex-1 space-y-2 overflow-y-auto px-5 py-4 sm:px-7">
+              {composition && composition.clusters.length > 0 ? (
+                composition.clusters.map((cluster, idx) => {
+                  const key = `${activeSize}-${idx}`;
+                  return (
+                    <ClusterCard
+                      key={key}
+                      cluster={cluster}
+                      expanded={expandedKey === key}
+                      onToggle={() =>
+                        setExpandedKey((prev) => (prev === key ? null : key))
+                      }
+                      importedUrls={importedUrls}
+                      importingUrl={importingUrl}
+                      onImport={handleImport}
+                    />
+                  );
+                })
+              ) : (
+                <p className="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+                  No clusters for this composition size.
+                </p>
+              )}
+            </div>
+          </>
+        ) : (
+          // Empty state — no data for this regulation
+          <div className="flex flex-1 items-center justify-center px-5 py-12 sm:px-7">
+            <div className="flex max-w-md flex-col items-center gap-3 text-center">
+              <Info className="h-10 w-10 text-gray-300 dark:text-gray-600" />
+              <h3 className="text-base font-semibold text-gray-700 dark:text-gray-300">
+                Not available yet
+              </h3>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Popular teams aren't available for{" "}
+                <span className="font-medium text-gray-700 dark:text-gray-300">
+                  {teamRegulation || "this regulation"}
+                </span>{" "}
+                yet. We currently have data for Regulation M-A — check back later
+                as more formats are added.
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+export default RecentTourModal;

--- a/frontend/src/components/modals/RecentTourModal.tsx
+++ b/frontend/src/components/modals/RecentTourModal.tsx
@@ -213,9 +213,15 @@ const RecentTourModal: React.FC<RecentTourModalProps> = ({
     <Modal
       isOpen={isOpen}
       onClose={onClose}
-      className="mx-2 my-4 flex max-h-[90vh] w-[calc(100vw-1rem)] max-w-4xl flex-col sm:mx-auto"
+      className="mx-2 my-4 w-[calc(100vw-1rem)] max-w-4xl overflow-hidden sm:mx-auto"
     >
-      <div className="flex flex-col overflow-hidden">
+      {/*
+        Explicit height (not just max-h) so the inner `flex-1 overflow-y-auto`
+        list has a definite parent height to fill — without it the list grows
+        to fit its content, overflows the dialog, and scroll-wheel events
+        bubble up to the Modal's outer wrapper.
+      */}
+      <div className="flex h-[calc(90vh-2rem)] max-h-[calc(100dvh-2rem)] flex-col">
         {/* Header */}
         <div className="border-b border-gray-200 px-5 pb-4 pt-5 dark:border-gray-700 sm:px-7 sm:pt-7">
           <h2 className="flex items-center gap-2 pr-10 text-lg font-semibold text-gray-800 dark:text-white/90 sm:text-xl">
@@ -272,7 +278,7 @@ const RecentTourModal: React.FC<RecentTourModalProps> = ({
             </div>
 
             {/* Cluster list */}
-            <div className="flex-1 space-y-2 overflow-y-auto px-5 py-4 sm:px-7">
+            <div className="min-h-0 flex-1 space-y-2 overflow-y-auto px-5 py-4 sm:px-7">
               {composition && composition.clusters.length > 0 ? (
                 composition.clusters.map((cluster, idx) => {
                   const key = `${activeSize}-${idx}`;

--- a/frontend/src/data/announcements.json
+++ b/frontend/src/data/announcements.json
@@ -1,5 +1,11 @@
 [
   {
+    "id": "2026-05-24-recent-tour",
+    "date": "2026-05-24",
+    "title": "New: Recent Tour Imports",
+    "message": "The Matchup Planner has a new 'Recent Tour' button that lets you browse popular tournament team archetypes (4/5/6-mon compositions) from the last two months and import one straight into your matchups. Currently covers Regulation M-A — more regulations coming. Data sourced from labmaus.net."
+  },
+  {
     "id": "2026-05-23-bulk-import",
     "date": "2026-05-23",
     "title": "Bulk Import Updates",

--- a/frontend/src/data/tournamentTeams-regM-A.json
+++ b/frontend/src/data/tournamentTeams-regM-A.json
@@ -1,0 +1,27656 @@
+{
+  "regulation": "M-A",
+  "labmausRegulation": "Regulation Set M-A",
+  "dateRange": {
+    "from": "2026-03-25",
+    "to": "2026-05-24"
+  },
+  "generatedAt": "2026-05-24",
+  "compositions": [
+    {
+      "size": 4,
+      "clusters": [
+        {
+          "pokemon": [
+            "006",
+            "445",
+            "902",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Garchomp",
+            "Basculegion-M",
+            "Kingambit"
+          ],
+          "wins": 1360,
+          "losses": 629,
+          "teams": [
+            {
+              "name": "mudhiman",
+              "placement": 1,
+              "record": "19-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/348127db40fb7b33",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "sword",
+              "placement": 1,
+              "record": "11-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Skarmory",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/911fc0a3f09bc4d0",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Drurtle",
+              "placement": 2,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/59d4a74a34d541e3",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Mentosbombe",
+              "placement": 3,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5b6333455eb1d308",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "EgoDeath",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Archaludon",
+                "Sableye",
+                "Garchomp",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/99782eaa9f14ada2",
+              "tournamentName": "*Sitrus-Series*|Champions|#57"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ea25e09006131d26",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "BigNation",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/800a3c915f24ab69",
+              "tournamentName": "Chaos League Sunday Slam #100 ($100 Prize Pool)"
+            },
+            {
+              "name": "Jin-Hao Jiang",
+              "placement": 1,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2aa8747d4bddd894",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "OrangeSteve",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/04783a017130fc96",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "Chrom",
+              "placement": 23,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c8fc5bcfddc17b3b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Luca",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/00503a0489ff0ccc",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "P_Amyrand",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0df4d758e8e4565c",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6b5c775626b6e112",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "JackChapman",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dde429f2fc6de55d",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "ZeBanded",
+              "placement": 3,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/927a1d9cc67e534f",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "KKCWind",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dadb91d6f888bff0",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Kim_Karzacian",
+              "placement": 5,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/177450409441dd3e",
+              "tournamentName": "ZGG #3 Pokemon Champions VGC $100 Tournament!"
+            },
+            {
+              "name": "Conics",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e22099ff2808b0bf",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "DobleK",
+              "placement": 6,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Incineroar",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fdf9f384711a811b",
+              "tournamentName": "Pokemon Champions Challenge #2"
+            },
+            {
+              "name": "anivgc",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83a3843ddca309ed",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "902",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Aerodactyl-Mega",
+            "Basculegion-M",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 1056,
+          "losses": 453,
+          "teams": [
+            {
+              "name": "soahmed",
+              "placement": 2,
+              "record": "11-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/10f4af89265000b8",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "OgreVGC",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/62ca06a2139fc268",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "Fluffy_m1n",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ec1822f5d298b94e",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Testing800",
+              "placement": 5,
+              "record": "16-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e2c09d328c27f6c8",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Marth",
+              "placement": 14,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/56ce80359fb80d9b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Wb_vg",
+              "placement": 1,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/79f18572188fc823",
+              "tournamentName": "Weekly | Liberation Crusade #1 | $100 |Volticons"
+            },
+            {
+              "name": "Andrea C",
+              "placement": 1,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ca59849270d1bd16",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "Mattytaxes",
+              "placement": 15,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1129e4a2ade1d08b",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "Kaz z",
+              "placement": 18,
+              "record": "13-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6a9d92ff26cca4c3",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Pabloam",
+              "placement": 29,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/06e6a4da985ac3a5",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 2,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b74f2a78b533ab2b",
+              "tournamentName": "The Drywall Series - Champions!"
+            },
+            {
+              "name": "Inge",
+              "placement": 2,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/33bc81394c5f587b",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "Wyuku",
+              "placement": 3,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b28e24f9e5b36bcf",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "JOAO",
+              "placement": 3,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c6eab74bc48b6f8d",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "DanielAcorn",
+              "placement": 3,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/46dd4679880267dc",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Z2R caiovibora",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/054ead062b8a2dff",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "Mattytaxes",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/18741766a50829d0",
+              "tournamentName": "Chaos League Sunday Slam #96"
+            },
+            {
+              "name": "TheOnlyHunt",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3d0ce9986ebd3f5a",
+              "tournamentName": "SNT First Pokémon Champions Tournament"
+            },
+            {
+              "name": "Starlight143",
+              "placement": 4,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Garchomp",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/801d6aa617a6863f",
+              "tournamentName": "Extreme Speed Pokémon Champions #2"
+            },
+            {
+              "name": "BrunoIPT",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c5df932ec1944d6",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "445",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Aerodactyl",
+            "Garchomp",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 1071,
+          "losses": 450,
+          "teams": [
+            {
+              "name": "Shishio_Ax",
+              "placement": 1,
+              "record": "11-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0d56e21aad4f3505",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "SilvioUeda",
+              "placement": 1,
+              "record": "12-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Volcarona",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e6752d26bfef1d42",
+              "tournamentName": "LIGA DA COMUNIDADE #3 (R$ 1.000 PRIZE POOL)"
+            },
+            {
+              "name": "tigerozi11",
+              "placement": 2,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ce03e3d95e233377",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "DozenSBU",
+              "placement": 7,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Garchomp",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/161200f3f4517e9e",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "Arekusabi",
+              "placement": 12,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b32461d35242dadb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Marth",
+              "placement": 14,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/56ce80359fb80d9b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "UItraVegito",
+              "placement": 3,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b14684ae442573c6",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 4,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7b11480dfff39367",
+              "tournamentName": "Coupe Critique Champions VGC #2 - 200€ prize"
+            },
+            {
+              "name": "arsalp",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a16cec328eefa9a4",
+              "tournamentName": "Chaos League Sunday Slam #96"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/50ab4d9dee0e56d3",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Andrea C",
+              "placement": 1,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ca59849270d1bd16",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "Kaz z",
+              "placement": 18,
+              "record": "13-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6a9d92ff26cca4c3",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Pabloam",
+              "placement": 29,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/06e6a4da985ac3a5",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Darkip_8",
+              "placement": 2,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Volcarona",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c2f82b11adb15a72",
+              "tournamentName": "Champions Tour LEPE #1 (5€ to 1st)"
+            },
+            {
+              "name": "averagememer57",
+              "placement": 2,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7f31b8d19a7b2a3e",
+              "tournamentName": "*Sitrus-Series*|Champions|#57"
+            },
+            {
+              "name": "MysticVGC_02",
+              "placement": 3,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7b086882a764ed2c",
+              "tournamentName": "Extreme Speed Pokémon Champions #2"
+            },
+            {
+              "name": "Raiyzer",
+              "placement": 3,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Delphox-Mega",
+                "Primarina",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d6e9688501151cfc",
+              "tournamentName": "Pokepal Smackdown #137 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "Swamp",
+              "placement": 3,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Delphox-Mega",
+                "Floette-Mega",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fa134c79a423553b",
+              "tournamentName": "VGCA Battle Hall #26"
+            },
+            {
+              "name": "Nano",
+              "placement": 3,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c54efc43422ddf9",
+              "tournamentName": "Extreme Speed Pokémon Champions #3"
+            },
+            {
+              "name": "DJGamer511",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Milotic",
+                "Garchomp",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e8a4f3659e82071b",
+              "tournamentName": "Talon's FIGHT CLUB #83 POKEMON CHAMPIONS"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "142",
+            "445",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Aerodactyl",
+            "Garchomp",
+            "Kingambit"
+          ],
+          "wins": 1107,
+          "losses": 512,
+          "teams": [
+            {
+              "name": "mudhiman",
+              "placement": 1,
+              "record": "19-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/348127db40fb7b33",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 1,
+              "record": "11-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0d56e21aad4f3505",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "Arekusabi",
+              "placement": 12,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b32461d35242dadb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "UItraVegito",
+              "placement": 3,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b14684ae442573c6",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "Mentosbombe",
+              "placement": 3,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5b6333455eb1d308",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 4,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7b11480dfff39367",
+              "tournamentName": "Coupe Critique Champions VGC #2 - 200€ prize"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/50ab4d9dee0e56d3",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ea25e09006131d26",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "BigNation",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/800a3c915f24ab69",
+              "tournamentName": "Chaos League Sunday Slam #100 ($100 Prize Pool)"
+            },
+            {
+              "name": "Chrom",
+              "placement": 23,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c8fc5bcfddc17b3b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "averagememer57",
+              "placement": 2,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7f31b8d19a7b2a3e",
+              "tournamentName": "*Sitrus-Series*|Champions|#57"
+            },
+            {
+              "name": "P_Amyrand",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0df4d758e8e4565c",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "MysticVGC_02",
+              "placement": 3,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7b086882a764ed2c",
+              "tournamentName": "Extreme Speed Pokémon Champions #2"
+            },
+            {
+              "name": "Nano",
+              "placement": 3,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c54efc43422ddf9",
+              "tournamentName": "Extreme Speed Pokémon Champions #3"
+            },
+            {
+              "name": "DJGamer511",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Milotic",
+                "Garchomp",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e8a4f3659e82071b",
+              "tournamentName": "Talon's FIGHT CLUB #83 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "averagememer57",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/588776aaf7efa3bc",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "KKCWind",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dadb91d6f888bff0",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Conics",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e22099ff2808b0bf",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "DyeItTight",
+              "placement": 59,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c1a5a1cee801cbf3",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/877aac7820d660d9",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "445",
+            "902",
+            "983"
+          ],
+          "pokemonNames": [
+            "Aerodactyl-Mega",
+            "Garchomp",
+            "Basculegion-M",
+            "Kingambit"
+          ],
+          "wins": 1079,
+          "losses": 506,
+          "teams": [
+            {
+              "name": "mudhiman",
+              "placement": 1,
+              "record": "19-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/348127db40fb7b33",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Marth",
+              "placement": 14,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/56ce80359fb80d9b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Mentosbombe",
+              "placement": 3,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5b6333455eb1d308",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Andrea C",
+              "placement": 1,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ca59849270d1bd16",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ea25e09006131d26",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "BigNation",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/800a3c915f24ab69",
+              "tournamentName": "Chaos League Sunday Slam #100 ($100 Prize Pool)"
+            },
+            {
+              "name": "Kaz z",
+              "placement": 18,
+              "record": "13-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6a9d92ff26cca4c3",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Chrom",
+              "placement": 23,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c8fc5bcfddc17b3b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Pabloam",
+              "placement": 29,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/06e6a4da985ac3a5",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "P_Amyrand",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0df4d758e8e4565c",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "charismaacheck",
+              "placement": 3,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/16eea4587f4df90f",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Starlight143",
+              "placement": 4,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Garchomp",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/801d6aa617a6863f",
+              "tournamentName": "Extreme Speed Pokémon Champions #2"
+            },
+            {
+              "name": "KKCWind",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dadb91d6f888bff0",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Conics",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e22099ff2808b0bf",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "ironicpanda",
+              "placement": 46,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83533838183d56bf",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Kibble125",
+              "placement": 47,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/44460d7760fb2a96",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/877aac7820d660d9",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Davi Guimaraes",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b0bce48841c2b8f",
+              "tournamentName": "Friday Fight Night #53 Reg M-A Bo3"
+            },
+            {
+              "name": "Sergyo91",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8645009bd9bb2117",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "Ksomon",
+              "placement": 1,
+              "record": "10-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ebef6770b45e9f2f",
+              "tournamentName": "Champions Collective #9"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "445",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Garchomp",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 902,
+          "losses": 410,
+          "teams": [
+            {
+              "name": "BIlllmads",
+              "placement": 2,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1c3f692f429b7efe",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 1,
+              "record": "11-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0d56e21aad4f3505",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "Guixx",
+              "placement": 2,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Dragapult",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e259cd0cfe5bb8d7",
+              "tournamentName": "TORNEO SALIDA POKÉMON CHAMPIONS"
+            },
+            {
+              "name": "Arekusabi",
+              "placement": 12,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b32461d35242dadb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "UItraVegito",
+              "placement": 3,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b14684ae442573c6",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 4,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7b11480dfff39367",
+              "tournamentName": "Coupe Critique Champions VGC #2 - 200€ prize"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/50ab4d9dee0e56d3",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "averagememer57",
+              "placement": 2,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7f31b8d19a7b2a3e",
+              "tournamentName": "*Sitrus-Series*|Champions|#57"
+            },
+            {
+              "name": "Fester213",
+              "placement": 3,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/88f02ce2c018c6c5",
+              "tournamentName": "Talon's FIGHT CLUB #79 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "MysticVGC_02",
+              "placement": 3,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7b086882a764ed2c",
+              "tournamentName": "Extreme Speed Pokémon Champions #2"
+            },
+            {
+              "name": "Nano",
+              "placement": 3,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c54efc43422ddf9",
+              "tournamentName": "Extreme Speed Pokémon Champions #3"
+            },
+            {
+              "name": "JackChapman",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dde429f2fc6de55d",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "DJGamer511",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Milotic",
+                "Garchomp",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e8a4f3659e82071b",
+              "tournamentName": "Talon's FIGHT CLUB #83 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Fireboule",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4d9af893845415dd",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "averagememer57",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/588776aaf7efa3bc",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "BySergi023",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Dragapult",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/60d9136febf7ab67",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "Kim_Karzacian",
+              "placement": 5,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/177450409441dd3e",
+              "tournamentName": "ZGG #3 Pokemon Champions VGC $100 Tournament!"
+            },
+            {
+              "name": "Raydevy",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b6aaf1d5a4e8948e",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "anivgc",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83a3843ddca309ed",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Arnau",
+              "placement": 7,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Gengar-Mega",
+                "Garchomp",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b1a3783c8c732cef",
+              "tournamentName": "TORNEO SALIDA POKÉMON CHAMPIONS"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "445",
+            "547",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Garchomp",
+            "Whimsicott",
+            "Kingambit"
+          ],
+          "wins": 874,
+          "losses": 374,
+          "teams": [
+            {
+              "name": "BIlllmads",
+              "placement": 2,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1c3f692f429b7efe",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "sword",
+              "placement": 1,
+              "record": "11-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Skarmory",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/911fc0a3f09bc4d0",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "nckster",
+              "placement": 6,
+              "record": "11-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Incineroar",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8281777eef16f5e6",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "Drurtle",
+              "placement": 2,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/59d4a74a34d541e3",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Jin-Hao Jiang",
+              "placement": 1,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2aa8747d4bddd894",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "OrangeSteve",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/04783a017130fc96",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "turboisonline",
+              "placement": 22,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Rotom-Wash",
+                "Conkeldurr",
+                "Whimsicott",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/bbe824dd8af21069",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Luca",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/00503a0489ff0ccc",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6b5c775626b6e112",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "Fester213",
+              "placement": 3,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/88f02ce2c018c6c5",
+              "tournamentName": "Talon's FIGHT CLUB #79 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "JackChapman",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dde429f2fc6de55d",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "ZeBanded",
+              "placement": 3,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/927a1d9cc67e534f",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Fireboule",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4d9af893845415dd",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "Raydevy",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b6aaf1d5a4e8948e",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "DobleK",
+              "placement": 6,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Incineroar",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fdf9f384711a811b",
+              "tournamentName": "Pokemon Champions Challenge #2"
+            },
+            {
+              "name": "anivgc",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83a3843ddca309ed",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Ihsan S",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Gardevoir",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/25a782ef3ff8a23b",
+              "tournamentName": "Coupe Critique Champions VGC #2 - 200€ prize"
+            },
+            {
+              "name": "allhailhippo",
+              "placement": 7,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Incineroar",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/96ba9bee8f9f3321",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "volcaronavgc",
+              "placement": 8,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Garchomp",
+                "Rotom-Wash",
+                "Whimsicott",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/69889d9c6e067695",
+              "tournamentName": "Pokemon Champions Challenge #1"
+            },
+            {
+              "name": "SableyeVGC",
+              "placement": 36,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e8ac52db2c9ae0da",
+              "tournamentName": "The Grand Champions Festival"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "445",
+            "902",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Garchomp",
+            "Basculegion-M",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 1022,
+          "losses": 441,
+          "teams": [
+            {
+              "name": "Grimmothy_Snarl",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Delphox-Mega",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5eb4ffae39975131",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "Marth",
+              "placement": 14,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/56ce80359fb80d9b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Andrea C",
+              "placement": 1,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ca59849270d1bd16",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "4lphabet",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9ff1b5571adf0ead",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "Kaz z",
+              "placement": 18,
+              "record": "13-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6a9d92ff26cca4c3",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Alex Madara",
+              "placement": 27,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c91a9f58a7fa86eb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "TechnicallyInsane",
+              "placement": 28,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/208f92972f973077",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Pabloam",
+              "placement": 29,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/06e6a4da985ac3a5",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "bpecina03",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Garchomp",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e0a0267aff1bdcfc",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "JackChapman",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dde429f2fc6de55d",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "4lphabet",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/999e838891b8264b",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            },
+            {
+              "name": "Starlight143",
+              "placement": 4,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Garchomp",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/801d6aa617a6863f",
+              "tournamentName": "Extreme Speed Pokémon Champions #2"
+            },
+            {
+              "name": "shaikhvgc786",
+              "placement": 4,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Sylveon",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0c5091cfc97606f4",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Kim_Karzacian",
+              "placement": 5,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/177450409441dd3e",
+              "tournamentName": "ZGG #3 Pokemon Champions VGC $100 Tournament!"
+            },
+            {
+              "name": "anivgc",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83a3843ddca309ed",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Dysi2404",
+              "placement": 7,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Gengar",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/46ae8c4df49315a9",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "aboxoftimbits",
+              "placement": 35,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Garchomp",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/df9c152dd73454cb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "SableyeVGC",
+              "placement": 36,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e8ac52db2c9ae0da",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "ironicpanda",
+              "placement": 46,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83533838183d56bf",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Kibble125",
+              "placement": 47,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/44460d7760fb2a96",
+              "tournamentName": "The Grand Champions Festival"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "670",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Aerodactyl-Mega",
+            "Floette-Mega",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 787,
+          "losses": 345,
+          "teams": [
+            {
+              "name": "soahmed",
+              "placement": 2,
+              "record": "11-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/10f4af89265000b8",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "OgreVGC",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/62ca06a2139fc268",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "SilvioUeda",
+              "placement": 1,
+              "record": "12-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Volcarona",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e6752d26bfef1d42",
+              "tournamentName": "LIGA DA COMUNIDADE #3 (R$ 1.000 PRIZE POOL)"
+            },
+            {
+              "name": "QuantumSlack",
+              "placement": 1,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Floette",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0ad0d5a5d6732495",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Selahattin Sturm",
+              "placement": 2,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e15c3f2bee0fc373",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "Arekusabi",
+              "placement": 12,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b32461d35242dadb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Marth",
+              "placement": 14,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/56ce80359fb80d9b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "HahaDeiv",
+              "placement": 1,
+              "record": "11-0-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Delphox",
+                "Floette-Mega",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/43f1fe56a9a074fe",
+              "tournamentName": "VGCA Battle #25"
+            },
+            {
+              "name": "Mattytaxes",
+              "placement": 15,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1129e4a2ade1d08b",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "Darkip_8",
+              "placement": 2,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Volcarona",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c2f82b11adb15a72",
+              "tournamentName": "Champions Tour LEPE #1 (5€ to 1st)"
+            },
+            {
+              "name": "NonoVGC",
+              "placement": 3,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Delphox",
+                "Floette-Mega",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a8960e93a0331a36",
+              "tournamentName": "TARTAN TAKEDOWN #27 - [CHAMPIONS]"
+            },
+            {
+              "name": "Wyuku",
+              "placement": 3,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b28e24f9e5b36bcf",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "Swamp",
+              "placement": 3,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Delphox-Mega",
+                "Floette-Mega",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fa134c79a423553b",
+              "tournamentName": "VGCA Battle Hall #26"
+            },
+            {
+              "name": "DanielAcorn",
+              "placement": 3,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/46dd4679880267dc",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Nano",
+              "placement": 3,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c54efc43422ddf9",
+              "tournamentName": "Extreme Speed Pokémon Champions #3"
+            },
+            {
+              "name": "Mattytaxes",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/18741766a50829d0",
+              "tournamentName": "Chaos League Sunday Slam #96"
+            },
+            {
+              "name": "TheOnlyHunt",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3d0ce9986ebd3f5a",
+              "tournamentName": "SNT First Pokémon Champions Tournament"
+            },
+            {
+              "name": "BrunoIPT",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c5df932ec1944d6",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Feitan7",
+              "placement": 5,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Whimsicott",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/09d4c18b2fcd796f",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "TheBardo",
+              "placement": 7,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0f798ccf85bdc13f",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "142",
+            "445",
+            "902"
+          ],
+          "pokemonNames": [
+            "Charizard-Mega Y",
+            "Aerodactyl",
+            "Garchomp",
+            "Basculegion-M"
+          ],
+          "wins": 908,
+          "losses": 452,
+          "teams": [
+            {
+              "name": "mudhiman",
+              "placement": 1,
+              "record": "19-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/348127db40fb7b33",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Mentosbombe",
+              "placement": 3,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5b6333455eb1d308",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "k3ngo",
+              "placement": 4,
+              "record": "10-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e5acc541b2683488",
+              "tournamentName": "LIGA DA COMUNIDADE #3 (R$ 1.000 PRIZE POOL)"
+            },
+            {
+              "name": "Kojay",
+              "placement": 4,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/026ccbe833514d3c",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ea25e09006131d26",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "BigNation",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/800a3c915f24ab69",
+              "tournamentName": "Chaos League Sunday Slam #100 ($100 Prize Pool)"
+            },
+            {
+              "name": "Kojay",
+              "placement": 1,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f72602b39bd3b599",
+              "tournamentName": "10ToesDownVGC #31 Champions $100 Top 4(Late Join)"
+            },
+            {
+              "name": "Chrom",
+              "placement": 23,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c8fc5bcfddc17b3b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Kojay",
+              "placement": 2,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0575b8df0394ea8c",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "P_Amyrand",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0df4d758e8e4565c",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "Kojay",
+              "placement": 3,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7caaeccf61114454",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "KKCWind",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dadb91d6f888bff0",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Conics",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e22099ff2808b0bf",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "TheGamerVGC",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fe863526ff682822",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/877aac7820d660d9",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Davi Guimaraes",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b0bce48841c2b8f",
+              "tournamentName": "Friday Fight Night #53 Reg M-A Bo3"
+            },
+            {
+              "name": "Sergyo91",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8645009bd9bb2117",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "Ksomon",
+              "placement": 1,
+              "record": "10-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ebef6770b45e9f2f",
+              "tournamentName": "Champions Collective #9"
+            },
+            {
+              "name": "NMR | FelipeT",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9da3ce35f701f567",
+              "tournamentName": "The Drywalls Series #5 - Champions!"
+            },
+            {
+              "name": "DaniVGC03",
+              "placement": 6,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fa7a9a3ddc0f8c45",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "670",
+            "902",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Floette",
+            "Basculegion-M",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 716,
+          "losses": 309,
+          "teams": [
+            {
+              "name": "soahmed",
+              "placement": 2,
+              "record": "11-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/10f4af89265000b8",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "OgreVGC",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/62ca06a2139fc268",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "Grimmothy_Snarl",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Delphox-Mega",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5eb4ffae39975131",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "Marth",
+              "placement": 14,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/56ce80359fb80d9b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Mariz",
+              "placement": 3,
+              "record": "11-2-0",
+              "pokemonNames": [
+                "Delphox",
+                "Floette",
+                "Aegislash-Blade",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/27b7bba18054ffe5",
+              "tournamentName": "LIGA DA COMUNIDADE #3 (R$ 1.000 PRIZE POOL)"
+            },
+            {
+              "name": "4lphabet",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9ff1b5571adf0ead",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "Murm",
+              "placement": 1,
+              "record": "11-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Whimsicott",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/301e87ce91a2d0e3",
+              "tournamentName": "Talon's FIGHT CLUB #82 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Mattytaxes",
+              "placement": 15,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1129e4a2ade1d08b",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "Alex Madara",
+              "placement": 27,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c91a9f58a7fa86eb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "TechnicallyInsane",
+              "placement": 28,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/208f92972f973077",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Wyuku",
+              "placement": 3,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b28e24f9e5b36bcf",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "DanielAcorn",
+              "placement": 3,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/46dd4679880267dc",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "4lphabet",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/999e838891b8264b",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            },
+            {
+              "name": "Mattytaxes",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/18741766a50829d0",
+              "tournamentName": "Chaos League Sunday Slam #96"
+            },
+            {
+              "name": "TheOnlyHunt",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3d0ce9986ebd3f5a",
+              "tournamentName": "SNT First Pokémon Champions Tournament"
+            },
+            {
+              "name": "Roi G",
+              "placement": 4,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Floette-Mega",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2f775058f87ae8fd",
+              "tournamentName": "Weekly | Liberation Crusade #1 | $100 |Volticons"
+            },
+            {
+              "name": "Murm",
+              "placement": 4,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Delphox-Mega",
+                "Talonflame",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/63b693c44c43b25e",
+              "tournamentName": "Talon's FIGHT CLUB #81 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "BrunoIPT",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c5df932ec1944d6",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "jANMxRin",
+              "placement": 29,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5d372827560c8482",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "sempra",
+              "placement": 32,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Kangaskhan",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/521c1a9ff79fd7f7",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "1018",
+            "279",
+            "902",
+            "903"
+          ],
+          "pokemonNames": [
+            "Archaludon",
+            "Pelipper",
+            "Basculegion-M",
+            "Sneasler"
+          ],
+          "wins": 871,
+          "losses": 438,
+          "teams": [
+            {
+              "name": "Freyaknightvgc",
+              "placement": 2,
+              "record": "10-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Archaludon",
+                "Pelipper",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fbca5ed14bab7da1",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "BlackwingKakashi",
+              "placement": 2,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler",
+                "Glimmora"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5a778483f3bc5e86",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Racka2023",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9e80cb9704c61ac9",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Kumanomi",
+              "placement": 1,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6922a9ea01e44bac",
+              "tournamentName": "Devils Den Tournaments #74"
+            },
+            {
+              "name": "jameskbostock",
+              "placement": 24,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Archaludon",
+                "Pelipper",
+                "Dragalge",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cb1e38105b7ffdec",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "charismaacheck",
+              "placement": 31,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Aerodactyl",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain"
+              ],
+              "pokepasteUrl": "https://pokepast.es/db8f38d75da6b8a1",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Martz",
+              "placement": 2,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite-Mega",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler",
+                "Orthworm"
+              ],
+              "pokepasteUrl": "https://pokepast.es/79b359914a3d3ed2",
+              "tournamentName": "Tenki's Cart - Pokémon Champions M-A ruleset!"
+            },
+            {
+              "name": "Justin G",
+              "placement": 2,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Pelipper",
+                "Manectric",
+                "Tsareena",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/62b58616c8e03dac",
+              "tournamentName": "Devils Den Tournaments #74"
+            },
+            {
+              "name": "Anzumous",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Meganium",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c6512f62ab827815",
+              "tournamentName": "The Drywall Series - Champions!"
+            },
+            {
+              "name": "jameskbostock",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Archaludon",
+                "Dragonite",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e4f136bed2e9e082",
+              "tournamentName": "TARTAN TAKEDOWN #27 - [CHAMPIONS]"
+            },
+            {
+              "name": "Z2R Queiroz",
+              "placement": 7,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Pelipper",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f6b579ed5be28c30",
+              "tournamentName": "LIGA DA COMUNIDADE #3 (R$ 1.000 PRIZE POOL)"
+            },
+            {
+              "name": "afakedugong",
+              "placement": 20,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite-Mega",
+                "Pelipper",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2bb38ae74a64bc20",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "J6Hydra",
+              "placement": 31,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Archaludon",
+                "Dragonite-Mega",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/88f93382c1b3f46a",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "patcon5",
+              "placement": 41,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2b074b2e16e3bbd8",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Azulite",
+              "placement": 43,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Aerodactyl",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain"
+              ],
+              "pokepasteUrl": "https://pokepast.es/56fec6712f3b581e",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "masa ",
+              "placement": 52,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Pelipper",
+                "Excadrill-Mega",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/bea9c64500e067e1",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "Fab2006",
+              "placement": 1,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Gengar-Mega",
+                "Archaludon",
+                "Meganium-Mega",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/da633734011f7a56",
+              "tournamentName": "Pregio Champions Tournament Weekly #21"
+            },
+            {
+              "name": "BowlingVGC",
+              "placement": 1,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Meganium",
+                "Tyranitar",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0d10075d1472149f",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #68👑"
+            },
+            {
+              "name": "HyogaVGC",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Aerodactyl",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain"
+              ],
+              "pokepasteUrl": "https://pokepast.es/051a9f086fb02df3",
+              "tournamentName": "The Wide League Saturday Night Rumble #85"
+            },
+            {
+              "name": "Furnoz",
+              "placement": 5,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Meganium",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/164a2d05321aac44",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "445",
+            "670",
+            "902",
+            "983"
+          ],
+          "pokemonNames": [
+            "Garchomp",
+            "Floette-Mega",
+            "Basculegion-M",
+            "Kingambit"
+          ],
+          "wins": 842,
+          "losses": 376,
+          "teams": [
+            {
+              "name": "mudhiman",
+              "placement": 1,
+              "record": "19-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/348127db40fb7b33",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Grimmothy_Snarl",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Delphox-Mega",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5eb4ffae39975131",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "Marth",
+              "placement": 14,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/56ce80359fb80d9b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "4lphabet",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9ff1b5571adf0ead",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "TurboMatt",
+              "placement": 1,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Aegislash-Blade",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/419b6ff3481023bd",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "PizzaMan",
+              "placement": 21,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Aegislash-Blade",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/bbbfe3a20b3dc65c",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Alex Madara",
+              "placement": 27,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c91a9f58a7fa86eb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "TechnicallyInsane",
+              "placement": 28,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/208f92972f973077",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "QueerCrocodile",
+              "placement": 3,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Whimsicott",
+                "Volcarona",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/301140d75a23c295",
+              "tournamentName": "Talon's FIGHT CLUB #82 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "4lphabet",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/999e838891b8264b",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            },
+            {
+              "name": "Conics",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e22099ff2808b0bf",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Hidan",
+              "placement": 44,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7c2d12d1649bcd59",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "washy",
+              "placement": 51,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cf2275d04536a34f",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/877aac7820d660d9",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Davi Guimaraes",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b0bce48841c2b8f",
+              "tournamentName": "Friday Fight Night #53 Reg M-A Bo3"
+            },
+            {
+              "name": "Sergyo91",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8645009bd9bb2117",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "Xeb41",
+              "placement": 5,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass-Mega",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3d5314b535e0403b",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "Neya",
+              "placement": 6,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Aegislash-Blade",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2c06c827ea449519",
+              "tournamentName": "Rookidee VGC Cup"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a8b7ca848bcf5d66",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "charpie",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b393ddebcd0fc581",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "445",
+            "478",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Garchomp",
+            "Froslass-Mega",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 766,
+          "losses": 317,
+          "teams": [
+            {
+              "name": "tigerozi11",
+              "placement": 2,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ce03e3d95e233377",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Hq2009",
+              "placement": 11,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/72c4df0b4951df04",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Z2R caiovibora",
+              "placement": 3,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Milotic",
+                "Garchomp",
+                "Froslass-Mega",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d3b9c7be62fd370a",
+              "tournamentName": "Pokemon Champions Challenge #1"
+            },
+            {
+              "name": "arsalp",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a16cec328eefa9a4",
+              "tournamentName": "Chaos League Sunday Slam #96"
+            },
+            {
+              "name": "Kaz z",
+              "placement": 18,
+              "record": "13-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6a9d92ff26cca4c3",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Pabloam",
+              "placement": 29,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/06e6a4da985ac3a5",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Luxerna",
+              "placement": 2,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Whimsicott",
+                "Delphox",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/80d92a9ebfc57884",
+              "tournamentName": "Pokémon Champions SV #1"
+            },
+            {
+              "name": "BatCoach",
+              "placement": 2,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6d19bcb7e5253072",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "BatCoach",
+              "placement": 2,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f8bc213bbe3a4763",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "almondspy",
+              "placement": 2,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e6a9312e6b3497aa",
+              "tournamentName": "Talon's FIGHT CLUB #82 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "trevYah",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Primarina",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/263e60e0cbd2f225",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "Willowatt",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e30472cf8d8b2f94",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "shaikhvgc786",
+              "placement": 4,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Sylveon",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0c5091cfc97606f4",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Hq2009",
+              "placement": 6,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/65b146a04b0df2b8",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Badus",
+              "placement": 26,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Primarina",
+                "Corviknight",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/924cdd8ff4a7f925",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "ironicpanda",
+              "placement": 46,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83533838183d56bf",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Kibble125",
+              "placement": 47,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/44460d7760fb2a96",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "BatCoach",
+              "placement": 1,
+              "record": "10-0-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/eb1545b33c2c98bc",
+              "tournamentName": "Unova Champions League #5 / POKÉMON CHAMPIONS"
+            },
+            {
+              "name": "Gustav H",
+              "placement": 1,
+              "record": "8-0-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/641c548126d6340d",
+              "tournamentName": "Champions Tour LEPE #5"
+            },
+            {
+              "name": "Xeb41",
+              "placement": 5,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass-Mega",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3d5314b535e0403b",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "670",
+            "902",
+            "983"
+          ],
+          "pokemonNames": [
+            "Aerodactyl",
+            "Floette",
+            "Basculegion-M",
+            "Kingambit"
+          ],
+          "wins": 662,
+          "losses": 318,
+          "teams": [
+            {
+              "name": "mudhiman",
+              "placement": 1,
+              "record": "19-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/348127db40fb7b33",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "soahmed",
+              "placement": 2,
+              "record": "11-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/10f4af89265000b8",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "OgreVGC",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/62ca06a2139fc268",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "Marth",
+              "placement": 14,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/56ce80359fb80d9b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Mattytaxes",
+              "placement": 15,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1129e4a2ade1d08b",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "Wyuku",
+              "placement": 3,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b28e24f9e5b36bcf",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "DanielAcorn",
+              "placement": 3,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/46dd4679880267dc",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Mattytaxes",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/18741766a50829d0",
+              "tournamentName": "Chaos League Sunday Slam #96"
+            },
+            {
+              "name": "TheOnlyHunt",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3d0ce9986ebd3f5a",
+              "tournamentName": "SNT First Pokémon Champions Tournament"
+            },
+            {
+              "name": "BrunoIPT",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c5df932ec1944d6",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Conics",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e22099ff2808b0bf",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "jANMxRin",
+              "placement": 29,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5d372827560c8482",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "sempra",
+              "placement": 32,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Kangaskhan",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/521c1a9ff79fd7f7",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/877aac7820d660d9",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Davi Guimaraes",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b0bce48841c2b8f",
+              "tournamentName": "Friday Fight Night #53 Reg M-A Bo3"
+            },
+            {
+              "name": "Sergyo91",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8645009bd9bb2117",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "Aitor54",
+              "placement": 5,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Aegislash-Blade",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c4e07993e81af368",
+              "tournamentName": "Tenki's Cart - Pokémon Champions M-A ruleset!"
+            },
+            {
+              "name": "Murm",
+              "placement": 6,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Blastoise-Mega",
+                "Aerodactyl",
+                "Floette-Mega",
+                "Aegislash-Blade",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f8b2b838ff32a444",
+              "tournamentName": "Talon's FIGHT CLUB #80 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Wyuku",
+              "placement": 6,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cef1711e4f592754",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "FF",
+              "placement": 7,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2f58e20d66659ce5",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "1018",
+            "149",
+            "279",
+            "902"
+          ],
+          "pokemonNames": [
+            "Archaludon",
+            "Dragonite",
+            "Pelipper",
+            "Basculegion-M"
+          ],
+          "wins": 782,
+          "losses": 369,
+          "teams": [
+            {
+              "name": "BlackwingKakashi",
+              "placement": 2,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler",
+                "Glimmora"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5a778483f3bc5e86",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "joethefenix",
+              "placement": 8,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Archaludon",
+                "Dragonite",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f582638fd3819dec",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "LovelyLuna",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83b7f94f93437d17",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Racka2023",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9e80cb9704c61ac9",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Kumanomi",
+              "placement": 1,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6922a9ea01e44bac",
+              "tournamentName": "Devils Den Tournaments #74"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 1,
+              "record": "12-0-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/49216904fa49e246",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Martz",
+              "placement": 2,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite-Mega",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler",
+                "Orthworm"
+              ],
+              "pokepasteUrl": "https://pokepast.es/79b359914a3d3ed2",
+              "tournamentName": "Tenki's Cart - Pokémon Champions M-A ruleset!"
+            },
+            {
+              "name": "eslsvsisss2",
+              "placement": 3,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Raichu",
+                "Archaludon",
+                "Dragonite-Mega",
+                "Azumarill",
+                "Pelipper",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fe3ae36923a80998",
+              "tournamentName": "Tenki's Cart - Pokémon Champions M-A ruleset!"
+            },
+            {
+              "name": "jameskbostock",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Archaludon",
+                "Dragonite",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e4f136bed2e9e082",
+              "tournamentName": "TARTAN TAKEDOWN #27 - [CHAMPIONS]"
+            },
+            {
+              "name": "Raichu123",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite-Mega",
+                "Scizor-Mega",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/846bd3281d7f460e",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "Jonnycat",
+              "placement": 7,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7008334d30cdea4c",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "afakedugong",
+              "placement": 20,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite-Mega",
+                "Pelipper",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2bb38ae74a64bc20",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "J6Hydra",
+              "placement": 31,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Archaludon",
+                "Dragonite-Mega",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/88f93382c1b3f46a",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "patcon5",
+              "placement": 41,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2b074b2e16e3bbd8",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/28c80f87a380cdc4",
+              "tournamentName": "*Sitrus-Series*|Champions|#59"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/87e74a59eb1e9ef1",
+              "tournamentName": "Talon's FIGHT CLUB #85 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Fester213",
+              "placement": 5,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2d083af8171a0f63",
+              "tournamentName": "Talon's FIGHT CLUB #81 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2d4bba21eb8ed36d",
+              "tournamentName": "Talon's FIGHT CLUB #82 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Raichu123",
+              "placement": 5,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2535cbc1fd236c6c",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 5,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f03ffd5dafb863a1",
+              "tournamentName": "*Sitrus-Series*|Champions|#57"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "478",
+            "902",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Froslass-Mega",
+            "Basculegion-M",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 695,
+          "losses": 302,
+          "teams": [
+            {
+              "name": "MegaUmbreonVGC",
+              "placement": 2,
+              "record": "17-3-0",
+              "pokemonNames": [
+                "Dragonite",
+                "Milotic",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fb02b02fc264939b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Benny V",
+              "placement": 1,
+              "record": "13-1-0",
+              "pokemonNames": [
+                "Clefable",
+                "Froslass",
+                "Rotom-Heat",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/162b72810953c7ae",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "Hoej",
+              "placement": 4,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Froslass",
+                "Tsareena",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/40fb85b14ad1be6b",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "Connor Sparks",
+              "placement": 1,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Dragonite",
+                "Milotic",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/08b38f8b54ff0372",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            },
+            {
+              "name": "Kaz z",
+              "placement": 18,
+              "record": "13-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6a9d92ff26cca4c3",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Pabloam",
+              "placement": 29,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/06e6a4da985ac3a5",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Exonarf",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Froslass",
+                "Primarina",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/44652c5152dd6e25",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "shaikhvgc786",
+              "placement": 4,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Sylveon",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0c5091cfc97606f4",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "mava",
+              "placement": 33,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Froslass",
+                "Rotom-Wash",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c8ad1848e00f3e6b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Fosco",
+              "placement": 37,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Dragonite",
+                "Milotic",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/40fd668c3132099f",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Alasdiego",
+              "placement": 45,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Froslass-Mega",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/833a3ba9ab87ea59",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "ironicpanda",
+              "placement": 46,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83533838183d56bf",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Kibble125",
+              "placement": 47,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/44460d7760fb2a96",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "steeltrainer",
+              "placement": 53,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Froslass",
+                "Floette",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a482eff8733d28f0",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "Lorenzaooooo",
+              "placement": 58,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Froslass",
+                "Rotom-Wash",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6e7f8fd11929754b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Sodamario",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Dragonite",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1b2db7ece2e7352d",
+              "tournamentName": "Head Bussa's Hoedown#30 Champions $100 Top 4"
+            },
+            {
+              "name": "Xeb41",
+              "placement": 5,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass-Mega",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3d5314b535e0403b",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "Davidbob32",
+              "placement": 5,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d5e29c2bd34ef0de",
+              "tournamentName": "VGCA Battle Hall #26"
+            },
+            {
+              "name": "SpicyCigar",
+              "placement": 5,
+              "record": "6-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/73a0e330e6f81d70",
+              "tournamentName": "Rookidee VGC Cup"
+            },
+            {
+              "name": "Soraxjm",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Froslass",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3096b54adf10ea58",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "142",
+            "902",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Aerodactyl",
+            "Basculegion-M",
+            "Kingambit"
+          ],
+          "wins": 773,
+          "losses": 379,
+          "teams": [
+            {
+              "name": "mudhiman",
+              "placement": 1,
+              "record": "19-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/348127db40fb7b33",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Mentosbombe",
+              "placement": 3,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5b6333455eb1d308",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ea25e09006131d26",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "BigNation",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/800a3c915f24ab69",
+              "tournamentName": "Chaos League Sunday Slam #100 ($100 Prize Pool)"
+            },
+            {
+              "name": "Chrom",
+              "placement": 23,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c8fc5bcfddc17b3b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "P_Amyrand",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0df4d758e8e4565c",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "BrunoIPT",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c5df932ec1944d6",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "KKCWind",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dadb91d6f888bff0",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Conics",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e22099ff2808b0bf",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/877aac7820d660d9",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "21kieran",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Excadrill",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2290b6d54b09e6a7",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "Davi Guimaraes",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b0bce48841c2b8f",
+              "tournamentName": "Friday Fight Night #53 Reg M-A Bo3"
+            },
+            {
+              "name": "Sergyo91",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8645009bd9bb2117",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "Ksomon",
+              "placement": 1,
+              "record": "10-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ebef6770b45e9f2f",
+              "tournamentName": "Champions Collective #9"
+            },
+            {
+              "name": "NMR | FelipeT",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9da3ce35f701f567",
+              "tournamentName": "The Drywalls Series #5 - Champions!"
+            },
+            {
+              "name": "DaniVGC03",
+              "placement": 6,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fa7a9a3ddc0f8c45",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "mrelax0327",
+              "placement": 7,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/118c68395a0a85a8",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a8b7ca848bcf5d66",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "charpie",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b393ddebcd0fc581",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "thekill009",
+              "placement": 2,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7e017159ea147fb3",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "445",
+            "670",
+            "983"
+          ],
+          "pokemonNames": [
+            "Aerodactyl",
+            "Garchomp",
+            "Floette-Mega",
+            "Kingambit"
+          ],
+          "wins": 749,
+          "losses": 334,
+          "teams": [
+            {
+              "name": "mudhiman",
+              "placement": 1,
+              "record": "19-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/348127db40fb7b33",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "SilvioUeda",
+              "placement": 1,
+              "record": "12-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Volcarona",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e6752d26bfef1d42",
+              "tournamentName": "LIGA DA COMUNIDADE #3 (R$ 1.000 PRIZE POOL)"
+            },
+            {
+              "name": "Arekusabi",
+              "placement": 12,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b32461d35242dadb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Marth",
+              "placement": 14,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/56ce80359fb80d9b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Darkip_8",
+              "placement": 2,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Volcarona",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c2f82b11adb15a72",
+              "tournamentName": "Champions Tour LEPE #1 (5€ to 1st)"
+            },
+            {
+              "name": "Swamp",
+              "placement": 3,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Delphox-Mega",
+                "Floette-Mega",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fa134c79a423553b",
+              "tournamentName": "VGCA Battle Hall #26"
+            },
+            {
+              "name": "Nano",
+              "placement": 3,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c54efc43422ddf9",
+              "tournamentName": "Extreme Speed Pokémon Champions #3"
+            },
+            {
+              "name": "Conics",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e22099ff2808b0bf",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Feitan7",
+              "placement": 5,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Whimsicott",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/09d4c18b2fcd796f",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "ScriptVX",
+              "placement": 8,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Garchomp",
+                "Delphox",
+                "Floette",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6a37c2296d89ea18",
+              "tournamentName": "ZGG #3 Pokemon Champions VGC $100 Tournament!"
+            },
+            {
+              "name": "DyeItTight",
+              "placement": 59,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c1a5a1cee801cbf3",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/877aac7820d660d9",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Davi Guimaraes",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b0bce48841c2b8f",
+              "tournamentName": "Friday Fight Night #53 Reg M-A Bo3"
+            },
+            {
+              "name": "Sergyo91",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8645009bd9bb2117",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "Ricardo A",
+              "placement": 5,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Delphox",
+                "Floette",
+                "Incineroar",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0c461e13d61612c8",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a8b7ca848bcf5d66",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "charpie",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b393ddebcd0fc581",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "thekill009",
+              "placement": 2,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7e017159ea147fb3",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Serber",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3629a0feb9659868",
+              "tournamentName": "Pokemon Champions Challenge #4"
+            },
+            {
+              "name": "Yuma0O",
+              "placement": 9,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/07fab198f290ddbe",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "445",
+            "547",
+            "902"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Garchomp",
+            "Whimsicott",
+            "Basculegion-M"
+          ],
+          "wins": 661,
+          "losses": 283,
+          "teams": [
+            {
+              "name": "sword",
+              "placement": 1,
+              "record": "11-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Skarmory",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/911fc0a3f09bc4d0",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Drurtle",
+              "placement": 2,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/59d4a74a34d541e3",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Jin-Hao Jiang",
+              "placement": 1,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2aa8747d4bddd894",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "OrangeSteve",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/04783a017130fc96",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "Luca",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/00503a0489ff0ccc",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6b5c775626b6e112",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "JackChapman",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dde429f2fc6de55d",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "ZeBanded",
+              "placement": 3,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/927a1d9cc67e534f",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "DobleK",
+              "placement": 6,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Incineroar",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fdf9f384711a811b",
+              "tournamentName": "Pokemon Champions Challenge #2"
+            },
+            {
+              "name": "anivgc",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83a3843ddca309ed",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Ihsan S",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Gardevoir",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/25a782ef3ff8a23b",
+              "tournamentName": "Coupe Critique Champions VGC #2 - 200€ prize"
+            },
+            {
+              "name": "allhailhippo",
+              "placement": 7,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Incineroar",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/96ba9bee8f9f3321",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "SableyeVGC",
+              "placement": 36,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e8ac52db2c9ae0da",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Hidan",
+              "placement": 44,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7c2d12d1649bcd59",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Holasoy",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/49ac56f0f7a7e3cd",
+              "tournamentName": "Pokepal Smackdown #138 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "mr_h",
+              "placement": 1,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Weavile",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6ca91f2b30742f27",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "Noah Smith",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b46c5e06f5bf93ce",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #3 2026"
+            },
+            {
+              "name": "Gerva02VGC",
+              "placement": 5,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Floette",
+                "Basculegion-M",
+                "Glimmora"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e62969c7c5c5be99",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "TinxoLibre",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0054d566adc72298",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Spindato",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d8e6c6141f87e4ec",
+              "tournamentName": "POKÉMON CHAMPIONS Circuito VGC #1 | Z2 Gaming"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "445",
+            "547",
+            "903"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Garchomp",
+            "Whimsicott",
+            "Sneasler"
+          ],
+          "wins": 604,
+          "losses": 307,
+          "teams": [
+            {
+              "name": "BIlllmads",
+              "placement": 2,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1c3f692f429b7efe",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "Bartho",
+              "placement": 1,
+              "record": "10-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Aegislash-Blade",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/41875d9aa20618a2",
+              "tournamentName": "Coupe Critique Champions VGC #1 - 100€ de cp"
+            },
+            {
+              "name": "Lore95",
+              "placement": 5,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Rotom-Wash",
+                "Whimsicott",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5c9812b718012dcd",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 16,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Aegislash-Blade",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/663919cfddd63f95",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "Fester213",
+              "placement": 3,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/88f02ce2c018c6c5",
+              "tournamentName": "Talon's FIGHT CLUB #79 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "JackChapman",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dde429f2fc6de55d",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "Fireboule",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4d9af893845415dd",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 5,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Aegislash-Blade",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/210a33e5e33a92d0",
+              "tournamentName": "TORNEO SALIDA POKÉMON CHAMPIONS"
+            },
+            {
+              "name": "Raydevy",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b6aaf1d5a4e8948e",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "anivgc",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83a3843ddca309ed",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "volcaronavgc",
+              "placement": 8,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Garchomp",
+                "Rotom-Wash",
+                "Whimsicott",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/69889d9c6e067695",
+              "tournamentName": "Pokemon Champions Challenge #1"
+            },
+            {
+              "name": "SableyeVGC",
+              "placement": 36,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e8ac52db2c9ae0da",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Watrr",
+              "placement": 37,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Rotom-Wash",
+                "Whimsicott",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a956f68633503ee7",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "NYR",
+              "placement": 64,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Sinistcha",
+                "Tyranitar",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f7aa94ee939d4a3f",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "illll",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Incineroar",
+                "Sneasler",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5be3c1bdc3edb7ef",
+              "tournamentName": "Pokémon Champions Reg M-A | CGCL Weekly #1"
+            },
+            {
+              "name": "Holasoy",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/49ac56f0f7a7e3cd",
+              "tournamentName": "Pokepal Smackdown #138 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "Laxidaze3",
+              "placement": 1,
+              "record": "6-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Gardevoir",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4a9d23d5fd284fc0",
+              "tournamentName": "[REG M-A] LearningtoSam's Weekly PokéLeague"
+            },
+            {
+              "name": "Lore95",
+              "placement": 7,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Garchomp",
+                "Rotom-Wash",
+                "Whimsicott",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/89be10249cea2900",
+              "tournamentName": "Champions Tour LEPE #1 (5€ to 1st)"
+            },
+            {
+              "name": "slimeslatt25",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/eb256351a870eb16",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "kuballo10",
+              "placement": 2,
+              "record": "6-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7034d23fa82fad46",
+              "tournamentName": "[REG M-A] LearningtoSam's Weekly PokéLeague"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "003",
+            "006",
+            "445",
+            "727"
+          ],
+          "pokemonNames": [
+            "Venusaur",
+            "Charizard-Mega Y",
+            "Garchomp",
+            "Incineroar"
+          ],
+          "wins": 667,
+          "losses": 392,
+          "teams": [
+            {
+              "name": "nckster",
+              "placement": 6,
+              "record": "11-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Incineroar",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8281777eef16f5e6",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "AnimatedEagle",
+              "placement": 9,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Milotic",
+                "Garchomp",
+                "Floette",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/831e1b957c9e531f",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "Ahaze13",
+              "placement": 12,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2e0271c472f8fd3e",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "Sanvy",
+              "placement": 3,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/28bfa91565bb181f",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "BADM_3",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e8a9c3fe1cafe141",
+              "tournamentName": "Extreme Speed Pokémon Champions #3"
+            },
+            {
+              "name": "B3N",
+              "placement": 25,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Torkoal",
+                "Garchomp",
+                "Incineroar",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/52607ee258928db6",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "Hidalgo F",
+              "placement": 30,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Gyarados",
+                "Garchomp",
+                "Incineroar",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6351de0d82f4290e",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "Cartman",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Orthworm"
+              ],
+              "pokepasteUrl": "https://pokepast.es/230d6d3e80a5e27a",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "Hooper",
+              "placement": 19,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Rotom-Wash",
+                "Incineroar",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2ba9369534664400",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "Piedrer",
+              "placement": 30,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a8c11914fb45aac7",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "AleK97",
+              "placement": 40,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Milotic",
+                "Garchomp",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b1dcac345227108c",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Magic_rana",
+              "placement": 54,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Milotic",
+                "Garchomp",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4f4a715e8e88c010",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Syntex",
+              "placement": 7,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard-Mega Y",
+                "Garchomp",
+                "Rotom-Wash",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2c71da9eb00d23b9",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "Mlgreen",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Sinistcha",
+                "Garchomp",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/895075529cd7de51",
+              "tournamentName": "Weekly | Liberation Crusade #1 | $100 |Volticons"
+            },
+            {
+              "name": "Style_VGC",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d4b040dc535f1991",
+              "tournamentName": "Pokémon Champions Reg M-A | CGCL Weekly #1"
+            },
+            {
+              "name": "kimi_au",
+              "placement": 10,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/62088f7298767e92",
+              "tournamentName": "*Sitrus-Series*|Champions|$100 to 1st"
+            },
+            {
+              "name": "FENIX",
+              "placement": 11,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Rotom-Wash",
+                "Incineroar",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/147110c418c2e344",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "ZUKY187",
+              "placement": 14,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard-Mega Y",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7e74ec574310896f",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "Scooteezy",
+              "placement": 15,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/680513585ec95801",
+              "tournamentName": "Pokemon Champions Challenge #1"
+            },
+            {
+              "name": "Zango",
+              "placement": 16,
+              "record": "6-4-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Incineroar",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/62aa8f0cbfd96597",
+              "tournamentName": "ZGG #3 Pokemon Champions VGC $100 Tournament!"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "445",
+            "670",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Garchomp",
+            "Floette-Mega",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 693,
+          "losses": 305,
+          "teams": [
+            {
+              "name": "Grimmothy_Snarl",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Delphox-Mega",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5eb4ffae39975131",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "SilvioUeda",
+              "placement": 1,
+              "record": "12-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Volcarona",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e6752d26bfef1d42",
+              "tournamentName": "LIGA DA COMUNIDADE #3 (R$ 1.000 PRIZE POOL)"
+            },
+            {
+              "name": "Arekusabi",
+              "placement": 12,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b32461d35242dadb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Marth",
+              "placement": 14,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/56ce80359fb80d9b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "4lphabet",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9ff1b5571adf0ead",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "Alex Madara",
+              "placement": 27,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c91a9f58a7fa86eb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "TechnicallyInsane",
+              "placement": 28,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/208f92972f973077",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Darkip_8",
+              "placement": 2,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Volcarona",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c2f82b11adb15a72",
+              "tournamentName": "Champions Tour LEPE #1 (5€ to 1st)"
+            },
+            {
+              "name": "Swamp",
+              "placement": 3,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Delphox-Mega",
+                "Floette-Mega",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fa134c79a423553b",
+              "tournamentName": "VGCA Battle Hall #26"
+            },
+            {
+              "name": "Nano",
+              "placement": 3,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c54efc43422ddf9",
+              "tournamentName": "Extreme Speed Pokémon Champions #3"
+            },
+            {
+              "name": "4lphabet",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/999e838891b8264b",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            },
+            {
+              "name": "Feitan7",
+              "placement": 5,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Whimsicott",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/09d4c18b2fcd796f",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "washy",
+              "placement": 51,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cf2275d04536a34f",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "DyeItTight",
+              "placement": 59,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c1a5a1cee801cbf3",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Otark",
+              "placement": 5,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Delphox",
+                "Floette",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cccc57409882cef2",
+              "tournamentName": "CHAMPIONS COLLECTIVE INAUGURAL TOURNAMENT"
+            },
+            {
+              "name": "Xeb41",
+              "placement": 5,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass-Mega",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3d5314b535e0403b",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "4lphabet",
+              "placement": 7,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Delphox",
+                "Floette",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/340632218e4b2cc5",
+              "tournamentName": "TARTAN TAKEDOWN #27 - [CHAMPIONS]"
+            },
+            {
+              "name": "asterisc",
+              "placement": 2,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Delphox",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/07861d7f07939b47",
+              "tournamentName": "PCP Premier Series: A Champion's Welcome!"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 9,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f418a398741b22cd",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "LiebesleidVGC",
+              "placement": 10,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/49b3061cb21922ff",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "547",
+            "902",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Whimsicott",
+            "Basculegion-M",
+            "Kingambit"
+          ],
+          "wins": 583,
+          "losses": 245,
+          "teams": [
+            {
+              "name": "sword",
+              "placement": 1,
+              "record": "11-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Skarmory",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/911fc0a3f09bc4d0",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Drurtle",
+              "placement": 2,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/59d4a74a34d541e3",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Murm",
+              "placement": 1,
+              "record": "11-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Whimsicott",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/301e87ce91a2d0e3",
+              "tournamentName": "Talon's FIGHT CLUB #82 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Jin-Hao Jiang",
+              "placement": 1,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2aa8747d4bddd894",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "OrangeSteve",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/04783a017130fc96",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "Luca",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/00503a0489ff0ccc",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6b5c775626b6e112",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "JackChapman",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dde429f2fc6de55d",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "ZeBanded",
+              "placement": 3,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/927a1d9cc67e534f",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "DobleK",
+              "placement": 6,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Incineroar",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fdf9f384711a811b",
+              "tournamentName": "Pokemon Champions Challenge #2"
+            },
+            {
+              "name": "anivgc",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83a3843ddca309ed",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Ihsan S",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Gardevoir",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/25a782ef3ff8a23b",
+              "tournamentName": "Coupe Critique Champions VGC #2 - 200€ prize"
+            },
+            {
+              "name": "allhailhippo",
+              "placement": 7,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Incineroar",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/96ba9bee8f9f3321",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "SableyeVGC",
+              "placement": 36,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e8ac52db2c9ae0da",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Hidan",
+              "placement": 44,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7c2d12d1649bcd59",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Holasoy",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/49ac56f0f7a7e3cd",
+              "tournamentName": "Pokepal Smackdown #138 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "TinxoLibre",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Whimsicott",
+                "Sylveon",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b34842af369f1918",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Noah Smith",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b46c5e06f5bf93ce",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #3 2026"
+            },
+            {
+              "name": "TinxoLibre",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0054d566adc72298",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Spindato",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d8e6c6141f87e4ec",
+              "tournamentName": "POKÉMON CHAMPIONS Circuito VGC #1 | Z2 Gaming"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "445",
+            "547",
+            "902",
+            "983"
+          ],
+          "pokemonNames": [
+            "Garchomp",
+            "Whimsicott",
+            "Basculegion-M",
+            "Kingambit"
+          ],
+          "wins": 595,
+          "losses": 249,
+          "teams": [
+            {
+              "name": "sword",
+              "placement": 1,
+              "record": "11-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Skarmory",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/911fc0a3f09bc4d0",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Drurtle",
+              "placement": 2,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/59d4a74a34d541e3",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Jin-Hao Jiang",
+              "placement": 1,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2aa8747d4bddd894",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "OrangeSteve",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/04783a017130fc96",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "Luca",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/00503a0489ff0ccc",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6b5c775626b6e112",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "JackChapman",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dde429f2fc6de55d",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "QueerCrocodile",
+              "placement": 3,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Whimsicott",
+                "Volcarona",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/301140d75a23c295",
+              "tournamentName": "Talon's FIGHT CLUB #82 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "ZeBanded",
+              "placement": 3,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/927a1d9cc67e534f",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "DobleK",
+              "placement": 6,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Incineroar",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fdf9f384711a811b",
+              "tournamentName": "Pokemon Champions Challenge #2"
+            },
+            {
+              "name": "anivgc",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83a3843ddca309ed",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Ihsan S",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Gardevoir",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/25a782ef3ff8a23b",
+              "tournamentName": "Coupe Critique Champions VGC #2 - 200€ prize"
+            },
+            {
+              "name": "allhailhippo",
+              "placement": 7,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Incineroar",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/96ba9bee8f9f3321",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "SableyeVGC",
+              "placement": 36,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e8ac52db2c9ae0da",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Hidan",
+              "placement": 44,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7c2d12d1649bcd59",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Holasoy",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/49ac56f0f7a7e3cd",
+              "tournamentName": "Pokepal Smackdown #138 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "Noah Smith",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b46c5e06f5bf93ce",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #3 2026"
+            },
+            {
+              "name": "TinxoLibre",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0054d566adc72298",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Spindato",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d8e6c6141f87e4ec",
+              "tournamentName": "POKÉMON CHAMPIONS Circuito VGC #1 | Z2 Gaming"
+            },
+            {
+              "name": "slimeslatt25",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/eb256351a870eb16",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "142",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard-Mega Y",
+            "Aerodactyl",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 541,
+          "losses": 221,
+          "teams": [
+            {
+              "name": "Shishio_Ax",
+              "placement": 1,
+              "record": "11-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0d56e21aad4f3505",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "QuantumSlack",
+              "placement": 1,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Floette",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0ad0d5a5d6732495",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Arekusabi",
+              "placement": 12,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b32461d35242dadb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "UItraVegito",
+              "placement": 3,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b14684ae442573c6",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 4,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7b11480dfff39367",
+              "tournamentName": "Coupe Critique Champions VGC #2 - 200€ prize"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/50ab4d9dee0e56d3",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "averagememer57",
+              "placement": 2,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7f31b8d19a7b2a3e",
+              "tournamentName": "*Sitrus-Series*|Champions|#57"
+            },
+            {
+              "name": "MysticVGC_02",
+              "placement": 3,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7b086882a764ed2c",
+              "tournamentName": "Extreme Speed Pokémon Champions #2"
+            },
+            {
+              "name": "Nano",
+              "placement": 3,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c54efc43422ddf9",
+              "tournamentName": "Extreme Speed Pokémon Champions #3"
+            },
+            {
+              "name": "DJGamer511",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Milotic",
+                "Garchomp",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e8a4f3659e82071b",
+              "tournamentName": "Talon's FIGHT CLUB #83 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "averagememer57",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/588776aaf7efa3bc",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "BrunoIPT",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c5df932ec1944d6",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "DyeItTight",
+              "placement": 59,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c1a5a1cee801cbf3",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "QuantumSlack",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Floette",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2829aac06c97904d",
+              "tournamentName": "PCP Premier Series: A Champion's Welcome!"
+            },
+            {
+              "name": "21kieran",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Excadrill",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2290b6d54b09e6a7",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "MothervieveRobbedonS50",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Clefable",
+                "Aerodactyl",
+                "Garchomp",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7205bf28f85d1e79",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "Nayle",
+              "placement": 5,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2707729c71296e58",
+              "tournamentName": "Weekly | Liberation Crusade #1 | $100 |Volticons"
+            },
+            {
+              "name": "GOUKI_PR",
+              "placement": 6,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a234048331d698df",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "MysticVGC_02",
+              "placement": 7,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2e3f5a1caf21a208",
+              "tournamentName": "Devils Den Tournaments #74"
+            },
+            {
+              "name": "Yegorushhka",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0ca52ea77c172e32",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "1018",
+            "279",
+            "727",
+            "902"
+          ],
+          "pokemonNames": [
+            "Archaludon",
+            "Pelipper",
+            "Incineroar",
+            "Basculegion-M"
+          ],
+          "wins": 607,
+          "losses": 270,
+          "teams": [
+            {
+              "name": "joethefenix",
+              "placement": 8,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Archaludon",
+                "Dragonite",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f582638fd3819dec",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "LovelyLuna",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83b7f94f93437d17",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 1,
+              "record": "12-0-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/49216904fa49e246",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "QuelloScarso",
+              "placement": 19,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Archaludon",
+                "Pelipper",
+                "Altaria",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/25da5c66dcfd3e3e",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "DragonMasterCody",
+              "placement": 31,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Gengar",
+                "Archaludon",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M",
+                "Quaquaval"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ab1089a905a137be",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "HumbreAlto",
+              "placement": 2,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Scizor",
+                "Pelipper",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7b1e7568bbeff882",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            },
+            {
+              "name": "Raichu123",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite-Mega",
+                "Scizor-Mega",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/846bd3281d7f460e",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "keenosabe",
+              "placement": 4,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Meganium",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8e2fff2246ffba17",
+              "tournamentName": "Talon's FIGHT CLUB #82 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Jonnycat",
+              "placement": 7,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7008334d30cdea4c",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Haman",
+              "placement": 47,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Archaludon",
+                "Pelipper",
+                "Floette",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b8f4fe9fcad70c8e",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "masa ",
+              "placement": 52,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Pelipper",
+                "Excadrill-Mega",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/bea9c64500e067e1",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "SeaSoil",
+              "placement": 52,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9b2fc4a257be2574",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Paghy",
+              "placement": 1,
+              "record": "8-0-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Archaludon",
+                "Pelipper",
+                "Floette",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9c647883fda1811d",
+              "tournamentName": "Pado's Dojo Reg M-A Pratice #1 🍥"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/28c80f87a380cdc4",
+              "tournamentName": "*Sitrus-Series*|Champions|#59"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/87e74a59eb1e9ef1",
+              "tournamentName": "Talon's FIGHT CLUB #85 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2d4bba21eb8ed36d",
+              "tournamentName": "Talon's FIGHT CLUB #82 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 5,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f03ffd5dafb863a1",
+              "tournamentName": "*Sitrus-Series*|Champions|#57"
+            },
+            {
+              "name": "TomBlues",
+              "placement": 6,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Archaludon",
+                "Pelipper",
+                "Gardevoir",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e6e8bc2353b9be0d",
+              "tournamentName": "Talon's FIGHT CLUB #81 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Ilan Petit-Khacem",
+              "placement": 8,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Archaludon",
+                "Pelipper",
+                "Lopunny",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/200801e8aa0944f7",
+              "tournamentName": "Chaos League Sunday Slam #96"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 2,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9d517a717e7b50c3",
+              "tournamentName": "Champions Collective #9"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "445",
+            "670",
+            "902"
+          ],
+          "pokemonNames": [
+            "Aerodactyl",
+            "Garchomp",
+            "Floette",
+            "Basculegion-M"
+          ],
+          "wins": 569,
+          "losses": 280,
+          "teams": [
+            {
+              "name": "mudhiman",
+              "placement": 1,
+              "record": "19-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/348127db40fb7b33",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Marth",
+              "placement": 14,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/56ce80359fb80d9b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "k3ngo",
+              "placement": 4,
+              "record": "10-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e5acc541b2683488",
+              "tournamentName": "LIGA DA COMUNIDADE #3 (R$ 1.000 PRIZE POOL)"
+            },
+            {
+              "name": "JOAO",
+              "placement": 16,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/478b03de615e1233",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "spaddy02",
+              "placement": 2,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Garchomp",
+                "Delphox-Mega",
+                "Floette-Mega",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7483b63b76a38d5a",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "Luca",
+              "placement": 2,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Delphox",
+                "Floette",
+                "Basculegion-M",
+                "Maushold"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8f4a93cefea1a13e",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "zlockbag1869",
+              "placement": 4,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/678d23f959ea0377",
+              "tournamentName": "Pokepal Smackdown #136 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "Pichu",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Delphox-Mega",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a2264e9a644e8ae9",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #65👑"
+            },
+            {
+              "name": "Conics",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e22099ff2808b0bf",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "rpr1020",
+              "placement": 42,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3d41088872f46360",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/877aac7820d660d9",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Davi Guimaraes",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b0bce48841c2b8f",
+              "tournamentName": "Friday Fight Night #53 Reg M-A Bo3"
+            },
+            {
+              "name": "Sergyo91",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8645009bd9bb2117",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "Asteriio",
+              "placement": 5,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Delphox",
+                "Floette",
+                "Basculegion-M",
+                "Maushold"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f5460c93ca3feb18",
+              "tournamentName": "Head Bussa's Hoedown#29 ChampionsReg M-A $25 1st"
+            },
+            {
+              "name": "Albert6496",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f546d01b218b3fb0",
+              "tournamentName": "Devils Den Tournaments #74"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a8b7ca848bcf5d66",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "charpie",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b393ddebcd0fc581",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "thekill009",
+              "placement": 2,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7e017159ea147fb3",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Serber",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3629a0feb9659868",
+              "tournamentName": "Pokemon Champions Challenge #4"
+            },
+            {
+              "name": "Yuma0O",
+              "placement": 9,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/07fab198f290ddbe",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "670",
+            "902",
+            "903"
+          ],
+          "pokemonNames": [
+            "Aerodactyl",
+            "Floette",
+            "Basculegion-M",
+            "Sneasler"
+          ],
+          "wins": 460,
+          "losses": 223,
+          "teams": [
+            {
+              "name": "soahmed",
+              "placement": 2,
+              "record": "11-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/10f4af89265000b8",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "OgreVGC",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/62ca06a2139fc268",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "Marth",
+              "placement": 14,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/56ce80359fb80d9b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "k3ngo",
+              "placement": 4,
+              "record": "10-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e5acc541b2683488",
+              "tournamentName": "LIGA DA COMUNIDADE #3 (R$ 1.000 PRIZE POOL)"
+            },
+            {
+              "name": "Mattytaxes",
+              "placement": 15,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1129e4a2ade1d08b",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "JOAO",
+              "placement": 16,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/478b03de615e1233",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "Wyuku",
+              "placement": 3,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b28e24f9e5b36bcf",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "DanielAcorn",
+              "placement": 3,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/46dd4679880267dc",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Mattytaxes",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/18741766a50829d0",
+              "tournamentName": "Chaos League Sunday Slam #96"
+            },
+            {
+              "name": "Magic_rana",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a72c62d91ab543e1",
+              "tournamentName": "Champions Tour LEPE #1 (5€ to 1st)"
+            },
+            {
+              "name": "zlockbag1869",
+              "placement": 4,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/678d23f959ea0377",
+              "tournamentName": "Pokepal Smackdown #136 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "TheOnlyHunt",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3d0ce9986ebd3f5a",
+              "tournamentName": "SNT First Pokémon Champions Tournament"
+            },
+            {
+              "name": "Pichu",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Delphox-Mega",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a2264e9a644e8ae9",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #65👑"
+            },
+            {
+              "name": "BrunoIPT",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c5df932ec1944d6",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "jANMxRin",
+              "placement": 29,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5d372827560c8482",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "sempra",
+              "placement": 32,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Kangaskhan",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/521c1a9ff79fd7f7",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "rpr1020",
+              "placement": 42,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3d41088872f46360",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Stallcelth",
+              "placement": 1,
+              "record": "8-0-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1eda0b42da662c6d",
+              "tournamentName": "Friday Fight Night #52 Reg M-A Bo3"
+            },
+            {
+              "name": "Aitor54",
+              "placement": 5,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Aegislash-Blade",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c4e07993e81af368",
+              "tournamentName": "Tenki's Cart - Pokémon Champions M-A ruleset!"
+            },
+            {
+              "name": "Wyuku",
+              "placement": 6,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cef1711e4f592754",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "655",
+            "902",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Delphox",
+            "Basculegion-M",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 530,
+          "losses": 225,
+          "teams": [
+            {
+              "name": "gamblingvgc92",
+              "placement": 1,
+              "record": "13-2-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9a56b82ba37cd5fc",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "Grimmothy_Snarl",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Delphox-Mega",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5eb4ffae39975131",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "Mariz",
+              "placement": 3,
+              "record": "11-2-0",
+              "pokemonNames": [
+                "Delphox",
+                "Floette",
+                "Aegislash-Blade",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/27b7bba18054ffe5",
+              "tournamentName": "LIGA DA COMUNIDADE #3 (R$ 1.000 PRIZE POOL)"
+            },
+            {
+              "name": "DisPlotfr",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5656a951188f7493",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "bpecina03",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Garchomp",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e0a0267aff1bdcfc",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "Pendraggon26",
+              "placement": 3,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b22713cddbbdb46f",
+              "tournamentName": "Chaos League Sunday Slam #100 ($100 Prize Pool)"
+            },
+            {
+              "name": "Laowai",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f5554b7be534571e",
+              "tournamentName": "VGCA Battle #25"
+            },
+            {
+              "name": "Murm",
+              "placement": 4,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Delphox-Mega",
+                "Talonflame",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/63b693c44c43b25e",
+              "tournamentName": "Talon's FIGHT CLUB #81 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Dan7487",
+              "placement": 7,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4318e6d15671f113",
+              "tournamentName": "Pokemon Champions Challenge #2"
+            },
+            {
+              "name": "Thanosgreninja",
+              "placement": 8,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/71367347c2ece27c",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "aboxoftimbits",
+              "placement": 35,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Garchomp",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/df9c152dd73454cb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "LiebesleidVGC",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Clefable",
+                "Garchomp",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9e7f83a33d784a8d",
+              "tournamentName": "POKEMON CHAMPAGNE- LO CAMBIA TODO N°1"
+            },
+            {
+              "name": "HowDz",
+              "placement": 1,
+              "record": "7-0-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Garchomp",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7a5c2e6df030f003",
+              "tournamentName": "[REG M-A] LearningtoSam's Weekly PokéLeague"
+            },
+            {
+              "name": "DigioVGC",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Whimsicott",
+                "Delphox",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/35824c4a9d640f87",
+              "tournamentName": "Champions Collective #4"
+            },
+            {
+              "name": "eanna_h",
+              "placement": 6,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fb7e4f3b9da36232",
+              "tournamentName": "Tenki's Cart - Pokémon Champions M-A ruleset!"
+            },
+            {
+              "name": "charpie",
+              "placement": 6,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ccce9b6a574fb34e",
+              "tournamentName": "CHAMPIONS COLLECTIVE INAUGURAL TOURNAMENT"
+            },
+            {
+              "name": "bowl_4",
+              "placement": 6,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass-Mega",
+                "Delphox-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ecfaeeea15deb512",
+              "tournamentName": "Extreme Speed Pokémon Champions #2"
+            },
+            {
+              "name": "averagememer57",
+              "placement": 6,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1bfb5eb348d6d526",
+              "tournamentName": "Devils Den Tournaments #74"
+            },
+            {
+              "name": "Lux_01",
+              "placement": 7,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Whimsicott",
+                "Delphox",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/79983ddcf2663753",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "Fastman24",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Delphox",
+                "Floette",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9470ae8914b37eb3",
+              "tournamentName": "Tenki's Cart - Pokémon Champions M-A ruleset!"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "size": 5,
+      "clusters": [
+        {
+          "pokemon": [
+            "006",
+            "142",
+            "445",
+            "902",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Aerodactyl",
+            "Garchomp",
+            "Basculegion-M",
+            "Kingambit"
+          ],
+          "wins": 702,
+          "losses": 351,
+          "teams": [
+            {
+              "name": "mudhiman",
+              "placement": 1,
+              "record": "19-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/348127db40fb7b33",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Mentosbombe",
+              "placement": 3,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5b6333455eb1d308",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ea25e09006131d26",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "BigNation",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/800a3c915f24ab69",
+              "tournamentName": "Chaos League Sunday Slam #100 ($100 Prize Pool)"
+            },
+            {
+              "name": "Chrom",
+              "placement": 23,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c8fc5bcfddc17b3b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "P_Amyrand",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0df4d758e8e4565c",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "KKCWind",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dadb91d6f888bff0",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Conics",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e22099ff2808b0bf",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/877aac7820d660d9",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Davi Guimaraes",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b0bce48841c2b8f",
+              "tournamentName": "Friday Fight Night #53 Reg M-A Bo3"
+            },
+            {
+              "name": "Sergyo91",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8645009bd9bb2117",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "Ksomon",
+              "placement": 1,
+              "record": "10-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ebef6770b45e9f2f",
+              "tournamentName": "Champions Collective #9"
+            },
+            {
+              "name": "NMR | FelipeT",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9da3ce35f701f567",
+              "tournamentName": "The Drywalls Series #5 - Champions!"
+            },
+            {
+              "name": "DaniVGC03",
+              "placement": 6,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fa7a9a3ddc0f8c45",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "mrelax0327",
+              "placement": 7,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/118c68395a0a85a8",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a8b7ca848bcf5d66",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "charpie",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b393ddebcd0fc581",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "thekill009",
+              "placement": 2,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7e017159ea147fb3",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Serber",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3629a0feb9659868",
+              "tournamentName": "Pokemon Champions Challenge #4"
+            },
+            {
+              "name": "Yuma0O",
+              "placement": 9,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/07fab198f290ddbe",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "445",
+            "547",
+            "902",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Garchomp",
+            "Whimsicott",
+            "Basculegion-M",
+            "Kingambit"
+          ],
+          "wins": 530,
+          "losses": 217,
+          "teams": [
+            {
+              "name": "sword",
+              "placement": 1,
+              "record": "11-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Skarmory",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/911fc0a3f09bc4d0",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Drurtle",
+              "placement": 2,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/59d4a74a34d541e3",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Jin-Hao Jiang",
+              "placement": 1,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2aa8747d4bddd894",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "OrangeSteve",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/04783a017130fc96",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "Luca",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/00503a0489ff0ccc",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6b5c775626b6e112",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "JackChapman",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dde429f2fc6de55d",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "ZeBanded",
+              "placement": 3,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/927a1d9cc67e534f",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "DobleK",
+              "placement": 6,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Incineroar",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fdf9f384711a811b",
+              "tournamentName": "Pokemon Champions Challenge #2"
+            },
+            {
+              "name": "anivgc",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83a3843ddca309ed",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Ihsan S",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Gardevoir",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/25a782ef3ff8a23b",
+              "tournamentName": "Coupe Critique Champions VGC #2 - 200€ prize"
+            },
+            {
+              "name": "allhailhippo",
+              "placement": 7,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Incineroar",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/96ba9bee8f9f3321",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "SableyeVGC",
+              "placement": 36,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e8ac52db2c9ae0da",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Hidan",
+              "placement": 44,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7c2d12d1649bcd59",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Holasoy",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/49ac56f0f7a7e3cd",
+              "tournamentName": "Pokepal Smackdown #138 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "Noah Smith",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b46c5e06f5bf93ce",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #3 2026"
+            },
+            {
+              "name": "TinxoLibre",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0054d566adc72298",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Spindato",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d8e6c6141f87e4ec",
+              "tournamentName": "POKÉMON CHAMPIONS Circuito VGC #1 | Z2 Gaming"
+            },
+            {
+              "name": "slimeslatt25",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/eb256351a870eb16",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "John Tan",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b7badc8e601f8ea",
+              "tournamentName": "King of Champions"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "142",
+            "445",
+            "700",
+            "902"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Aerodactyl",
+            "Garchomp",
+            "Sylveon",
+            "Basculegion-M"
+          ],
+          "wins": 459,
+          "losses": 224,
+          "teams": [
+            {
+              "name": "Mentosbombe",
+              "placement": 3,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5b6333455eb1d308",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Kojay",
+              "placement": 4,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/026ccbe833514d3c",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ea25e09006131d26",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "BigNation",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/800a3c915f24ab69",
+              "tournamentName": "Chaos League Sunday Slam #100 ($100 Prize Pool)"
+            },
+            {
+              "name": "Kojay",
+              "placement": 1,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f72602b39bd3b599",
+              "tournamentName": "10ToesDownVGC #31 Champions $100 Top 4(Late Join)"
+            },
+            {
+              "name": "Chrom",
+              "placement": 23,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c8fc5bcfddc17b3b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Kojay",
+              "placement": 2,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0575b8df0394ea8c",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "P_Amyrand",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0df4d758e8e4565c",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "Kojay",
+              "placement": 3,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7caaeccf61114454",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "KKCWind",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dadb91d6f888bff0",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "TheGamerVGC",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fe863526ff682822",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Ksomon",
+              "placement": 1,
+              "record": "10-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ebef6770b45e9f2f",
+              "tournamentName": "Champions Collective #9"
+            },
+            {
+              "name": "NMR | FelipeT",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9da3ce35f701f567",
+              "tournamentName": "The Drywalls Series #5 - Champions!"
+            },
+            {
+              "name": "DaniVGC03",
+              "placement": 6,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fa7a9a3ddc0f8c45",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "LelloCartello",
+              "placement": 6,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ed1f2f72da377624",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "mrelax0327",
+              "placement": 7,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/118c68395a0a85a8",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "charpie",
+              "placement": 7,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b7154f61bc853a30",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "carlos_012",
+              "placement": 2,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/370d476f14890b8f",
+              "tournamentName": "Champions Collective #8"
+            },
+            {
+              "name": "Welmey",
+              "placement": 14,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Aegislash-Blade",
+                "Sylveon",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/913440d6c5602e3b",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Oscar P",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3a18c928051fda87",
+              "tournamentName": "Pokemon Dominicana - Champions League #5"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "142",
+            "445",
+            "670",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard-Mega Y",
+            "Aerodactyl",
+            "Garchomp",
+            "Floette-Mega",
+            "Kingambit"
+          ],
+          "wins": 509,
+          "losses": 223,
+          "teams": [
+            {
+              "name": "mudhiman",
+              "placement": 1,
+              "record": "19-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/348127db40fb7b33",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Arekusabi",
+              "placement": 12,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b32461d35242dadb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Nano",
+              "placement": 3,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c54efc43422ddf9",
+              "tournamentName": "Extreme Speed Pokémon Champions #3"
+            },
+            {
+              "name": "Conics",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e22099ff2808b0bf",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "DyeItTight",
+              "placement": 59,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c1a5a1cee801cbf3",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/877aac7820d660d9",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Davi Guimaraes",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b0bce48841c2b8f",
+              "tournamentName": "Friday Fight Night #53 Reg M-A Bo3"
+            },
+            {
+              "name": "Sergyo91",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8645009bd9bb2117",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a8b7ca848bcf5d66",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "charpie",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b393ddebcd0fc581",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "thekill009",
+              "placement": 2,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7e017159ea147fb3",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Serber",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3629a0feb9659868",
+              "tournamentName": "Pokemon Champions Challenge #4"
+            },
+            {
+              "name": "Yuma0O",
+              "placement": 9,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/07fab198f290ddbe",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 9,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f418a398741b22cd",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Trafalgar_VGC",
+              "placement": 1,
+              "record": "6-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d12e0b8adc667a85",
+              "tournamentName": "POKÉMON CHAMPIONS Circuito VGC #2 | Z2 Gaming"
+            },
+            {
+              "name": "Darkip_8",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/03be675e2dbe11cd",
+              "tournamentName": "Champions Tour LEPE #3"
+            },
+            {
+              "name": "iamstrawberry93",
+              "placement": 1,
+              "record": "4-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4226c7bb8b3c2f70",
+              "tournamentName": "제2회 너클시티 챌린저스 [Hammerlocke Challengers]"
+            },
+            {
+              "name": "TerroneVGC",
+              "placement": 1,
+              "record": "6-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/41fccb7cc14d48c3",
+              "tournamentName": "Dark Storm Team testing #6"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b97ba507a0f8ffd6",
+              "tournamentName": "Buffet Battles Regulation M-A #1 - 16/5/26"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 2,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/376ca4222b175d65",
+              "tournamentName": "Torneo #4 Ranking PokéChampionsDestiny"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "142",
+            "445",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Aerodactyl",
+            "Garchomp",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 369,
+          "losses": 150,
+          "teams": [
+            {
+              "name": "Shishio_Ax",
+              "placement": 1,
+              "record": "11-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0d56e21aad4f3505",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "Arekusabi",
+              "placement": 12,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b32461d35242dadb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "UItraVegito",
+              "placement": 3,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b14684ae442573c6",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 4,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7b11480dfff39367",
+              "tournamentName": "Coupe Critique Champions VGC #2 - 200€ prize"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/50ab4d9dee0e56d3",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "averagememer57",
+              "placement": 2,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7f31b8d19a7b2a3e",
+              "tournamentName": "*Sitrus-Series*|Champions|#57"
+            },
+            {
+              "name": "MysticVGC_02",
+              "placement": 3,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7b086882a764ed2c",
+              "tournamentName": "Extreme Speed Pokémon Champions #2"
+            },
+            {
+              "name": "Nano",
+              "placement": 3,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c54efc43422ddf9",
+              "tournamentName": "Extreme Speed Pokémon Champions #3"
+            },
+            {
+              "name": "DJGamer511",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Milotic",
+                "Garchomp",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e8a4f3659e82071b",
+              "tournamentName": "Talon's FIGHT CLUB #83 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "averagememer57",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/588776aaf7efa3bc",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "DyeItTight",
+              "placement": 59,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c1a5a1cee801cbf3",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "MothervieveRobbedonS50",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Clefable",
+                "Aerodactyl",
+                "Garchomp",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7205bf28f85d1e79",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "Nayle",
+              "placement": 5,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2707729c71296e58",
+              "tournamentName": "Weekly | Liberation Crusade #1 | $100 |Volticons"
+            },
+            {
+              "name": "GOUKI_PR",
+              "placement": 6,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a234048331d698df",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "MysticVGC_02",
+              "placement": 7,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2e3f5a1caf21a208",
+              "tournamentName": "Devils Den Tournaments #74"
+            },
+            {
+              "name": "STKSigurboy",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/381e1074ac822623",
+              "tournamentName": "Talon's FIGHT CLUB #83 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "JaviGote",
+              "placement": 2,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Dragapult",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/50f3fd0408945b36",
+              "tournamentName": "Pokevents Champions Opening Tour"
+            },
+            {
+              "name": "GOUKI_PR",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b74edaf92bb008c0",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #3 2026"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 9,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f418a398741b22cd",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Davi Guimaraes",
+              "placement": 11,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Gengar",
+                "Aerodactyl",
+                "Garchomp",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/da9c7a022a050313",
+              "tournamentName": "ZGG #3 Pokemon Champions VGC $100 Tournament!"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "445",
+            "670",
+            "902",
+            "983"
+          ],
+          "pokemonNames": [
+            "Aerodactyl",
+            "Garchomp",
+            "Floette-Mega",
+            "Basculegion-M",
+            "Kingambit"
+          ],
+          "wins": 417,
+          "losses": 200,
+          "teams": [
+            {
+              "name": "mudhiman",
+              "placement": 1,
+              "record": "19-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/348127db40fb7b33",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Marth",
+              "placement": 14,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/56ce80359fb80d9b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Conics",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e22099ff2808b0bf",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/877aac7820d660d9",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Davi Guimaraes",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b0bce48841c2b8f",
+              "tournamentName": "Friday Fight Night #53 Reg M-A Bo3"
+            },
+            {
+              "name": "Sergyo91",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8645009bd9bb2117",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a8b7ca848bcf5d66",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "charpie",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b393ddebcd0fc581",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "thekill009",
+              "placement": 2,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7e017159ea147fb3",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Serber",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3629a0feb9659868",
+              "tournamentName": "Pokemon Champions Challenge #4"
+            },
+            {
+              "name": "Yuma0O",
+              "placement": 9,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/07fab198f290ddbe",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "iamstrawberry93",
+              "placement": 1,
+              "record": "4-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4226c7bb8b3c2f70",
+              "tournamentName": "제2회 너클시티 챌린저스 [Hammerlocke Challengers]"
+            },
+            {
+              "name": "TerroneVGC",
+              "placement": 1,
+              "record": "6-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/41fccb7cc14d48c3",
+              "tournamentName": "Dark Storm Team testing #6"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b97ba507a0f8ffd6",
+              "tournamentName": "Buffet Battles Regulation M-A #1 - 16/5/26"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 2,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/376ca4222b175d65",
+              "tournamentName": "Torneo #4 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7d0240470f0743e3",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "MetalLegsSolid",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5e5a8f9e50d474de",
+              "tournamentName": "The Drywalls Seriers #4 - Champions!"
+            },
+            {
+              "name": "Will Alcântara",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c350e44a7dcccffc",
+              "tournamentName": "Intimidators Champions Challenge #10- REG M-A"
+            },
+            {
+              "name": "Astrah",
+              "placement": 4,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dc1c01addd0b1f99",
+              "tournamentName": "The Drywalls Series #3 - Champions!"
+            },
+            {
+              "name": "Jsparks1102",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8089f5d6c2a8f7da",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "1018",
+            "149",
+            "212",
+            "279",
+            "902"
+          ],
+          "pokemonNames": [
+            "Archaludon",
+            "Dragonite",
+            "Scizor-Mega",
+            "Pelipper",
+            "Basculegion-M"
+          ],
+          "wins": 429,
+          "losses": 166,
+          "teams": [
+            {
+              "name": "LovelyLuna",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83b7f94f93437d17",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Racka2023",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9e80cb9704c61ac9",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Kumanomi",
+              "placement": 1,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6922a9ea01e44bac",
+              "tournamentName": "Devils Den Tournaments #74"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 1,
+              "record": "12-0-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/49216904fa49e246",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Raichu123",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite-Mega",
+                "Scizor-Mega",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/846bd3281d7f460e",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "Jonnycat",
+              "placement": 7,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7008334d30cdea4c",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "patcon5",
+              "placement": 41,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2b074b2e16e3bbd8",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/28c80f87a380cdc4",
+              "tournamentName": "*Sitrus-Series*|Champions|#59"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/87e74a59eb1e9ef1",
+              "tournamentName": "Talon's FIGHT CLUB #85 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Fester213",
+              "placement": 5,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2d083af8171a0f63",
+              "tournamentName": "Talon's FIGHT CLUB #81 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2d4bba21eb8ed36d",
+              "tournamentName": "Talon's FIGHT CLUB #82 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Raichu123",
+              "placement": 5,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2535cbc1fd236c6c",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 5,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f03ffd5dafb863a1",
+              "tournamentName": "*Sitrus-Series*|Champions|#57"
+            },
+            {
+              "name": "FA_C0N",
+              "placement": 2,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c86f8290d46d2b23",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "Raichu123",
+              "placement": 2,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/859828511a9199f9",
+              "tournamentName": "Unova Champions League #5 / POKÉMON CHAMPIONS"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 2,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9d517a717e7b50c3",
+              "tournamentName": "Champions Collective #9"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/abcc734e9d64bfa0",
+              "tournamentName": "Pokepal Smackdown #140 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 1,
+              "record": "7-0-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8945bd01ce248806",
+              "tournamentName": "VGC Gemeinde Showdown #7"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 2,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/551091c6fa627ffa",
+              "tournamentName": "Northern Ontario VGC Tour - April 29th"
+            },
+            {
+              "name": "Raichu123",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fe418678d981393a",
+              "tournamentName": "Boldore's Gate #8 - $5 USD - Champions Weekly 4/27"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "670",
+            "902",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Aerodactyl",
+            "Floette",
+            "Basculegion-M",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 275,
+          "losses": 131,
+          "teams": [
+            {
+              "name": "soahmed",
+              "placement": 2,
+              "record": "11-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/10f4af89265000b8",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "OgreVGC",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/62ca06a2139fc268",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "Marth",
+              "placement": 14,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/56ce80359fb80d9b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Mattytaxes",
+              "placement": 15,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1129e4a2ade1d08b",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "Wyuku",
+              "placement": 3,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b28e24f9e5b36bcf",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "DanielAcorn",
+              "placement": 3,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/46dd4679880267dc",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Mattytaxes",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/18741766a50829d0",
+              "tournamentName": "Chaos League Sunday Slam #96"
+            },
+            {
+              "name": "TheOnlyHunt",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3d0ce9986ebd3f5a",
+              "tournamentName": "SNT First Pokémon Champions Tournament"
+            },
+            {
+              "name": "BrunoIPT",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c5df932ec1944d6",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "jANMxRin",
+              "placement": 29,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5d372827560c8482",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "sempra",
+              "placement": 32,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Kangaskhan",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/521c1a9ff79fd7f7",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "Aitor54",
+              "placement": 5,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Aegislash-Blade",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c4e07993e81af368",
+              "tournamentName": "Tenki's Cart - Pokémon Champions M-A ruleset!"
+            },
+            {
+              "name": "Wyuku",
+              "placement": 6,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cef1711e4f592754",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "FF",
+              "placement": 7,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2f58e20d66659ce5",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "SideB",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Delphox",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a5f32930d39e424e",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "Igor Fagundes",
+              "placement": 10,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/38b10439404853ca",
+              "tournamentName": "LIGA DA COMUNIDADE #3 (R$ 1.000 PRIZE POOL)"
+            },
+            {
+              "name": "Silo",
+              "placement": 12,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/66d81c0532a3e6b7",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "Habiss",
+              "placement": 16,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/733afdcb675da3c3",
+              "tournamentName": "Coupe Critique Champions VGC #1 - 100€ de cp"
+            },
+            {
+              "name": "OgreVGC",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7af9b558dffbb9a8",
+              "tournamentName": "Torneo #4 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Fr33z",
+              "placement": 11,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0c19eb486a9df2d7",
+              "tournamentName": "SNT First Pokémon Champions Tournament"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "142",
+            "445",
+            "670",
+            "902"
+          ],
+          "pokemonNames": [
+            "Charizard-Mega Y",
+            "Aerodactyl",
+            "Garchomp",
+            "Floette-Mega",
+            "Basculegion-M"
+          ],
+          "wins": 387,
+          "losses": 186,
+          "teams": [
+            {
+              "name": "mudhiman",
+              "placement": 1,
+              "record": "19-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/348127db40fb7b33",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "k3ngo",
+              "placement": 4,
+              "record": "10-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e5acc541b2683488",
+              "tournamentName": "LIGA DA COMUNIDADE #3 (R$ 1.000 PRIZE POOL)"
+            },
+            {
+              "name": "Conics",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e22099ff2808b0bf",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/877aac7820d660d9",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Davi Guimaraes",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b0bce48841c2b8f",
+              "tournamentName": "Friday Fight Night #53 Reg M-A Bo3"
+            },
+            {
+              "name": "Sergyo91",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8645009bd9bb2117",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "Albert6496",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f546d01b218b3fb0",
+              "tournamentName": "Devils Den Tournaments #74"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a8b7ca848bcf5d66",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "charpie",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b393ddebcd0fc581",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "thekill009",
+              "placement": 2,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7e017159ea147fb3",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Serber",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3629a0feb9659868",
+              "tournamentName": "Pokemon Champions Challenge #4"
+            },
+            {
+              "name": "Yuma0O",
+              "placement": 9,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/07fab198f290ddbe",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "iamstrawberry93",
+              "placement": 1,
+              "record": "4-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4226c7bb8b3c2f70",
+              "tournamentName": "제2회 너클시티 챌린저스 [Hammerlocke Challengers]"
+            },
+            {
+              "name": "TerroneVGC",
+              "placement": 1,
+              "record": "6-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/41fccb7cc14d48c3",
+              "tournamentName": "Dark Storm Team testing #6"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b97ba507a0f8ffd6",
+              "tournamentName": "Buffet Battles Regulation M-A #1 - 16/5/26"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 2,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/376ca4222b175d65",
+              "tournamentName": "Torneo #4 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7d0240470f0743e3",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "MetalLegsSolid",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5e5a8f9e50d474de",
+              "tournamentName": "The Drywalls Seriers #4 - Champions!"
+            },
+            {
+              "name": "Will Alcântara",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c350e44a7dcccffc",
+              "tournamentName": "Intimidators Champions Challenge #10- REG M-A"
+            },
+            {
+              "name": "Astrah",
+              "placement": 4,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dc1c01addd0b1f99",
+              "tournamentName": "The Drywalls Series #3 - Champions!"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "445",
+            "670",
+            "902",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Garchomp",
+            "Floette",
+            "Basculegion-M",
+            "Kingambit"
+          ],
+          "wins": 429,
+          "losses": 206,
+          "teams": [
+            {
+              "name": "mudhiman",
+              "placement": 1,
+              "record": "19-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/348127db40fb7b33",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Conics",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e22099ff2808b0bf",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Hidan",
+              "placement": 44,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7c2d12d1649bcd59",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/877aac7820d660d9",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Davi Guimaraes",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b0bce48841c2b8f",
+              "tournamentName": "Friday Fight Night #53 Reg M-A Bo3"
+            },
+            {
+              "name": "Sergyo91",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8645009bd9bb2117",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a8b7ca848bcf5d66",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "charpie",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b393ddebcd0fc581",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "thekill009",
+              "placement": 2,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7e017159ea147fb3",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Serber",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3629a0feb9659868",
+              "tournamentName": "Pokemon Champions Challenge #4"
+            },
+            {
+              "name": "Yuma0O",
+              "placement": 9,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/07fab198f290ddbe",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "iamstrawberry93",
+              "placement": 1,
+              "record": "4-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4226c7bb8b3c2f70",
+              "tournamentName": "제2회 너클시티 챌린저스 [Hammerlocke Challengers]"
+            },
+            {
+              "name": "NMR | Ueda",
+              "placement": 1,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4b252d322d418753",
+              "tournamentName": "Intimidators Champions Challenge #11- REG M-A"
+            },
+            {
+              "name": "TerroneVGC",
+              "placement": 1,
+              "record": "6-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/41fccb7cc14d48c3",
+              "tournamentName": "Dark Storm Team testing #6"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b97ba507a0f8ffd6",
+              "tournamentName": "Buffet Battles Regulation M-A #1 - 16/5/26"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 2,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/376ca4222b175d65",
+              "tournamentName": "Torneo #4 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7d0240470f0743e3",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "MetalLegsSolid",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5e5a8f9e50d474de",
+              "tournamentName": "The Drywalls Seriers #4 - Champions!"
+            },
+            {
+              "name": "Will Alcântara",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c350e44a7dcccffc",
+              "tournamentName": "Intimidators Champions Challenge #10- REG M-A"
+            },
+            {
+              "name": "JackChapman",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/681980d744043e59",
+              "tournamentName": "VGC Trainer School; champions M/A #3"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "142",
+            "670",
+            "902",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Aerodactyl",
+            "Floette",
+            "Basculegion-M",
+            "Kingambit"
+          ],
+          "wins": 389,
+          "losses": 183,
+          "teams": [
+            {
+              "name": "mudhiman",
+              "placement": 1,
+              "record": "19-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/348127db40fb7b33",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "BrunoIPT",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c5df932ec1944d6",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Conics",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e22099ff2808b0bf",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/877aac7820d660d9",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Davi Guimaraes",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b0bce48841c2b8f",
+              "tournamentName": "Friday Fight Night #53 Reg M-A Bo3"
+            },
+            {
+              "name": "Sergyo91",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8645009bd9bb2117",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a8b7ca848bcf5d66",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "charpie",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b393ddebcd0fc581",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "thekill009",
+              "placement": 2,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7e017159ea147fb3",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Serber",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3629a0feb9659868",
+              "tournamentName": "Pokemon Champions Challenge #4"
+            },
+            {
+              "name": "Yuma0O",
+              "placement": 9,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/07fab198f290ddbe",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "OgreVGC",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7af9b558dffbb9a8",
+              "tournamentName": "Torneo #4 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "iamstrawberry93",
+              "placement": 1,
+              "record": "4-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4226c7bb8b3c2f70",
+              "tournamentName": "제2회 너클시티 챌린저스 [Hammerlocke Challengers]"
+            },
+            {
+              "name": "TerroneVGC",
+              "placement": 1,
+              "record": "6-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/41fccb7cc14d48c3",
+              "tournamentName": "Dark Storm Team testing #6"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b97ba507a0f8ffd6",
+              "tournamentName": "Buffet Battles Regulation M-A #1 - 16/5/26"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 2,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/376ca4222b175d65",
+              "tournamentName": "Torneo #4 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7d0240470f0743e3",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "MetalLegsSolid",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5e5a8f9e50d474de",
+              "tournamentName": "The Drywalls Seriers #4 - Champions!"
+            },
+            {
+              "name": "Will Alcântara",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c350e44a7dcccffc",
+              "tournamentName": "Intimidators Champions Challenge #10- REG M-A"
+            },
+            {
+              "name": "Astrah",
+              "placement": 4,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dc1c01addd0b1f99",
+              "tournamentName": "The Drywalls Series #3 - Champions!"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "445",
+            "547",
+            "902",
+            "970"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Garchomp",
+            "Whimsicott",
+            "Basculegion-M",
+            "Glimmora"
+          ],
+          "wins": 359,
+          "losses": 161,
+          "teams": [
+            {
+              "name": "Drurtle",
+              "placement": 2,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/59d4a74a34d541e3",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Jin-Hao Jiang",
+              "placement": 1,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2aa8747d4bddd894",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "OrangeSteve",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/04783a017130fc96",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "Luca",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/00503a0489ff0ccc",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6b5c775626b6e112",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "ZeBanded",
+              "placement": 3,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/927a1d9cc67e534f",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "mr_h",
+              "placement": 1,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Weavile",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6ca91f2b30742f27",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "Noah Smith",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b46c5e06f5bf93ce",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #3 2026"
+            },
+            {
+              "name": "Gerva02VGC",
+              "placement": 5,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Floette",
+                "Basculegion-M",
+                "Glimmora"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e62969c7c5c5be99",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "TinxoLibre",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0054d566adc72298",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "John Tan",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b7badc8e601f8ea",
+              "tournamentName": "King of Champions"
+            },
+            {
+              "name": "juneberry123",
+              "placement": 2,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/05e696c01762868b",
+              "tournamentName": "Pokepal Smackdown #141 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "Boopmydoop",
+              "placement": 2,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8618a189947cc301",
+              "tournamentName": "The Drywalls Series #5 - Champions!"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 2,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3ff47e887a334304",
+              "tournamentName": "Devils Den Tournaments #77"
+            },
+            {
+              "name": "TenkiPK",
+              "placement": 1,
+              "record": "7-1-1",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/323fa1a513431620",
+              "tournamentName": "King's Gambit #3 | Reg M-A"
+            },
+            {
+              "name": "Ruben Abreu",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/bbb5a0f2412f692e",
+              "tournamentName": "Game Corner Showdown 2025 - Split 3 | Torneio #4"
+            },
+            {
+              "name": "Pro4tomico",
+              "placement": 2,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b41d18da6b9f4090",
+              "tournamentName": "Road to Area 229 #3"
+            },
+            {
+              "name": "Niel Arveen Serrato",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/517cb342c3b64b7f",
+              "tournamentName": "King of Champions"
+            },
+            {
+              "name": "dameenmachine",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Weavile",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d492b5763de88aa8",
+              "tournamentName": "The Drywalls Series #5 - Champions!"
+            },
+            {
+              "name": "Ugaitz",
+              "placement": 3,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Floette",
+                "Basculegion-M",
+                "Glimmora"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a3eb1d5ca7866fc0",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "1018",
+            "149",
+            "279",
+            "902",
+            "903"
+          ],
+          "pokemonNames": [
+            "Archaludon",
+            "Dragonite",
+            "Pelipper",
+            "Basculegion-M",
+            "Sneasler"
+          ],
+          "wins": 361,
+          "losses": 186,
+          "teams": [
+            {
+              "name": "BlackwingKakashi",
+              "placement": 2,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler",
+                "Glimmora"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5a778483f3bc5e86",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Racka2023",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9e80cb9704c61ac9",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Kumanomi",
+              "placement": 1,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6922a9ea01e44bac",
+              "tournamentName": "Devils Den Tournaments #74"
+            },
+            {
+              "name": "Martz",
+              "placement": 2,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite-Mega",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler",
+                "Orthworm"
+              ],
+              "pokepasteUrl": "https://pokepast.es/79b359914a3d3ed2",
+              "tournamentName": "Tenki's Cart - Pokémon Champions M-A ruleset!"
+            },
+            {
+              "name": "jameskbostock",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Archaludon",
+                "Dragonite",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e4f136bed2e9e082",
+              "tournamentName": "TARTAN TAKEDOWN #27 - [CHAMPIONS]"
+            },
+            {
+              "name": "afakedugong",
+              "placement": 20,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite-Mega",
+                "Pelipper",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2bb38ae74a64bc20",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "J6Hydra",
+              "placement": 31,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Archaludon",
+                "Dragonite-Mega",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/88f93382c1b3f46a",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "patcon5",
+              "placement": 41,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2b074b2e16e3bbd8",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Raichu123",
+              "placement": 5,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2535cbc1fd236c6c",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            },
+            {
+              "name": "Venture",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Meganium",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b4b4fd4a7c43db82",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "Raichu123",
+              "placement": 2,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/859828511a9199f9",
+              "tournamentName": "Unova Champions League #5 / POKÉMON CHAMPIONS"
+            },
+            {
+              "name": "Philippejava",
+              "placement": 10,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Pelipper",
+                "Corviknight",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/bd984436d4725251",
+              "tournamentName": "Coupe Critique Champions VGC #1 - 100€ de cp"
+            },
+            {
+              "name": "capitanpkmn",
+              "placement": 14,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Archaludon",
+                "Dragonite",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/501057e68b119dba",
+              "tournamentName": "TORNEO SALIDA POKÉMON CHAMPIONS"
+            },
+            {
+              "name": "Jakyred",
+              "placement": 16,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Archaludon",
+                "Dragonite",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2eafda5a9f0a7feb",
+              "tournamentName": "TORNEO SALIDA POKÉMON CHAMPIONS"
+            },
+            {
+              "name": "BigDev",
+              "placement": 2,
+              "record": "5-4-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/74e02c8cad44c4dc",
+              "tournamentName": "Flashback's Midwest Monthly - $100 PRIZE POT"
+            },
+            {
+              "name": "Adam_Axolotl9",
+              "placement": 2,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Archaludon",
+                "Dragonite-Mega",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/311eff8035d4d97b",
+              "tournamentName": "WARTORTLE WEDNESDAYS #55 FIRST CHAMPS REG M-A"
+            },
+            {
+              "name": "Raichu123",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fe418678d981393a",
+              "tournamentName": "Boldore's Gate #8 - $5 USD - Champions Weekly 4/27"
+            },
+            {
+              "name": "Puxcci",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/484669a0f11f0cd9",
+              "tournamentName": "Intimidators Champions Challenge #8 - REG M-A"
+            },
+            {
+              "name": "Facundito",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Archaludon",
+                "Dragonite",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5b6ad0a9ff791408",
+              "tournamentName": "Boldore's Gate #8 - $5 USD - Champions Weekly 4/27"
+            },
+            {
+              "name": "twlamere",
+              "placement": 12,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1155a9572f42362a",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "445",
+            "547",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Garchomp",
+            "Whimsicott",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 335,
+          "losses": 157,
+          "teams": [
+            {
+              "name": "BIlllmads",
+              "placement": 2,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1c3f692f429b7efe",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "Fester213",
+              "placement": 3,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/88f02ce2c018c6c5",
+              "tournamentName": "Talon's FIGHT CLUB #79 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "JackChapman",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dde429f2fc6de55d",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "Fireboule",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4d9af893845415dd",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "Raydevy",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b6aaf1d5a4e8948e",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "anivgc",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83a3843ddca309ed",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "volcaronavgc",
+              "placement": 8,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Garchomp",
+                "Rotom-Wash",
+                "Whimsicott",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/69889d9c6e067695",
+              "tournamentName": "Pokemon Champions Challenge #1"
+            },
+            {
+              "name": "SableyeVGC",
+              "placement": 36,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e8ac52db2c9ae0da",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Holasoy",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/49ac56f0f7a7e3cd",
+              "tournamentName": "Pokepal Smackdown #138 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "Laxidaze3",
+              "placement": 1,
+              "record": "6-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Gardevoir",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4a9d23d5fd284fc0",
+              "tournamentName": "[REG M-A] LearningtoSam's Weekly PokéLeague"
+            },
+            {
+              "name": "slimeslatt25",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/eb256351a870eb16",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "kuballo10",
+              "placement": 2,
+              "record": "6-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7034d23fa82fad46",
+              "tournamentName": "[REG M-A] LearningtoSam's Weekly PokéLeague"
+            },
+            {
+              "name": "Ludikrik",
+              "placement": 15,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83b74a6cc03591ab",
+              "tournamentName": "Coupe Critique Champions VGC #2 - 200€ prize"
+            },
+            {
+              "name": "chris17c",
+              "placement": 16,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3eb097ff04a29053",
+              "tournamentName": "Pokemon Champions Challenge #2"
+            },
+            {
+              "name": "Fireboule",
+              "placement": 16,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/811add92ecaaba8e",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Fireboule",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1689a66f45c3ac9f",
+              "tournamentName": "Champions Tour LEPE #2"
+            },
+            {
+              "name": "CMeshell",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/94ac9b984e83de28",
+              "tournamentName": "Pokémon Champions Reg M-A | CGCL Weekly #2"
+            },
+            {
+              "name": "Kapchul",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dc06692d30432278",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Fireboule",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4f3f66ede605fcba",
+              "tournamentName": "Metro Manila Eastern Conference"
+            },
+            {
+              "name": "Junyao Zhang",
+              "placement": 10,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Garchomp",
+                "Whimsicott",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b4e1d2de7749023b",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "1013",
+            "142",
+            "670",
+            "727",
+            "903"
+          ],
+          "pokemonNames": [
+            "Sinistcha",
+            "Aerodactyl-Mega",
+            "Floette-Mega",
+            "Incineroar",
+            "Sneasler"
+          ],
+          "wins": 277,
+          "losses": 126,
+          "teams": [
+            {
+              "name": "Selahattin Sturm",
+              "placement": 2,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e15c3f2bee0fc373",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "LeCehlou",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Scizor",
+                "Floette",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b1f63b10d89af82e",
+              "tournamentName": "Coupe Critique Champions VGC #1 - 100€ de cp"
+            },
+            {
+              "name": "Wilfire70",
+              "placement": 4,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Rotom-Wash",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c803745db9a80168",
+              "tournamentName": "*Sitrus-Series*|Champions|$100 to 1st"
+            },
+            {
+              "name": "manuel9519",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Scizor-Mega",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5f080641bfdfe28d",
+              "tournamentName": "Wolfey Patreon Tournament - Pokémon Champions #2"
+            },
+            {
+              "name": "Redsilver",
+              "placement": 1,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Scizor",
+                "Floette",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/963645aef072acf5",
+              "tournamentName": "Head Bussa's Hoedown#29 ChampionsReg M-A $25 1st"
+            },
+            {
+              "name": "Magic_rana",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a72c62d91ab543e1",
+              "tournamentName": "Champions Tour LEPE #1 (5€ to 1st)"
+            },
+            {
+              "name": "DaniVGC03",
+              "placement": 5,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette-Mega",
+                "Incineroar",
+                "Corviknight",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1d87ed27e8a18086",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "TheBardo",
+              "placement": 7,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0f798ccf85bdc13f",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "Playboi Carti",
+              "placement": 8,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f8aa3c702528d184",
+              "tournamentName": "*Sitrus-Series*|Champions|$100 to 1st"
+            },
+            {
+              "name": "Stallcelth",
+              "placement": 1,
+              "record": "8-0-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1eda0b42da662c6d",
+              "tournamentName": "Friday Fight Night #52 Reg M-A Bo3"
+            },
+            {
+              "name": "Shark032",
+              "placement": 6,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/02315644e2d9555a",
+              "tournamentName": "Chaos League Sunday Slam #96"
+            },
+            {
+              "name": "LeCehlou",
+              "placement": 7,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Scizor",
+                "Floette",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d51b55229c997bfe",
+              "tournamentName": "CHAMPIONS COLLECTIVE INAUGURAL TOURNAMENT"
+            },
+            {
+              "name": "BaldoVGC",
+              "placement": 10,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Scizor",
+                "Floette",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0eac36aab1b3e81c",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "CiccioCT29",
+              "placement": 15,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3f18a6c3f4f01a7a",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "LeCehlou",
+              "placement": 3,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Scizor",
+                "Floette",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2e8ccfcd8800505f",
+              "tournamentName": "Champions Collective #2"
+            },
+            {
+              "name": "gagartoo",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b14e1217f0da6053",
+              "tournamentName": "POKEMON CHAMPAGNE- LO CAMBIA TODO N°1"
+            },
+            {
+              "name": "kerni361",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/db0ceccb1a6a2803",
+              "tournamentName": "Wolfey Patreon Tournament - Pokémon Champions #1"
+            },
+            {
+              "name": "ethnol1816",
+              "placement": 4,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a133ab86daa9cf5c",
+              "tournamentName": "Friday Fight Night #52 Reg M-A Bo3"
+            },
+            {
+              "name": "PokeReplay",
+              "placement": 9,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette-Mega",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4da0172c64c33c46",
+              "tournamentName": "Champions Tour LEPE #1 (5€ to 1st)"
+            },
+            {
+              "name": "mcdarvarian",
+              "placement": 10,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3cad484fcae774db",
+              "tournamentName": "Pokepal Smackdown #137 (Champions) (Reg M-A)"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "445",
+            "902",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Aerodactyl-Mega",
+            "Garchomp",
+            "Basculegion-M",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 348,
+          "losses": 142,
+          "teams": [
+            {
+              "name": "Marth",
+              "placement": 14,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/56ce80359fb80d9b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Andrea C",
+              "placement": 1,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ca59849270d1bd16",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "Kaz z",
+              "placement": 18,
+              "record": "13-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6a9d92ff26cca4c3",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Pabloam",
+              "placement": 29,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/06e6a4da985ac3a5",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Starlight143",
+              "placement": 4,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Garchomp",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/801d6aa617a6863f",
+              "tournamentName": "Extreme Speed Pokémon Champions #2"
+            },
+            {
+              "name": "ironicpanda",
+              "placement": 46,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83533838183d56bf",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Kibble125",
+              "placement": 47,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/44460d7760fb2a96",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Davidbob32",
+              "placement": 5,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d5e29c2bd34ef0de",
+              "tournamentName": "VGCA Battle Hall #26"
+            },
+            {
+              "name": "SpicyCigar",
+              "placement": 5,
+              "record": "6-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/73a0e330e6f81d70",
+              "tournamentName": "Rookidee VGC Cup"
+            },
+            {
+              "name": "averagememer57",
+              "placement": 6,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1bfb5eb348d6d526",
+              "tournamentName": "Devils Den Tournaments #74"
+            },
+            {
+              "name": "Bebot",
+              "placement": 8,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5a0a2ceda1a7fb92",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "Jonnycat",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/efddb60c6f7fa5e1",
+              "tournamentName": "10ToesDownVGC #31 Champions $100 Top 4(Late Join)"
+            },
+            {
+              "name": "damiameru",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cbad0d9cd5a296c1",
+              "tournamentName": "Friday Fight Night #52 Reg M-A Bo3"
+            },
+            {
+              "name": "Sakusa",
+              "placement": 10,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1845dbc08603c8cc",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Setagaya",
+              "placement": 14,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d80a35b31b0f29d5",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Victor Matheus",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/db475614ce23db38",
+              "tournamentName": "Intimidators Champions Challenge #5 - REG M-A"
+            },
+            {
+              "name": "Bebot",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/581d5cccb9f6509f",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "alexro22",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c5d8d950e4ed34f0",
+              "tournamentName": "Champions Collective #4"
+            },
+            {
+              "name": "TPP",
+              "placement": 4,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/161fa9c6f8534384",
+              "tournamentName": "ChampionMads Singles Battle Arena #1 - $50 USD"
+            },
+            {
+              "name": "Fr33z",
+              "placement": 11,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0c19eb486a9df2d7",
+              "tournamentName": "SNT First Pokémon Champions Tournament"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "445",
+            "478",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Aerodactyl",
+            "Garchomp",
+            "Froslass",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 317,
+          "losses": 124,
+          "teams": [
+            {
+              "name": "tigerozi11",
+              "placement": 2,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ce03e3d95e233377",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "arsalp",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a16cec328eefa9a4",
+              "tournamentName": "Chaos League Sunday Slam #96"
+            },
+            {
+              "name": "Kaz z",
+              "placement": 18,
+              "record": "13-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6a9d92ff26cca4c3",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Pabloam",
+              "placement": 29,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/06e6a4da985ac3a5",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "trevYah",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Primarina",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/263e60e0cbd2f225",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "Willowatt",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e30472cf8d8b2f94",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "ironicpanda",
+              "placement": 46,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83533838183d56bf",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Kibble125",
+              "placement": 47,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/44460d7760fb2a96",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Davidbob32",
+              "placement": 5,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d5e29c2bd34ef0de",
+              "tournamentName": "VGCA Battle Hall #26"
+            },
+            {
+              "name": "SpicyCigar",
+              "placement": 5,
+              "record": "6-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/73a0e330e6f81d70",
+              "tournamentName": "Rookidee VGC Cup"
+            },
+            {
+              "name": "Sedia",
+              "placement": 5,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Primarina",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8aa9186fc8bbcc8a",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "Bebot",
+              "placement": 8,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5a0a2ceda1a7fb92",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "Jonnycat",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/efddb60c6f7fa5e1",
+              "tournamentName": "10ToesDownVGC #31 Champions $100 Top 4(Late Join)"
+            },
+            {
+              "name": "damiameru",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cbad0d9cd5a296c1",
+              "tournamentName": "Friday Fight Night #52 Reg M-A Bo3"
+            },
+            {
+              "name": "Sakusa",
+              "placement": 10,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1845dbc08603c8cc",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Setagaya",
+              "placement": 14,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d80a35b31b0f29d5",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Victor Matheus",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/db475614ce23db38",
+              "tournamentName": "Intimidators Champions Challenge #5 - REG M-A"
+            },
+            {
+              "name": "Bebot",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/581d5cccb9f6509f",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "alexro22",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c5d8d950e4ed34f0",
+              "tournamentName": "Champions Collective #4"
+            },
+            {
+              "name": "TPP",
+              "placement": 4,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/161fa9c6f8534384",
+              "tournamentName": "ChampionMads Singles Battle Arena #1 - $50 USD"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "142",
+            "445",
+            "700",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Aerodactyl",
+            "Garchomp",
+            "Sylveon",
+            "Kingambit"
+          ],
+          "wins": 319,
+          "losses": 152,
+          "teams": [
+            {
+              "name": "Mentosbombe",
+              "placement": 3,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5b6333455eb1d308",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ea25e09006131d26",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "BigNation",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/800a3c915f24ab69",
+              "tournamentName": "Chaos League Sunday Slam #100 ($100 Prize Pool)"
+            },
+            {
+              "name": "Chrom",
+              "placement": 23,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c8fc5bcfddc17b3b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "averagememer57",
+              "placement": 2,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7f31b8d19a7b2a3e",
+              "tournamentName": "*Sitrus-Series*|Champions|#57"
+            },
+            {
+              "name": "P_Amyrand",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0df4d758e8e4565c",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "averagememer57",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/588776aaf7efa3bc",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "KKCWind",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dadb91d6f888bff0",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Ksomon",
+              "placement": 1,
+              "record": "10-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ebef6770b45e9f2f",
+              "tournamentName": "Champions Collective #9"
+            },
+            {
+              "name": "NMR | FelipeT",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9da3ce35f701f567",
+              "tournamentName": "The Drywalls Series #5 - Champions!"
+            },
+            {
+              "name": "DaniVGC03",
+              "placement": 6,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fa7a9a3ddc0f8c45",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "mrelax0327",
+              "placement": 7,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/118c68395a0a85a8",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "averagememer57",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e5ea69794b0ac78a",
+              "tournamentName": "Devils Den Tournaments #75"
+            },
+            {
+              "name": "TerroneVGC",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f6c62d5346fc4564",
+              "tournamentName": "Dark Storm Team testing #8"
+            },
+            {
+              "name": "Silo",
+              "placement": 2,
+              "record": "5-3-1",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9032d0828bc0bfe6",
+              "tournamentName": "King's Gambit #3 | Reg M-A"
+            },
+            {
+              "name": "MrZiege",
+              "placement": 2,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fcbcd40379bcc6f6",
+              "tournamentName": "WARTORTLE WEDNESDAYS #60 REG M-A BO3 SWISS"
+            },
+            {
+              "name": "itsDani",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/86e19bab88a4eeaa",
+              "tournamentName": "Head Bussa's Hoedown#30 Champions $100 Top 4"
+            },
+            {
+              "name": "rapty",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b27859fd98ed3c00",
+              "tournamentName": "The Wide League Saturday Night Rumble #85"
+            },
+            {
+              "name": "juneberry123",
+              "placement": 11,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b3542a135702f8f8",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Drakypana",
+              "placement": 12,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b11ddfcfa1f3d6ae",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "445",
+            "478",
+            "902",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Garchomp",
+            "Froslass",
+            "Basculegion-M",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 384,
+          "losses": 159,
+          "teams": [
+            {
+              "name": "Kaz z",
+              "placement": 18,
+              "record": "13-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6a9d92ff26cca4c3",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Pabloam",
+              "placement": 29,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/06e6a4da985ac3a5",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "shaikhvgc786",
+              "placement": 4,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Sylveon",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0c5091cfc97606f4",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "ironicpanda",
+              "placement": 46,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83533838183d56bf",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Kibble125",
+              "placement": 47,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/44460d7760fb2a96",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Xeb41",
+              "placement": 5,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass-Mega",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3d5314b535e0403b",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "Davidbob32",
+              "placement": 5,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d5e29c2bd34ef0de",
+              "tournamentName": "VGCA Battle Hall #26"
+            },
+            {
+              "name": "SpicyCigar",
+              "placement": 5,
+              "record": "6-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/73a0e330e6f81d70",
+              "tournamentName": "Rookidee VGC Cup"
+            },
+            {
+              "name": "bowl_4",
+              "placement": 6,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass-Mega",
+                "Delphox-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ecfaeeea15deb512",
+              "tournamentName": "Extreme Speed Pokémon Champions #2"
+            },
+            {
+              "name": "Bebot",
+              "placement": 8,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5a0a2ceda1a7fb92",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "Jonnycat",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/efddb60c6f7fa5e1",
+              "tournamentName": "10ToesDownVGC #31 Champions $100 Top 4(Late Join)"
+            },
+            {
+              "name": "damiameru",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cbad0d9cd5a296c1",
+              "tournamentName": "Friday Fight Night #52 Reg M-A Bo3"
+            },
+            {
+              "name": "LiebesleidVGC",
+              "placement": 10,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/49b3061cb21922ff",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "Sakusa",
+              "placement": 10,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1845dbc08603c8cc",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Setagaya",
+              "placement": 14,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d80a35b31b0f29d5",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "BismarckB",
+              "placement": 1,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/19c3c043920ec1c5",
+              "tournamentName": "Pokemon Dominicana - Champions League #2"
+            },
+            {
+              "name": "Victor Matheus",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/db475614ce23db38",
+              "tournamentName": "Intimidators Champions Challenge #5 - REG M-A"
+            },
+            {
+              "name": "Bebot",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/581d5cccb9f6509f",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "phan7oom",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/454b259af46031db",
+              "tournamentName": "Intimidators Champions Challenge #6 - REG M-A"
+            },
+            {
+              "name": "alexro22",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c5d8d950e4ed34f0",
+              "tournamentName": "Champions Collective #4"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "445",
+            "547",
+            "970",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Garchomp",
+            "Whimsicott",
+            "Glimmora",
+            "Kingambit"
+          ],
+          "wins": 309,
+          "losses": 137,
+          "teams": [
+            {
+              "name": "Drurtle",
+              "placement": 2,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/59d4a74a34d541e3",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Jin-Hao Jiang",
+              "placement": 1,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2aa8747d4bddd894",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "OrangeSteve",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/04783a017130fc96",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "Luca",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/00503a0489ff0ccc",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6b5c775626b6e112",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "ZeBanded",
+              "placement": 3,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/927a1d9cc67e534f",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "JovenColo",
+              "placement": 1,
+              "record": "6-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Rotom-Wash",
+                "Whimsicott",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0ce94616c838780d",
+              "tournamentName": "[REG M-A] LearningtoSam's Weekly PokéLeague"
+            },
+            {
+              "name": "Noah Smith",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b46c5e06f5bf93ce",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #3 2026"
+            },
+            {
+              "name": "TinxoLibre",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0054d566adc72298",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "John Tan",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b7badc8e601f8ea",
+              "tournamentName": "King of Champions"
+            },
+            {
+              "name": "juneberry123",
+              "placement": 2,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/05e696c01762868b",
+              "tournamentName": "Pokepal Smackdown #141 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "Boopmydoop",
+              "placement": 2,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8618a189947cc301",
+              "tournamentName": "The Drywalls Series #5 - Champions!"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 2,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3ff47e887a334304",
+              "tournamentName": "Devils Den Tournaments #77"
+            },
+            {
+              "name": "TenkiPK",
+              "placement": 1,
+              "record": "7-1-1",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/323fa1a513431620",
+              "tournamentName": "King's Gambit #3 | Reg M-A"
+            },
+            {
+              "name": "Ruben Abreu",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/bbb5a0f2412f692e",
+              "tournamentName": "Game Corner Showdown 2025 - Split 3 | Torneio #4"
+            },
+            {
+              "name": "Pro4tomico",
+              "placement": 2,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b41d18da6b9f4090",
+              "tournamentName": "Road to Area 229 #3"
+            },
+            {
+              "name": "Niel Arveen Serrato",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/517cb342c3b64b7f",
+              "tournamentName": "King of Champions"
+            },
+            {
+              "name": "DennisTheWeird",
+              "placement": 3,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/adc924e19eb232b3",
+              "tournamentName": "[REG M-A] LearningtoSam's Weekly"
+            },
+            {
+              "name": "gham",
+              "placement": 4,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/eb7c3f761cd1f01a",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "Fernando R",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7b3d56d451ffd39d",
+              "tournamentName": "Champions Collective #9"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "445",
+            "670",
+            "902",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Garchomp",
+            "Floette-Mega",
+            "Basculegion-M",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 332,
+          "losses": 147,
+          "teams": [
+            {
+              "name": "Grimmothy_Snarl",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Delphox-Mega",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5eb4ffae39975131",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "Marth",
+              "placement": 14,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/56ce80359fb80d9b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "4lphabet",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9ff1b5571adf0ead",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "Alex Madara",
+              "placement": 27,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c91a9f58a7fa86eb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "TechnicallyInsane",
+              "placement": 28,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/208f92972f973077",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "4lphabet",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/999e838891b8264b",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            },
+            {
+              "name": "washy",
+              "placement": 51,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cf2275d04536a34f",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Xeb41",
+              "placement": 5,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass-Mega",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3d5314b535e0403b",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "asterisc",
+              "placement": 2,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Delphox",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/07861d7f07939b47",
+              "tournamentName": "PCP Premier Series: A Champion's Welcome!"
+            },
+            {
+              "name": "LiebesleidVGC",
+              "placement": 10,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/49b3061cb21922ff",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "volcaronavgc",
+              "placement": 1,
+              "record": "4-0-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Delphox-Mega",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8662c500ae2723bc",
+              "tournamentName": "[REG M-A] LearningtoSam's Weekly PokéLeague"
+            },
+            {
+              "name": "BismarckB",
+              "placement": 1,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/19c3c043920ec1c5",
+              "tournamentName": "Pokemon Dominicana - Champions League #2"
+            },
+            {
+              "name": "Treshole",
+              "placement": 3,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Delphox",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/001b695a4d2d65aa",
+              "tournamentName": "Champions 🇨🇷 tour #1"
+            },
+            {
+              "name": "riomelaceto92",
+              "placement": 3,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f0bd8eaf89d9d403",
+              "tournamentName": "VGC Trainer School; champions M/A #4"
+            },
+            {
+              "name": "LorGhez11",
+              "placement": 10,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0bb04a704cf7d00a",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            },
+            {
+              "name": "Fr33z",
+              "placement": 11,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0c19eb486a9df2d7",
+              "tournamentName": "SNT First Pokémon Champions Tournament"
+            },
+            {
+              "name": "Starlight143",
+              "placement": 12,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Delphox-Mega",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6987071c3b142434",
+              "tournamentName": "Extreme Speed Pokémon Champions"
+            },
+            {
+              "name": "SomeoneOffical",
+              "placement": 13,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/66ffbd9fabebafe3",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "Yoshi1267",
+              "placement": 18,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/915c1ec24ef3f5a3",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "volcaronavgc",
+              "placement": 21,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Delphox-Mega",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/04d5977844db7ee6",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "547",
+            "902",
+            "970",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Whimsicott",
+            "Basculegion-M",
+            "Glimmora",
+            "Kingambit"
+          ],
+          "wins": 288,
+          "losses": 125,
+          "teams": [
+            {
+              "name": "Drurtle",
+              "placement": 2,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/59d4a74a34d541e3",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Jin-Hao Jiang",
+              "placement": 1,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2aa8747d4bddd894",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "OrangeSteve",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/04783a017130fc96",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "Luca",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/00503a0489ff0ccc",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6b5c775626b6e112",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "ZeBanded",
+              "placement": 3,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/927a1d9cc67e534f",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "TinxoLibre",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Whimsicott",
+                "Sylveon",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b34842af369f1918",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Noah Smith",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b46c5e06f5bf93ce",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #3 2026"
+            },
+            {
+              "name": "TinxoLibre",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0054d566adc72298",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "John Tan",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b7badc8e601f8ea",
+              "tournamentName": "King of Champions"
+            },
+            {
+              "name": "juneberry123",
+              "placement": 2,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/05e696c01762868b",
+              "tournamentName": "Pokepal Smackdown #141 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "Boopmydoop",
+              "placement": 2,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8618a189947cc301",
+              "tournamentName": "The Drywalls Series #5 - Champions!"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 2,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3ff47e887a334304",
+              "tournamentName": "Devils Den Tournaments #77"
+            },
+            {
+              "name": "TenkiPK",
+              "placement": 1,
+              "record": "7-1-1",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/323fa1a513431620",
+              "tournamentName": "King's Gambit #3 | Reg M-A"
+            },
+            {
+              "name": "Ruben Abreu",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/bbb5a0f2412f692e",
+              "tournamentName": "Game Corner Showdown 2025 - Split 3 | Torneio #4"
+            },
+            {
+              "name": "Pro4tomico",
+              "placement": 2,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b41d18da6b9f4090",
+              "tournamentName": "Road to Area 229 #3"
+            },
+            {
+              "name": "Niel Arveen Serrato",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/517cb342c3b64b7f",
+              "tournamentName": "King of Champions"
+            },
+            {
+              "name": "DennisTheWeird",
+              "placement": 3,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/adc924e19eb232b3",
+              "tournamentName": "[REG M-A] LearningtoSam's Weekly"
+            },
+            {
+              "name": "gham",
+              "placement": 4,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/eb7c3f761cd1f01a",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "Fernando R",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7b3d56d451ffd39d",
+              "tournamentName": "Champions Collective #9"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "445",
+            "700",
+            "902",
+            "983"
+          ],
+          "pokemonNames": [
+            "Aerodactyl",
+            "Garchomp",
+            "Sylveon",
+            "Basculegion-M",
+            "Kingambit"
+          ],
+          "wins": 310,
+          "losses": 155,
+          "teams": [
+            {
+              "name": "Mentosbombe",
+              "placement": 3,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5b6333455eb1d308",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ea25e09006131d26",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "BigNation",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/800a3c915f24ab69",
+              "tournamentName": "Chaos League Sunday Slam #100 ($100 Prize Pool)"
+            },
+            {
+              "name": "Chrom",
+              "placement": 23,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c8fc5bcfddc17b3b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "P_Amyrand",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0df4d758e8e4565c",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "charismaacheck",
+              "placement": 3,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/16eea4587f4df90f",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "KKCWind",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dadb91d6f888bff0",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Ksomon",
+              "placement": 1,
+              "record": "10-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ebef6770b45e9f2f",
+              "tournamentName": "Champions Collective #9"
+            },
+            {
+              "name": "NMR | FelipeT",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9da3ce35f701f567",
+              "tournamentName": "The Drywalls Series #5 - Champions!"
+            },
+            {
+              "name": "DaniVGC03",
+              "placement": 6,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fa7a9a3ddc0f8c45",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "mrelax0327",
+              "placement": 7,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/118c68395a0a85a8",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "Silo",
+              "placement": 2,
+              "record": "5-3-1",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9032d0828bc0bfe6",
+              "tournamentName": "King's Gambit #3 | Reg M-A"
+            },
+            {
+              "name": "MrZiege",
+              "placement": 2,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fcbcd40379bcc6f6",
+              "tournamentName": "WARTORTLE WEDNESDAYS #60 REG M-A BO3 SWISS"
+            },
+            {
+              "name": "itsDani",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/86e19bab88a4eeaa",
+              "tournamentName": "Head Bussa's Hoedown#30 Champions $100 Top 4"
+            },
+            {
+              "name": "rapty",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b27859fd98ed3c00",
+              "tournamentName": "The Wide League Saturday Night Rumble #85"
+            },
+            {
+              "name": "juneberry123",
+              "placement": 11,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b3542a135702f8f8",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Drakypana",
+              "placement": 12,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b11ddfcfa1f3d6ae",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Animod",
+              "placement": 12,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2cbb68723d7838c7",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "disa",
+              "placement": 15,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e6ed9c381b8f0f15",
+              "tournamentName": "10ToesDownVGC #31 Champions $100 Top 4(Late Join)"
+            },
+            {
+              "name": "chabezoid",
+              "placement": 18,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/775ebd396669ba5a",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "445",
+            "547",
+            "902",
+            "970",
+            "983"
+          ],
+          "pokemonNames": [
+            "Garchomp",
+            "Whimsicott",
+            "Basculegion-M",
+            "Glimmora",
+            "Kingambit"
+          ],
+          "wins": 283,
+          "losses": 126,
+          "teams": [
+            {
+              "name": "Drurtle",
+              "placement": 2,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/59d4a74a34d541e3",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Jin-Hao Jiang",
+              "placement": 1,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2aa8747d4bddd894",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "OrangeSteve",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/04783a017130fc96",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "Luca",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/00503a0489ff0ccc",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6b5c775626b6e112",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "ZeBanded",
+              "placement": 3,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/927a1d9cc67e534f",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Noah Smith",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b46c5e06f5bf93ce",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #3 2026"
+            },
+            {
+              "name": "TinxoLibre",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0054d566adc72298",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "John Tan",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b7badc8e601f8ea",
+              "tournamentName": "King of Champions"
+            },
+            {
+              "name": "juneberry123",
+              "placement": 2,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/05e696c01762868b",
+              "tournamentName": "Pokepal Smackdown #141 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "Boopmydoop",
+              "placement": 2,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8618a189947cc301",
+              "tournamentName": "The Drywalls Series #5 - Champions!"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 2,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3ff47e887a334304",
+              "tournamentName": "Devils Den Tournaments #77"
+            },
+            {
+              "name": "TenkiPK",
+              "placement": 1,
+              "record": "7-1-1",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/323fa1a513431620",
+              "tournamentName": "King's Gambit #3 | Reg M-A"
+            },
+            {
+              "name": "Ruben Abreu",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/bbb5a0f2412f692e",
+              "tournamentName": "Game Corner Showdown 2025 - Split 3 | Torneio #4"
+            },
+            {
+              "name": "Pro4tomico",
+              "placement": 2,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b41d18da6b9f4090",
+              "tournamentName": "Road to Area 229 #3"
+            },
+            {
+              "name": "Niel Arveen Serrato",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/517cb342c3b64b7f",
+              "tournamentName": "King of Champions"
+            },
+            {
+              "name": "DennisTheWeird",
+              "placement": 3,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/adc924e19eb232b3",
+              "tournamentName": "[REG M-A] LearningtoSam's Weekly"
+            },
+            {
+              "name": "gham",
+              "placement": 4,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/eb7c3f761cd1f01a",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "Fernando R",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7b3d56d451ffd39d",
+              "tournamentName": "Champions Collective #9"
+            },
+            {
+              "name": "blackkobra",
+              "placement": 10,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4935f97ff921d6ad",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "445",
+            "902",
+            "970",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Garchomp",
+            "Basculegion-M",
+            "Glimmora",
+            "Kingambit"
+          ],
+          "wins": 280,
+          "losses": 123,
+          "teams": [
+            {
+              "name": "Drurtle",
+              "placement": 2,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/59d4a74a34d541e3",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Jin-Hao Jiang",
+              "placement": 1,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2aa8747d4bddd894",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "OrangeSteve",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/04783a017130fc96",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "Luca",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/00503a0489ff0ccc",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6b5c775626b6e112",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "ZeBanded",
+              "placement": 3,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/927a1d9cc67e534f",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Noah Smith",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b46c5e06f5bf93ce",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #3 2026"
+            },
+            {
+              "name": "TinxoLibre",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0054d566adc72298",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "John Tan",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b7badc8e601f8ea",
+              "tournamentName": "King of Champions"
+            },
+            {
+              "name": "juneberry123",
+              "placement": 2,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/05e696c01762868b",
+              "tournamentName": "Pokepal Smackdown #141 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "Boopmydoop",
+              "placement": 2,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8618a189947cc301",
+              "tournamentName": "The Drywalls Series #5 - Champions!"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 2,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3ff47e887a334304",
+              "tournamentName": "Devils Den Tournaments #77"
+            },
+            {
+              "name": "TenkiPK",
+              "placement": 1,
+              "record": "7-1-1",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/323fa1a513431620",
+              "tournamentName": "King's Gambit #3 | Reg M-A"
+            },
+            {
+              "name": "Ruben Abreu",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/bbb5a0f2412f692e",
+              "tournamentName": "Game Corner Showdown 2025 - Split 3 | Torneio #4"
+            },
+            {
+              "name": "Pro4tomico",
+              "placement": 2,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b41d18da6b9f4090",
+              "tournamentName": "Road to Area 229 #3"
+            },
+            {
+              "name": "Niel Arveen Serrato",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/517cb342c3b64b7f",
+              "tournamentName": "King of Champions"
+            },
+            {
+              "name": "DennisTheWeird",
+              "placement": 3,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/adc924e19eb232b3",
+              "tournamentName": "[REG M-A] LearningtoSam's Weekly"
+            },
+            {
+              "name": "gham",
+              "placement": 4,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/eb7c3f761cd1f01a",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "Fernando R",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7b3d56d451ffd39d",
+              "tournamentName": "Champions Collective #9"
+            },
+            {
+              "name": "blackkobra",
+              "placement": 10,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4935f97ff921d6ad",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "036",
+            "655",
+            "902",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Clefable",
+            "Delphox",
+            "Basculegion-M",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 256,
+          "losses": 115,
+          "teams": [
+            {
+              "name": "gamblingvgc92",
+              "placement": 1,
+              "record": "13-2-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9a56b82ba37cd5fc",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "DisPlotfr",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5656a951188f7493",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "bpecina03",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Garchomp",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e0a0267aff1bdcfc",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "Pendraggon26",
+              "placement": 3,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b22713cddbbdb46f",
+              "tournamentName": "Chaos League Sunday Slam #100 ($100 Prize Pool)"
+            },
+            {
+              "name": "Dan7487",
+              "placement": 7,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4318e6d15671f113",
+              "tournamentName": "Pokemon Champions Challenge #2"
+            },
+            {
+              "name": "Thanosgreninja",
+              "placement": 8,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/71367347c2ece27c",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "aboxoftimbits",
+              "placement": 35,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Garchomp",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/df9c152dd73454cb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "LiebesleidVGC",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Clefable",
+                "Garchomp",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9e7f83a33d784a8d",
+              "tournamentName": "POKEMON CHAMPAGNE- LO CAMBIA TODO N°1"
+            },
+            {
+              "name": "eanna_h",
+              "placement": 6,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fb7e4f3b9da36232",
+              "tournamentName": "Tenki's Cart - Pokémon Champions M-A ruleset!"
+            },
+            {
+              "name": "Nehzzy",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/57e5073ae4280502",
+              "tournamentName": "The Drywall Series - CHAMPIONS"
+            },
+            {
+              "name": "6nerox",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/70ed6d61fbf01d68",
+              "tournamentName": "The Dark League champions pop up! 5$usd"
+            },
+            {
+              "name": "Leonardoahl",
+              "placement": 1,
+              "record": "4-0-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c3ddc29c2c96f602",
+              "tournamentName": "🏆Pokémon CHAMPIONS🏆 Mi Dulce Japón Tournament #1"
+            },
+            {
+              "name": "Zaiko",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d1e612e5e5aed254",
+              "tournamentName": "Ratorneo #2 Apertura Champions 2026 | Reg MA | BO3"
+            },
+            {
+              "name": "Diogo Henriques",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Clefable",
+                "Garchomp",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1a99397f82a67458",
+              "tournamentName": "Game Corner Showdown 2025 - Split 3 | Torneio #2"
+            },
+            {
+              "name": "HardFreaQ",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/06cdd0594a91be76",
+              "tournamentName": "Friendly #1 - Game Corner - Champions"
+            },
+            {
+              "name": "BHelixB",
+              "placement": 4,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Garchomp",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/566e87876a25e327",
+              "tournamentName": "Friday Fight Night #53 Reg M-A Bo3"
+            },
+            {
+              "name": "joniaco",
+              "placement": 4,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Garchomp",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/60e208843506b5c8",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "6nerox",
+              "placement": 11,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/48cfaa4a489c14ac",
+              "tournamentName": "Extreme Speed Pokémon Champions"
+            },
+            {
+              "name": "Wax18",
+              "placement": 12,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cb7093afd867a0fb",
+              "tournamentName": "CHAMPIONS COLLECTIVE INAUGURAL TOURNAMENT"
+            },
+            {
+              "name": "Jehanne",
+              "placement": 17,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Aerodactyl",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5f749eb9353e742d",
+              "tournamentName": "LIGA DA COMUNIDADE #3 (R$ 1.000 PRIZE POOL)"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "445",
+            "700",
+            "902",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Garchomp",
+            "Sylveon",
+            "Basculegion-M",
+            "Kingambit"
+          ],
+          "wins": 299,
+          "losses": 151,
+          "teams": [
+            {
+              "name": "Mentosbombe",
+              "placement": 3,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5b6333455eb1d308",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ea25e09006131d26",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "BigNation",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/800a3c915f24ab69",
+              "tournamentName": "Chaos League Sunday Slam #100 ($100 Prize Pool)"
+            },
+            {
+              "name": "Chrom",
+              "placement": 23,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c8fc5bcfddc17b3b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "P_Amyrand",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0df4d758e8e4565c",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "KKCWind",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dadb91d6f888bff0",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Ksomon",
+              "placement": 1,
+              "record": "10-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ebef6770b45e9f2f",
+              "tournamentName": "Champions Collective #9"
+            },
+            {
+              "name": "NMR | FelipeT",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9da3ce35f701f567",
+              "tournamentName": "The Drywalls Series #5 - Champions!"
+            },
+            {
+              "name": "DaniVGC03",
+              "placement": 6,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fa7a9a3ddc0f8c45",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "mrelax0327",
+              "placement": 7,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/118c68395a0a85a8",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "Silo",
+              "placement": 2,
+              "record": "5-3-1",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9032d0828bc0bfe6",
+              "tournamentName": "King's Gambit #3 | Reg M-A"
+            },
+            {
+              "name": "MrZiege",
+              "placement": 2,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fcbcd40379bcc6f6",
+              "tournamentName": "WARTORTLE WEDNESDAYS #60 REG M-A BO3 SWISS"
+            },
+            {
+              "name": "itsDani",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/86e19bab88a4eeaa",
+              "tournamentName": "Head Bussa's Hoedown#30 Champions $100 Top 4"
+            },
+            {
+              "name": "rapty",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b27859fd98ed3c00",
+              "tournamentName": "The Wide League Saturday Night Rumble #85"
+            },
+            {
+              "name": "juneberry123",
+              "placement": 11,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b3542a135702f8f8",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Drakypana",
+              "placement": 12,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b11ddfcfa1f3d6ae",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Animod",
+              "placement": 12,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2cbb68723d7838c7",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "disa",
+              "placement": 15,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e6ed9c381b8f0f15",
+              "tournamentName": "10ToesDownVGC #31 Champions $100 Top 4(Late Join)"
+            },
+            {
+              "name": "chabezoid",
+              "placement": 18,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/775ebd396669ba5a",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Alkai",
+              "placement": 27,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6b3341a26b6a46ca",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "142",
+            "700",
+            "902",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Aerodactyl",
+            "Sylveon",
+            "Basculegion-M",
+            "Kingambit"
+          ],
+          "wins": 295,
+          "losses": 145,
+          "teams": [
+            {
+              "name": "Mentosbombe",
+              "placement": 3,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5b6333455eb1d308",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ea25e09006131d26",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "BigNation",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/800a3c915f24ab69",
+              "tournamentName": "Chaos League Sunday Slam #100 ($100 Prize Pool)"
+            },
+            {
+              "name": "Chrom",
+              "placement": 23,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c8fc5bcfddc17b3b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "P_Amyrand",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0df4d758e8e4565c",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "KKCWind",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dadb91d6f888bff0",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Ksomon",
+              "placement": 1,
+              "record": "10-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ebef6770b45e9f2f",
+              "tournamentName": "Champions Collective #9"
+            },
+            {
+              "name": "NMR | FelipeT",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9da3ce35f701f567",
+              "tournamentName": "The Drywalls Series #5 - Champions!"
+            },
+            {
+              "name": "DaniVGC03",
+              "placement": 6,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fa7a9a3ddc0f8c45",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "mrelax0327",
+              "placement": 7,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/118c68395a0a85a8",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "Silo",
+              "placement": 2,
+              "record": "5-3-1",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9032d0828bc0bfe6",
+              "tournamentName": "King's Gambit #3 | Reg M-A"
+            },
+            {
+              "name": "MrZiege",
+              "placement": 2,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fcbcd40379bcc6f6",
+              "tournamentName": "WARTORTLE WEDNESDAYS #60 REG M-A BO3 SWISS"
+            },
+            {
+              "name": "itsDani",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/86e19bab88a4eeaa",
+              "tournamentName": "Head Bussa's Hoedown#30 Champions $100 Top 4"
+            },
+            {
+              "name": "rapty",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b27859fd98ed3c00",
+              "tournamentName": "The Wide League Saturday Night Rumble #85"
+            },
+            {
+              "name": "juneberry123",
+              "placement": 11,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b3542a135702f8f8",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Drakypana",
+              "placement": 12,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b11ddfcfa1f3d6ae",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Animod",
+              "placement": 12,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2cbb68723d7838c7",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "disa",
+              "placement": 15,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e6ed9c381b8f0f15",
+              "tournamentName": "10ToesDownVGC #31 Champions $100 Top 4(Late Join)"
+            },
+            {
+              "name": "chabezoid",
+              "placement": 18,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/775ebd396669ba5a",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Alkai",
+              "placement": 27,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6b3341a26b6a46ca",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "445",
+            "670",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Aerodactyl",
+            "Garchomp",
+            "Floette-Mega",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 326,
+          "losses": 134,
+          "teams": [
+            {
+              "name": "SilvioUeda",
+              "placement": 1,
+              "record": "12-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Volcarona",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e6752d26bfef1d42",
+              "tournamentName": "LIGA DA COMUNIDADE #3 (R$ 1.000 PRIZE POOL)"
+            },
+            {
+              "name": "Arekusabi",
+              "placement": 12,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b32461d35242dadb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Marth",
+              "placement": 14,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/56ce80359fb80d9b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Darkip_8",
+              "placement": 2,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Volcarona",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c2f82b11adb15a72",
+              "tournamentName": "Champions Tour LEPE #1 (5€ to 1st)"
+            },
+            {
+              "name": "Swamp",
+              "placement": 3,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Delphox-Mega",
+                "Floette-Mega",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fa134c79a423553b",
+              "tournamentName": "VGCA Battle Hall #26"
+            },
+            {
+              "name": "Nano",
+              "placement": 3,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c54efc43422ddf9",
+              "tournamentName": "Extreme Speed Pokémon Champions #3"
+            },
+            {
+              "name": "Feitan7",
+              "placement": 5,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Whimsicott",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/09d4c18b2fcd796f",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "DyeItTight",
+              "placement": 59,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c1a5a1cee801cbf3",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 9,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f418a398741b22cd",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "MarvVGC",
+              "placement": 12,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Delphox",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/362204992b8b9c78",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "Trafalgar_VGC",
+              "placement": 1,
+              "record": "6-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d12e0b8adc667a85",
+              "tournamentName": "POKÉMON CHAMPIONS Circuito VGC #2 | Z2 Gaming"
+            },
+            {
+              "name": "Darkip_8",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/03be675e2dbe11cd",
+              "tournamentName": "Champions Tour LEPE #3"
+            },
+            {
+              "name": "Jesse504",
+              "placement": 9,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/df64b2c54395305b",
+              "tournamentName": "Talon's FIGHT CLUB #81 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Fr33z",
+              "placement": 11,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0c19eb486a9df2d7",
+              "tournamentName": "SNT First Pokémon Champions Tournament"
+            },
+            {
+              "name": "Arekusabi",
+              "placement": 12,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2dca0b01f2f26cc4",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "Raiyzer",
+              "placement": 14,
+              "record": "3-2-0",
+              "pokemonNames": [
+                "Aerodactyl-Mega",
+                "Garchomp",
+                "Floette-Mega",
+                "Aegislash-Blade",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c4613ead5c6f3e9b",
+              "tournamentName": "Pokepal Smackdown #136 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "KST VGC ",
+              "placement": 16,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/518075ed423bbb79",
+              "tournamentName": "Chaos League Sunday Slam #96"
+            },
+            {
+              "name": "slothdiesel",
+              "placement": 97,
+              "record": "11-4-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/26aff3b4be147d1e",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "RiotJuice",
+              "placement": 128,
+              "record": "10-5-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b3c395017bef07eb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "SilvioUeda",
+              "placement": 5,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Volcarona",
+                "Floette-Mega",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cb47729a81fc2516",
+              "tournamentName": "Intimidators Champions Challenge #3 - REG M-A"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "154",
+            "902",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Aerodactyl",
+            "Meganium-Mega",
+            "Basculegion-M",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 232,
+          "losses": 93,
+          "teams": [
+            {
+              "name": "Fluffy_m1n",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ec1822f5d298b94e",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Wb_vg",
+              "placement": 1,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/79f18572188fc823",
+              "tournamentName": "Weekly | Liberation Crusade #1 | $100 |Volticons"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 2,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b74f2a78b533ab2b",
+              "tournamentName": "The Drywall Series - Champions!"
+            },
+            {
+              "name": "JOAO",
+              "placement": 3,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c6eab74bc48b6f8d",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "Z2R caiovibora",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/054ead062b8a2dff",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "Starlight143",
+              "placement": 4,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Garchomp",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/801d6aa617a6863f",
+              "tournamentName": "Extreme Speed Pokémon Champions #2"
+            },
+            {
+              "name": "Kaige",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1187bd89a1f4347c",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "Kaige",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/469c7cca3fddbe19",
+              "tournamentName": "Champions 🇨🇷 tour #1"
+            },
+            {
+              "name": "Fluffy_m1n",
+              "placement": 1,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/afa825915003385a",
+              "tournamentName": "Devils Den Tournaments #77"
+            },
+            {
+              "name": "Kana Arima",
+              "placement": 5,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a98e852999d94292",
+              "tournamentName": "Pokémon Champions SV #1"
+            },
+            {
+              "name": "Kaige",
+              "placement": 5,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/bb33aca675c84fad",
+              "tournamentName": "The Drywall Series - Champions!"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d34badbafba9ea22",
+              "tournamentName": "VGCA Battle Hall #26"
+            },
+            {
+              "name": "Fluffy_m1n",
+              "placement": 8,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/365d925eda28d4aa",
+              "tournamentName": "The Drywall Series - Champions!"
+            },
+            {
+              "name": "chromeo ",
+              "placement": 8,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7d895bd5b30d3c67",
+              "tournamentName": "Extreme Speed Pokémon Champions #3"
+            },
+            {
+              "name": "Fluffy_m1n",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5a3ae51e427374ff",
+              "tournamentName": "Pokeacadamy throwdown"
+            },
+            {
+              "name": "Kaige",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c4329e6a9490da7a",
+              "tournamentName": "Pokemon Champions Challenge #4"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 10,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f3075c9516e6e090",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 10,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d8d2af66a6828060",
+              "tournamentName": "Talon's FIGHT CLUB #81 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Hagakury",
+              "placement": 28,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4e18530a0cb9068f",
+              "tournamentName": "LIGA DA COMUNIDADE #3 (R$ 1.000 PRIZE POOL)"
+            },
+            {
+              "name": "Kaige",
+              "placement": 32,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3efb341306c58c13",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "size": 6,
+      "clusters": [
+        {
+          "pokemon": [
+            "006",
+            "142",
+            "445",
+            "670",
+            "902",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Aerodactyl",
+            "Garchomp",
+            "Floette",
+            "Basculegion-M",
+            "Kingambit"
+          ],
+          "wins": 360,
+          "losses": 172,
+          "teams": [
+            {
+              "name": "mudhiman",
+              "placement": 1,
+              "record": "19-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/348127db40fb7b33",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Conics",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e22099ff2808b0bf",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/877aac7820d660d9",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Davi Guimaraes",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b0bce48841c2b8f",
+              "tournamentName": "Friday Fight Night #53 Reg M-A Bo3"
+            },
+            {
+              "name": "Sergyo91",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8645009bd9bb2117",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a8b7ca848bcf5d66",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "charpie",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b393ddebcd0fc581",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "thekill009",
+              "placement": 2,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Charizard-Mega Y",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7e017159ea147fb3",
+              "tournamentName": "Torneo #2 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Serber",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3629a0feb9659868",
+              "tournamentName": "Pokemon Champions Challenge #4"
+            },
+            {
+              "name": "Yuma0O",
+              "placement": 9,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/07fab198f290ddbe",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "iamstrawberry93",
+              "placement": 1,
+              "record": "4-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4226c7bb8b3c2f70",
+              "tournamentName": "제2회 너클시티 챌린저스 [Hammerlocke Challengers]"
+            },
+            {
+              "name": "TerroneVGC",
+              "placement": 1,
+              "record": "6-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/41fccb7cc14d48c3",
+              "tournamentName": "Dark Storm Team testing #6"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b97ba507a0f8ffd6",
+              "tournamentName": "Buffet Battles Regulation M-A #1 - 16/5/26"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 2,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/376ca4222b175d65",
+              "tournamentName": "Torneo #4 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7d0240470f0743e3",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "MetalLegsSolid",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5e5a8f9e50d474de",
+              "tournamentName": "The Drywalls Seriers #4 - Champions!"
+            },
+            {
+              "name": "Will Alcântara",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c350e44a7dcccffc",
+              "tournamentName": "Intimidators Champions Challenge #10- REG M-A"
+            },
+            {
+              "name": "Astrah",
+              "placement": 4,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dc1c01addd0b1f99",
+              "tournamentName": "The Drywalls Series #3 - Champions!"
+            },
+            {
+              "name": "Jsparks1102",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8089f5d6c2a8f7da",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "Diwek",
+              "placement": 9,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4b5306cb7bb3fef7",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "445",
+            "547",
+            "902",
+            "970",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Garchomp",
+            "Whimsicott",
+            "Basculegion-M",
+            "Glimmora",
+            "Kingambit"
+          ],
+          "wins": 280,
+          "losses": 123,
+          "teams": [
+            {
+              "name": "Drurtle",
+              "placement": 2,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/59d4a74a34d541e3",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Jin-Hao Jiang",
+              "placement": 1,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2aa8747d4bddd894",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "OrangeSteve",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/04783a017130fc96",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "Luca",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/00503a0489ff0ccc",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6b5c775626b6e112",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "ZeBanded",
+              "placement": 3,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/927a1d9cc67e534f",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Noah Smith",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b46c5e06f5bf93ce",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #3 2026"
+            },
+            {
+              "name": "TinxoLibre",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0054d566adc72298",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "John Tan",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8b7badc8e601f8ea",
+              "tournamentName": "King of Champions"
+            },
+            {
+              "name": "juneberry123",
+              "placement": 2,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/05e696c01762868b",
+              "tournamentName": "Pokepal Smackdown #141 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "Boopmydoop",
+              "placement": 2,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8618a189947cc301",
+              "tournamentName": "The Drywalls Series #5 - Champions!"
+            },
+            {
+              "name": "JuanPabla",
+              "placement": 2,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3ff47e887a334304",
+              "tournamentName": "Devils Den Tournaments #77"
+            },
+            {
+              "name": "TenkiPK",
+              "placement": 1,
+              "record": "7-1-1",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/323fa1a513431620",
+              "tournamentName": "King's Gambit #3 | Reg M-A"
+            },
+            {
+              "name": "Ruben Abreu",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/bbb5a0f2412f692e",
+              "tournamentName": "Game Corner Showdown 2025 - Split 3 | Torneio #4"
+            },
+            {
+              "name": "Pro4tomico",
+              "placement": 2,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b41d18da6b9f4090",
+              "tournamentName": "Road to Area 229 #3"
+            },
+            {
+              "name": "Niel Arveen Serrato",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/517cb342c3b64b7f",
+              "tournamentName": "King of Champions"
+            },
+            {
+              "name": "DennisTheWeird",
+              "placement": 3,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/adc924e19eb232b3",
+              "tournamentName": "[REG M-A] LearningtoSam's Weekly"
+            },
+            {
+              "name": "gham",
+              "placement": 4,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/eb7c3f761cd1f01a",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "Fernando R",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7b3d56d451ffd39d",
+              "tournamentName": "Champions Collective #9"
+            },
+            {
+              "name": "blackkobra",
+              "placement": 10,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Basculegion-M",
+                "Glimmora",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4935f97ff921d6ad",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "142",
+            "445",
+            "700",
+            "902",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Aerodactyl",
+            "Garchomp",
+            "Sylveon",
+            "Basculegion-M",
+            "Kingambit"
+          ],
+          "wins": 292,
+          "losses": 145,
+          "teams": [
+            {
+              "name": "Mentosbombe",
+              "placement": 3,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5b6333455eb1d308",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Duxlemon",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ea25e09006131d26",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "BigNation",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/800a3c915f24ab69",
+              "tournamentName": "Chaos League Sunday Slam #100 ($100 Prize Pool)"
+            },
+            {
+              "name": "Chrom",
+              "placement": 23,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c8fc5bcfddc17b3b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "P_Amyrand",
+              "placement": 2,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0df4d758e8e4565c",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "KKCWind",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/dadb91d6f888bff0",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "Ksomon",
+              "placement": 1,
+              "record": "10-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ebef6770b45e9f2f",
+              "tournamentName": "Champions Collective #9"
+            },
+            {
+              "name": "NMR | FelipeT",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9da3ce35f701f567",
+              "tournamentName": "The Drywalls Series #5 - Champions!"
+            },
+            {
+              "name": "DaniVGC03",
+              "placement": 6,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fa7a9a3ddc0f8c45",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "mrelax0327",
+              "placement": 7,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/118c68395a0a85a8",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "Silo",
+              "placement": 2,
+              "record": "5-3-1",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9032d0828bc0bfe6",
+              "tournamentName": "King's Gambit #3 | Reg M-A"
+            },
+            {
+              "name": "MrZiege",
+              "placement": 2,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fcbcd40379bcc6f6",
+              "tournamentName": "WARTORTLE WEDNESDAYS #60 REG M-A BO3 SWISS"
+            },
+            {
+              "name": "itsDani",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/86e19bab88a4eeaa",
+              "tournamentName": "Head Bussa's Hoedown#30 Champions $100 Top 4"
+            },
+            {
+              "name": "rapty",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b27859fd98ed3c00",
+              "tournamentName": "The Wide League Saturday Night Rumble #85"
+            },
+            {
+              "name": "juneberry123",
+              "placement": 11,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b3542a135702f8f8",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Drakypana",
+              "placement": 12,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b11ddfcfa1f3d6ae",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Animod",
+              "placement": 12,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2cbb68723d7838c7",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "disa",
+              "placement": 15,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e6ed9c381b8f0f15",
+              "tournamentName": "10ToesDownVGC #31 Champions $100 Top 4(Late Join)"
+            },
+            {
+              "name": "chabezoid",
+              "placement": 18,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/775ebd396669ba5a",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Alkai",
+              "placement": 27,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6b3341a26b6a46ca",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "445",
+            "478",
+            "902",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Aerodactyl",
+            "Garchomp",
+            "Froslass",
+            "Basculegion-M",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 221,
+          "losses": 81,
+          "teams": [
+            {
+              "name": "Kaz z",
+              "placement": 18,
+              "record": "13-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6a9d92ff26cca4c3",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Pabloam",
+              "placement": 29,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/06e6a4da985ac3a5",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "ironicpanda",
+              "placement": 46,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83533838183d56bf",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Kibble125",
+              "placement": 47,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/44460d7760fb2a96",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Davidbob32",
+              "placement": 5,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d5e29c2bd34ef0de",
+              "tournamentName": "VGCA Battle Hall #26"
+            },
+            {
+              "name": "SpicyCigar",
+              "placement": 5,
+              "record": "6-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/73a0e330e6f81d70",
+              "tournamentName": "Rookidee VGC Cup"
+            },
+            {
+              "name": "Bebot",
+              "placement": 8,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5a0a2ceda1a7fb92",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "Jonnycat",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/efddb60c6f7fa5e1",
+              "tournamentName": "10ToesDownVGC #31 Champions $100 Top 4(Late Join)"
+            },
+            {
+              "name": "damiameru",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cbad0d9cd5a296c1",
+              "tournamentName": "Friday Fight Night #52 Reg M-A Bo3"
+            },
+            {
+              "name": "Sakusa",
+              "placement": 10,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1845dbc08603c8cc",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Setagaya",
+              "placement": 14,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d80a35b31b0f29d5",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Victor Matheus",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/db475614ce23db38",
+              "tournamentName": "Intimidators Champions Challenge #5 - REG M-A"
+            },
+            {
+              "name": "Bebot",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/581d5cccb9f6509f",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "alexro22",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c5d8d950e4ed34f0",
+              "tournamentName": "Champions Collective #4"
+            },
+            {
+              "name": "TPP",
+              "placement": 4,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/161fa9c6f8534384",
+              "tournamentName": "ChampionMads Singles Battle Arena #1 - $50 USD"
+            },
+            {
+              "name": "JuicyJuiceBox789",
+              "placement": 13,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e92cdb2427b36cb7",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Selu_VGC",
+              "placement": 16,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4c4079ac5d37dd03",
+              "tournamentName": "Head Bussa's Hoedown#29 ChampionsReg M-A $25 1st"
+            },
+            {
+              "name": "CbuttyVGC",
+              "placement": 68,
+              "record": "11-4-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/384e318640623988",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Jesuuuus",
+              "placement": 94,
+              "record": "11-4-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3c95fbc986d6936b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "ElFullbuster",
+              "placement": 125,
+              "record": "11-4-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2cb0161f71e6d2ce",
+              "tournamentName": "The Grand Champions Festival"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "670",
+            "902",
+            "903",
+            "925",
+            "983"
+          ],
+          "pokemonNames": [
+            "Aerodactyl",
+            "Floette",
+            "Basculegion-M",
+            "Sneasler",
+            "Maushold",
+            "Kingambit"
+          ],
+          "wins": 99,
+          "losses": 48,
+          "teams": [
+            {
+              "name": "soahmed",
+              "placement": 2,
+              "record": "11-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/10f4af89265000b8",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "OgreVGC",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/62ca06a2139fc268",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "Mattytaxes",
+              "placement": 15,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1129e4a2ade1d08b",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "Wyuku",
+              "placement": 3,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b28e24f9e5b36bcf",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "Mattytaxes",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/18741766a50829d0",
+              "tournamentName": "Chaos League Sunday Slam #96"
+            },
+            {
+              "name": "jANMxRin",
+              "placement": 29,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5d372827560c8482",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "Wyuku",
+              "placement": 6,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cef1711e4f592754",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "FF",
+              "placement": 7,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2f58e20d66659ce5",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "Silo",
+              "placement": 12,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/66d81c0532a3e6b7",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "kmilly132",
+              "placement": 12,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a17501acd615097d",
+              "tournamentName": "Pokepal Smackdown #137 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "Leon000",
+              "placement": 27,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b332fe11be15a043",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "Zaiko",
+              "placement": 4,
+              "record": "3-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/651d6fed6046623e",
+              "tournamentName": "Mega Tournament"
+            },
+            {
+              "name": "BrunoIPT",
+              "placement": 11,
+              "record": "3-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9aefb78975e09a0d",
+              "tournamentName": "Pado's Dojo Reg M-A Pratice #1 🍥"
+            },
+            {
+              "name": "Wyuku",
+              "placement": 13,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d66d9cf865a6d0a6",
+              "tournamentName": "Road to Area 229 #1"
+            },
+            {
+              "name": "skipoiz",
+              "placement": 19,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/787ca8d10d3f16f3",
+              "tournamentName": "VGCA Battle #25"
+            },
+            {
+              "name": "katabo",
+              "placement": 25,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/51bac31e42f43b8b",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "DrPixel",
+              "placement": 28,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ccebde055af4fc33",
+              "tournamentName": "Chaos League Sunday Slam #96"
+            },
+            {
+              "name": "HepoK",
+              "placement": 37,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/45630c70e0c714a9",
+              "tournamentName": "Coupe Critique Champions VGC #2 - 200€ prize"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "445",
+            "547",
+            "903",
+            "981",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Garchomp",
+            "Whimsicott",
+            "Sneasler",
+            "Farigiraf",
+            "Kingambit"
+          ],
+          "wins": 184,
+          "losses": 91,
+          "teams": [
+            {
+              "name": "BIlllmads",
+              "placement": 2,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1c3f692f429b7efe",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "Fester213",
+              "placement": 3,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/88f02ce2c018c6c5",
+              "tournamentName": "Talon's FIGHT CLUB #79 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Fireboule",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4d9af893845415dd",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "Raydevy",
+              "placement": 6,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b6aaf1d5a4e8948e",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "kuballo10",
+              "placement": 2,
+              "record": "6-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7034d23fa82fad46",
+              "tournamentName": "[REG M-A] LearningtoSam's Weekly PokéLeague"
+            },
+            {
+              "name": "Ludikrik",
+              "placement": 15,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83b74a6cc03591ab",
+              "tournamentName": "Coupe Critique Champions VGC #2 - 200€ prize"
+            },
+            {
+              "name": "chris17c",
+              "placement": 16,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3eb097ff04a29053",
+              "tournamentName": "Pokemon Champions Challenge #2"
+            },
+            {
+              "name": "Fireboule",
+              "placement": 16,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/811add92ecaaba8e",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Fireboule",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1689a66f45c3ac9f",
+              "tournamentName": "Champions Tour LEPE #2"
+            },
+            {
+              "name": "Fireboule",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4f3f66ede605fcba",
+              "tournamentName": "Metro Manila Eastern Conference"
+            },
+            {
+              "name": "KokeVGC",
+              "placement": 10,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5c236619255ff3f9",
+              "tournamentName": "Extreme Speed Pokémon Champions #3"
+            },
+            {
+              "name": "chris17c",
+              "placement": 16,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b0e895577ea8cece",
+              "tournamentName": "Talon's FIGHT CLUB #79 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "ArKloK",
+              "placement": 16,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/70fcd1593bda617d",
+              "tournamentName": "Rookidee VGC Cup"
+            },
+            {
+              "name": "Raydevy",
+              "placement": 19,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/bed09f5d88349b8e",
+              "tournamentName": "Coupe Critique Champions VGC #1 - 100€ de cp"
+            },
+            {
+              "name": "winton",
+              "placement": 46,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5d0c0bee3048e5ae",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "Pierreboss123",
+              "placement": 4,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/be7475b6a9f05c47",
+              "tournamentName": "Pregio Champions Tournament Weekly #20"
+            },
+            {
+              "name": "Acebaltasat25",
+              "placement": 5,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3d865311ebb1d97b",
+              "tournamentName": "VGC Trainer School; champions M/A #4"
+            },
+            {
+              "name": "UtenteVGC",
+              "placement": 6,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7e3110a40b8d13f7",
+              "tournamentName": "Pokémon Champions Reg M-A | CGCL Weekly #1"
+            },
+            {
+              "name": "almondspy",
+              "placement": 6,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/879245be81b641fa",
+              "tournamentName": "Pokepal Smackdown #138 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "Gald",
+              "placement": 6,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Garchomp",
+                "Whimsicott",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c300be41f5ad940c",
+              "tournamentName": "Champions Collective #4"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "036",
+            "149",
+            "655",
+            "902",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Clefable",
+            "Dragonite",
+            "Delphox",
+            "Basculegion-M",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 125,
+          "losses": 53,
+          "teams": [
+            {
+              "name": "gamblingvgc92",
+              "placement": 1,
+              "record": "13-2-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9a56b82ba37cd5fc",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "DisPlotfr",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5656a951188f7493",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "Pendraggon26",
+              "placement": 3,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b22713cddbbdb46f",
+              "tournamentName": "Chaos League Sunday Slam #100 ($100 Prize Pool)"
+            },
+            {
+              "name": "Dan7487",
+              "placement": 7,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4318e6d15671f113",
+              "tournamentName": "Pokemon Champions Challenge #2"
+            },
+            {
+              "name": "Thanosgreninja",
+              "placement": 8,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/71367347c2ece27c",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "eanna_h",
+              "placement": 6,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fb7e4f3b9da36232",
+              "tournamentName": "Tenki's Cart - Pokémon Champions M-A ruleset!"
+            },
+            {
+              "name": "Nehzzy",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/57e5073ae4280502",
+              "tournamentName": "The Drywall Series - CHAMPIONS"
+            },
+            {
+              "name": "6nerox",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/70ed6d61fbf01d68",
+              "tournamentName": "The Dark League champions pop up! 5$usd"
+            },
+            {
+              "name": "Leonardoahl",
+              "placement": 1,
+              "record": "4-0-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c3ddc29c2c96f602",
+              "tournamentName": "🏆Pokémon CHAMPIONS🏆 Mi Dulce Japón Tournament #1"
+            },
+            {
+              "name": "Zaiko",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d1e612e5e5aed254",
+              "tournamentName": "Ratorneo #2 Apertura Champions 2026 | Reg MA | BO3"
+            },
+            {
+              "name": "HardFreaQ",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/06cdd0594a91be76",
+              "tournamentName": "Friendly #1 - Game Corner - Champions"
+            },
+            {
+              "name": "6nerox",
+              "placement": 11,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/48cfaa4a489c14ac",
+              "tournamentName": "Extreme Speed Pokémon Champions"
+            },
+            {
+              "name": "Wax18",
+              "placement": 12,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cb7093afd867a0fb",
+              "tournamentName": "CHAMPIONS COLLECTIVE INAUGURAL TOURNAMENT"
+            },
+            {
+              "name": "Mauttrainer",
+              "placement": 18,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b5c2c6358c9ac6ea",
+              "tournamentName": "Extreme Speed Pokémon Champions"
+            },
+            {
+              "name": "Pendraggon26",
+              "placement": 19,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4c9eda66701c0a5a",
+              "tournamentName": "10ToesDownVGC #31 Champions $100 Top 4(Late Join)"
+            },
+            {
+              "name": "Klaydoe",
+              "placement": 23,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0e5264c752685439",
+              "tournamentName": "Wolfey Patreon Tournament - Pokémon Champions #2"
+            },
+            {
+              "name": "Hobbitandrei",
+              "placement": 24,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/be0bdc8929a86341",
+              "tournamentName": "SNT First Pokémon Champions Tournament"
+            },
+            {
+              "name": "ItzStevioo",
+              "placement": 32,
+              "record": "1-5-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d69e44cfb5ae6e17",
+              "tournamentName": "VGCA Battle #25"
+            },
+            {
+              "name": "jamchi",
+              "placement": 32,
+              "record": "3-2-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/830fc74f979d0c8b",
+              "tournamentName": "Devils Den Tournaments #74"
+            },
+            {
+              "name": "oAsakusa",
+              "placement": 46,
+              "record": "4-4-0",
+              "pokemonNames": [
+                "Clefable",
+                "Dragonite",
+                "Delphox",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5d6eb714595c0e76",
+              "tournamentName": "*Sitrus-Series*|Champions|$100 to 1st"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "1018",
+            "149",
+            "212",
+            "279",
+            "727",
+            "902"
+          ],
+          "pokemonNames": [
+            "Archaludon",
+            "Dragonite-Mega",
+            "Scizor-Mega",
+            "Pelipper",
+            "Incineroar",
+            "Basculegion-M"
+          ],
+          "wins": 199,
+          "losses": 53,
+          "teams": [
+            {
+              "name": "LovelyLuna",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83b7f94f93437d17",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 1,
+              "record": "12-0-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/49216904fa49e246",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Raichu123",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite-Mega",
+                "Scizor-Mega",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/846bd3281d7f460e",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "Jonnycat",
+              "placement": 7,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7008334d30cdea4c",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/28c80f87a380cdc4",
+              "tournamentName": "*Sitrus-Series*|Champions|#59"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/87e74a59eb1e9ef1",
+              "tournamentName": "Talon's FIGHT CLUB #85 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2d4bba21eb8ed36d",
+              "tournamentName": "Talon's FIGHT CLUB #82 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 5,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f03ffd5dafb863a1",
+              "tournamentName": "*Sitrus-Series*|Champions|#57"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 2,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9d517a717e7b50c3",
+              "tournamentName": "Champions Collective #9"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/abcc734e9d64bfa0",
+              "tournamentName": "Pokepal Smackdown #140 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 1,
+              "record": "7-0-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8945bd01ce248806",
+              "tournamentName": "VGC Gemeinde Showdown #7"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 2,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/551091c6fa627ffa",
+              "tournamentName": "Northern Ontario VGC Tour - April 29th"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2c6e43d898f53d8c",
+              "tournamentName": "The Wide League Saturday Night Rumble #85"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 9,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/280a51fb4f3b3c3a",
+              "tournamentName": "Talon's FIGHT CLUB #83 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "ggttmmhh",
+              "placement": 93,
+              "record": "11-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/08f17c36c1b38346",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Giottas",
+              "placement": 117,
+              "record": "11-4-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2f53abdd4385a601",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 3,
+              "record": "6-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/997826e2fe053a51",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 3,
+              "record": "6-1-1",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3c8225fa084b0015",
+              "tournamentName": "King's Gambit #3 | Reg M-A"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 4,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/34eacdb3232c1472",
+              "tournamentName": "WARTORTLE WEDNESDAYS #58 REG M-A BO3 SWISS"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 5,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Incineroar",
+                "Basculegion-M"
+              ],
+              "pokepasteUrl": "https://pokepast.es/607433736862b5a2",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "445",
+            "479-w",
+            "670",
+            "681",
+            "727"
+          ],
+          "pokemonNames": [
+            "Aerodactyl",
+            "Garchomp",
+            "Rotom-Wash",
+            "Floette",
+            "Aegislash-Blade",
+            "Incineroar"
+          ],
+          "wins": 108,
+          "losses": 42,
+          "teams": [
+            {
+              "name": "Samuel T",
+              "placement": 3,
+              "record": "16-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Floette",
+                "Aegislash-Blade",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/059a882f82e37ede",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Samuel T",
+              "placement": 3,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Floette-Mega",
+                "Aegislash-Blade",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ad99a629760ffd71",
+              "tournamentName": "Pokemon Champions Challenge #2"
+            },
+            {
+              "name": "Purple_Meowstic",
+              "placement": 3,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Floette",
+                "Aegislash-Blade",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3953f2c5edaaa12a",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Samuel T",
+              "placement": 2,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Floette",
+                "Aegislash-Blade",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5744540cf0ce7add",
+              "tournamentName": "10ToesDownVGC #31 Champions $100 Top 4(Late Join)"
+            },
+            {
+              "name": "PollitoA7",
+              "placement": 4,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Floette-Mega",
+                "Aegislash-Blade",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0825bd697e2c0aa7",
+              "tournamentName": "The Drywall Series - Champions!"
+            },
+            {
+              "name": "Samuel T",
+              "placement": 1,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Floette",
+                "Aegislash-Blade",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/535bf302ed42f79f",
+              "tournamentName": "VGC Trainer School; champions M/A #5"
+            },
+            {
+              "name": "PollitoA7",
+              "placement": 5,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Floette",
+                "Aegislash-Blade",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c0d8ca8e304ada25",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "FullCrimp",
+              "placement": 7,
+              "record": "6-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Floette",
+                "Aegislash-Blade",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6e9c733d8d54b7c5",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Bisca",
+              "placement": 14,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Floette-Mega",
+                "Aegislash-Blade",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/90fdd88377956c6a",
+              "tournamentName": "Pokémon Champions SV #1"
+            },
+            {
+              "name": "SlimVali",
+              "placement": 7,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Floette",
+                "Aegislash-Blade",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/df5bb055ac4e1f34",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #68👑"
+            },
+            {
+              "name": "Oscarbolt",
+              "placement": 3,
+              "record": "3-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Floette",
+                "Aegislash-Blade",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b7669140c92f15e3",
+              "tournamentName": "Pokemon Dominicana - Champions League #4"
+            },
+            {
+              "name": "Pedro Soares",
+              "placement": 6,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Floette",
+                "Aegislash-Blade",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b00d1d54fb1ebd53",
+              "tournamentName": "Intimidators Champions Challenge #11- REG M-A"
+            },
+            {
+              "name": "squib",
+              "placement": 22,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Floette",
+                "Aegislash-Blade",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/944dc031de44dbb0",
+              "tournamentName": "Head Bussa's Hoedown#29 ChampionsReg M-A $25 1st"
+            },
+            {
+              "name": "Modedo",
+              "placement": 28,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Floette",
+                "Aegislash-Blade",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9a47102f876285b6",
+              "tournamentName": "Rookidee VGC Cup"
+            },
+            {
+              "name": "carlos_012",
+              "placement": 31,
+              "record": "3-4-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Floette",
+                "Aegislash-Blade",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/45ec59c795c6de16",
+              "tournamentName": "CHAMPIONS COLLECTIVE INAUGURAL TOURNAMENT"
+            },
+            {
+              "name": "carlos_012",
+              "placement": 58,
+              "record": "3-5-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Floette",
+                "Aegislash-Blade",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/930aaca879b505dc",
+              "tournamentName": "Pokemon Champions Challenge #2"
+            },
+            {
+              "name": "KhaiWings",
+              "placement": 184,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Garchomp",
+                "Rotom-Wash",
+                "Floette",
+                "Aegislash-Blade",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9b426311976793b6",
+              "tournamentName": "The Grand Champions Festival"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "059-h",
+            "1013",
+            "478",
+            "903",
+            "964",
+            "983"
+          ],
+          "pokemonNames": [
+            "Arcanine-Hisui",
+            "Sinistcha",
+            "Froslass-Mega",
+            "Sneasler",
+            "Palafin",
+            "Kingambit"
+          ],
+          "wins": 142,
+          "losses": 59,
+          "teams": [
+            {
+              "name": "Rheiyne",
+              "placement": 5,
+              "record": "11-2-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass-Mega",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a081ebf9d2809ad8",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "WeAreToast",
+              "placement": 2,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass-Mega",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/195d18d92c849341",
+              "tournamentName": "Wolfey Patreon Tournament - Pokémon Champions #2"
+            },
+            {
+              "name": "Asteriio",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass-Mega",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/02058ab7960ec5e2",
+              "tournamentName": "Unova Champions League / POKÉMON CHAMPIONS / 30€"
+            },
+            {
+              "name": "agniso",
+              "placement": 5,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass-Mega",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/865fb0bc6c51c271",
+              "tournamentName": "Pokemon Champions Challenge #2"
+            },
+            {
+              "name": "Dryster",
+              "placement": 7,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f3ab1508510dd57d",
+              "tournamentName": "Coupe Critique Champions VGC #1 - 100€ de cp"
+            },
+            {
+              "name": "Konoz",
+              "placement": 24,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1724c1105d58c4d6",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "WeAreToast",
+              "placement": 55,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/06d156abbd062d78",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Felipe Soria",
+              "placement": 6,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/59541408399aeb65",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Dray",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/bc010bf56ca77eea",
+              "tournamentName": "Flashback's Midwest Monthly - $100 PRIZE POT"
+            },
+            {
+              "name": "Dray",
+              "placement": 1,
+              "record": "7-0-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/469a79951f91edd1",
+              "tournamentName": "Northern Ontario VGC Tour"
+            },
+            {
+              "name": "Voltri",
+              "placement": 15,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c08ac6c2f742703b",
+              "tournamentName": "Wolfey Patreon Tournament - Pokémon Champions #2"
+            },
+            {
+              "name": "Reaza",
+              "placement": 21,
+              "record": "5-4-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fe3b5f098bdf818d",
+              "tournamentName": "ZGG #3 Pokemon Champions VGC $100 Tournament!"
+            },
+            {
+              "name": "Felipe Soria",
+              "placement": 4,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/bc991122176e7db0",
+              "tournamentName": "Champions Tour LEPE #2"
+            },
+            {
+              "name": "ChosenPig32",
+              "placement": 10,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass-Mega",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/36f9e8d5562c83ce",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "Loonefox",
+              "placement": 11,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8677c34df16c8272",
+              "tournamentName": "Chaos League Sunday Slam #98"
+            },
+            {
+              "name": "hummus",
+              "placement": 19,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1db28fb1d338be98",
+              "tournamentName": "Extreme Speed Pokémon Champions"
+            },
+            {
+              "name": "FiganSG",
+              "placement": 22,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/26c1e333150f62a0",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Vesfale",
+              "placement": 23,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4d208f3276197ac4",
+              "tournamentName": "CHAMPIONS COLLECTIVE INAUGURAL TOURNAMENT"
+            },
+            {
+              "name": "Miguelowned",
+              "placement": 33,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/93171067ed864ece",
+              "tournamentName": "TORNEO SALIDA POKÉMON CHAMPIONS"
+            },
+            {
+              "name": "Loonefox",
+              "placement": 38,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Arcanine-Hisui",
+                "Sinistcha",
+                "Froslass",
+                "Sneasler",
+                "Palafin",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/621e02219459cad2",
+              "tournamentName": "LIGA DA COMUNIDADE #3 (R$ 1.000 PRIZE POOL)"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "248",
+            "479-w",
+            "530",
+            "635",
+            "778",
+            "823"
+          ],
+          "pokemonNames": [
+            "Tyranitar-Mega",
+            "Rotom-Wash",
+            "Excadrill",
+            "Hydreigon",
+            "Mimikyu",
+            "Corviknight"
+          ],
+          "wins": 184,
+          "losses": 76,
+          "teams": [
+            {
+              "name": "JoeUX9",
+              "placement": 32,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Tyranitar",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/51ba849402523ee3",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "heckheckingheck",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Tyranitar",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e936caa5c3404352",
+              "tournamentName": "Rookidee VGC Cup"
+            },
+            {
+              "name": "Mastaroth",
+              "placement": 4,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Tyranitar",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/08ffdc4351040c87",
+              "tournamentName": "Pokepal Smackdown #137 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "PokeReplay",
+              "placement": 38,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Tyranitar",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/35a994d4d68b6fcf",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "KingRexal",
+              "placement": 1,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Tyranitar",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/34cbad32e4f3892d",
+              "tournamentName": "The Drywalls Series #2 - Champions!"
+            },
+            {
+              "name": "Guffumbo",
+              "placement": 1,
+              "record": "8-0-0",
+              "pokemonNames": [
+                "Tyranitar",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5510e1a97deb791d",
+              "tournamentName": "Road to Area 229 #2"
+            },
+            {
+              "name": "TypNull07",
+              "placement": 1,
+              "record": "7-0-0",
+              "pokemonNames": [
+                "Tyranitar",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f0774634de9df252",
+              "tournamentName": "[REG M-A] LearningtoSam's Weekly"
+            },
+            {
+              "name": "TypNull07",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Tyranitar",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b39a82e2e2effa53",
+              "tournamentName": "Champions Tour LEPE #4"
+            },
+            {
+              "name": "divaddoodles",
+              "placement": 1,
+              "record": "4-0-0",
+              "pokemonNames": [
+                "Tyranitar",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7d3fe44b619598d4",
+              "tournamentName": "BPL LAST DAY CHAMPIONS TOSS DOWN"
+            },
+            {
+              "name": "PokeReplay",
+              "placement": 2,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Tyranitar",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b9479e259cb9ecb5",
+              "tournamentName": "Champions Collective #7.5"
+            },
+            {
+              "name": "4lphabet",
+              "placement": 4,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Tyranitar",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2dd3d17c864b020f",
+              "tournamentName": "[REG M-A] LearningtoSam's Weekly PokéLeague"
+            },
+            {
+              "name": "LqdSnake",
+              "placement": 15,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Tyranitar",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a1259d373ef53455",
+              "tournamentName": "Talon's FIGHT CLUB #83 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "seyn30",
+              "placement": 17,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Tyranitar",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cdc5522a9b915458",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Ksomon",
+              "placement": 31,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Tyranitar",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/420250c81d7982ca",
+              "tournamentName": "Coupe Critique Champions VGC #2 - 200€ prize"
+            },
+            {
+              "name": "Martinus_03",
+              "placement": 32,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Tyranitar",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/735238d9b7aa5638",
+              "tournamentName": "Coupe Critique Champions VGC #2 - 200€ prize"
+            },
+            {
+              "name": "Dialing",
+              "placement": 70,
+              "record": "11-4-0",
+              "pokemonNames": [
+                "Tyranitar",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/368588d5795e061a",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "ramicasal",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Tyranitar",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5d249eb9526422da",
+              "tournamentName": "Rookidee VGC Cup 2"
+            },
+            {
+              "name": "Jhinting",
+              "placement": 4,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Tyranitar-Mega",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/12f3ee1c583f4aab",
+              "tournamentName": "Chaos League Sunday Slam #97"
+            },
+            {
+              "name": "Martinus_03",
+              "placement": 5,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Tyranitar",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c7fe61010ef45784",
+              "tournamentName": "Champions Collective #8"
+            },
+            {
+              "name": "LqdSnake",
+              "placement": 4,
+              "record": "2-2-0",
+              "pokemonNames": [
+                "Tyranitar",
+                "Rotom-Wash",
+                "Excadrill",
+                "Hydreigon",
+                "Mimikyu",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/25bd911a405ded72",
+              "tournamentName": "Moxie Monday Sub Tour #4"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "445",
+            "478",
+            "479-w",
+            "663",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Garchomp",
+            "Froslass",
+            "Rotom-Wash",
+            "Talonflame",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 122,
+          "losses": 28,
+          "teams": [
+            {
+              "name": "Hq2009",
+              "placement": 11,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/72c4df0b4951df04",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "BatCoach",
+              "placement": 2,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6d19bcb7e5253072",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "BatCoach",
+              "placement": 2,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f8bc213bbe3a4763",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "almondspy",
+              "placement": 2,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e6a9312e6b3497aa",
+              "tournamentName": "Talon's FIGHT CLUB #82 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Hq2009",
+              "placement": 6,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/65b146a04b0df2b8",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "BatCoach",
+              "placement": 1,
+              "record": "10-0-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/eb1545b33c2c98bc",
+              "tournamentName": "Unova Champions League #5 / POKÉMON CHAMPIONS"
+            },
+            {
+              "name": "Gustav H",
+              "placement": 1,
+              "record": "8-0-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/641c548126d6340d",
+              "tournamentName": "Champions Tour LEPE #5"
+            },
+            {
+              "name": "BatCoach",
+              "placement": 2,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c694c7124a0dd8a2",
+              "tournamentName": "Chaos League Sunday Slam #98"
+            },
+            {
+              "name": "BatCoach",
+              "placement": 10,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4c9b3845f0833d02",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Vanilla0731",
+              "placement": 1,
+              "record": "8-0-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c008f8cecd1d84f3",
+              "tournamentName": "Pokevents Champions Challenge"
+            },
+            {
+              "name": "DALu",
+              "placement": 13,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4099061234a11e31",
+              "tournamentName": "Talon's FIGHT CLUB #80 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "almondspy",
+              "placement": 16,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/01b6a4b6257e832a",
+              "tournamentName": "Talon's FIGHT CLUB #83 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Lux0x0",
+              "placement": 44,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f522a15dade37e6e",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "Notskillz",
+              "placement": 5,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9db6e9743183dd0f",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Jonnycat",
+              "placement": 10,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1b238785b0421472",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #2 2026"
+            },
+            {
+              "name": "BatCoach",
+              "placement": 12,
+              "record": "2-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Froslass",
+                "Rotom-Wash",
+                "Talonflame",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/38f28724ecfabd7f",
+              "tournamentName": "[REG M-A] LearningtoSam's Weekly PokéLeague"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "282",
+            "445",
+            "663",
+            "902",
+            "925",
+            "983"
+          ],
+          "pokemonNames": [
+            "Gardevoir",
+            "Garchomp",
+            "Talonflame",
+            "Basculegion-M",
+            "Maushold",
+            "Kingambit"
+          ],
+          "wins": 185,
+          "losses": 80,
+          "teams": [
+            {
+              "name": "zL",
+              "placement": 1,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/48e588b7b095e8d4",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "Dimsun",
+              "placement": 19,
+              "record": "13-3-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8d107eea8a47a690",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "itsDani",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7e2f1d4212d67733",
+              "tournamentName": "Devils Den Tournaments #74"
+            },
+            {
+              "name": "Zimmer003",
+              "placement": 6,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/246fa26a8318a041",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Javivarela",
+              "placement": 5,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6468c2c1adf99429",
+              "tournamentName": "Wolfey Patreon Tournament - Pokémon Champions #2"
+            },
+            {
+              "name": "huanyu1229",
+              "placement": 5,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c164b665d5d1d811",
+              "tournamentName": "Sheep Cup#14[Reg M-A]"
+            },
+            {
+              "name": "DokkaToast",
+              "placement": 12,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7a4da904b881e836",
+              "tournamentName": "ZGG #3 Pokemon Champions VGC $100 Tournament!"
+            },
+            {
+              "name": "Kotori",
+              "placement": 2,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/575a917a863b4d11",
+              "tournamentName": "VGC Gemeinde Showdown #7"
+            },
+            {
+              "name": "Bahamut",
+              "placement": 12,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/77df6ac0f3b04550",
+              "tournamentName": "Talon's FIGHT CLUB #81 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "palkia",
+              "placement": 13,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/490cb78a2ef0a64d",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "Javivarela",
+              "placement": 15,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ca3f07ddd52470aa",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Bahamut",
+              "placement": 90,
+              "record": "11-4-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/089d87688205dfef",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "pokeDiamond",
+              "placement": 91,
+              "record": "11-4-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/958945c297b64f7f",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Javivarela",
+              "placement": 3,
+              "record": "3-0-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d1fbe4cf217d9977",
+              "tournamentName": "Base Camp #1 - Tournament for beginners!"
+            },
+            {
+              "name": "Kerzz",
+              "placement": 4,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/086609131e1c860d",
+              "tournamentName": "Champions Collective #5"
+            },
+            {
+              "name": "Soosendosen",
+              "placement": 7,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5608198b3af028e1",
+              "tournamentName": "Boldore's Gate #8 - $5 USD - Champions Weekly 4/27"
+            },
+            {
+              "name": "Luisete",
+              "placement": 7,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/241743c32177d160",
+              "tournamentName": "Road to Area 229 #2"
+            },
+            {
+              "name": "KronyaNep",
+              "placement": 4,
+              "record": "2-2-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fa6bd2e441bbb29e",
+              "tournamentName": "DucPokémonChampions#2"
+            },
+            {
+              "name": "fakedejan",
+              "placement": 5,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/238f0fec5858fcfa",
+              "tournamentName": "TIM3L3SS TOURS"
+            },
+            {
+              "name": "Javivarela",
+              "placement": 8,
+              "record": "3-1-0",
+              "pokemonNames": [
+                "Gardevoir",
+                "Garchomp",
+                "Talonflame",
+                "Basculegion-M",
+                "Maushold",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c5023f8bb1dabcd6",
+              "tournamentName": "Mega Tournament"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "784",
+            "902",
+            "903",
+            "952",
+            "983"
+          ],
+          "pokemonNames": [
+            "Aerodactyl",
+            "Kommo-o",
+            "Basculegion-M",
+            "Sneasler",
+            "Scovillain",
+            "Kingambit"
+          ],
+          "wins": 142,
+          "losses": 60,
+          "teams": [
+            {
+              "name": "Testing800",
+              "placement": 5,
+              "record": "16-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e2c09d328c27f6c8",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Inge",
+              "placement": 2,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/33bc81394c5f587b",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "lukasjoel1",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9e44571b160cd6d1",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            },
+            {
+              "name": "magnus309",
+              "placement": 5,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fd4a449551612392",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "mamaimchasinaghostt",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/67a1b8baa3f88ed6",
+              "tournamentName": "Metro Manila Eastern Conference"
+            },
+            {
+              "name": "Jonnycat",
+              "placement": 5,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a345418c60d99f35",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "Zeitsnom",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c16b080e8bfc49fd",
+              "tournamentName": "🟊 @AustinMcfraud's CHAMPIONS Showdown #2 🟊"
+            },
+            {
+              "name": "Pichu",
+              "placement": 3,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6b468057f03e484a",
+              "tournamentName": "Extreme Speed Pokémon Champions #4"
+            },
+            {
+              "name": "Inge",
+              "placement": 3,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2c2788f9dc0f272f",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #2 2026"
+            },
+            {
+              "name": "Fastman24",
+              "placement": 4,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7aa9f67a84a2fc90",
+              "tournamentName": "Champions 🇨🇷 tour #1"
+            },
+            {
+              "name": "Bonzo713",
+              "placement": 9,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e3b64bf1a06f3d03",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Luca_ORLANDO",
+              "placement": 11,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7e4a40fc6dd5dc06",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Hanlau",
+              "placement": 19,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c1b9423e608d6fdc",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "giac28",
+              "placement": 2,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a973091f57fe4c42",
+              "tournamentName": "King's Gambit #2 | Reg M-A"
+            },
+            {
+              "name": "Inge",
+              "placement": 8,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c8fac0bf23b32b1",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #68👑"
+            },
+            {
+              "name": "primsh",
+              "placement": 6,
+              "record": "3-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/890e32fa87590b2c",
+              "tournamentName": "제2회 너클시티 챌린저스 [Hammerlocke Challengers]"
+            },
+            {
+              "name": "Inge",
+              "placement": 6,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a1f49874e8eedc58",
+              "tournamentName": "Extreme Speed Pokémon Champions #5"
+            },
+            {
+              "name": "Fastman24",
+              "placement": 7,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6a51cd9f6b1939e5",
+              "tournamentName": "Champions Tour LEPE #2"
+            },
+            {
+              "name": "noodle_sandwich",
+              "placement": 8,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b98ec519e98b17a9",
+              "tournamentName": "Road to Area 229 #3"
+            },
+            {
+              "name": "Bond",
+              "placement": 12,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Kommo-o",
+                "Basculegion-M",
+                "Sneasler",
+                "Scovillain",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b982ac436ae6b255",
+              "tournamentName": "Boldore's Gate #8 - $5 USD - Champions Weekly 4/27"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "142",
+            "445",
+            "700",
+            "902",
+            "981"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Aerodactyl",
+            "Garchomp",
+            "Sylveon",
+            "Basculegion-M",
+            "Farigiraf"
+          ],
+          "wins": 107,
+          "losses": 39,
+          "teams": [
+            {
+              "name": "Kojay",
+              "placement": 4,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/026ccbe833514d3c",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Kojay",
+              "placement": 1,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f72602b39bd3b599",
+              "tournamentName": "10ToesDownVGC #31 Champions $100 Top 4(Late Join)"
+            },
+            {
+              "name": "Kojay",
+              "placement": 2,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0575b8df0394ea8c",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Kojay",
+              "placement": 3,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7caaeccf61114454",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "TheGamerVGC",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fe863526ff682822",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "LelloCartello",
+              "placement": 6,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ed1f2f72da377624",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "charpie",
+              "placement": 7,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b7154f61bc853a30",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #69👑"
+            },
+            {
+              "name": "carlos_012",
+              "placement": 2,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/370d476f14890b8f",
+              "tournamentName": "Champions Collective #8"
+            },
+            {
+              "name": "Oscar P",
+              "placement": 1,
+              "record": "5-0-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3a18c928051fda87",
+              "tournamentName": "Pokemon Dominicana - Champions League #5"
+            },
+            {
+              "name": "LelloCartello",
+              "placement": 10,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1a414bdd86bcacf6",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            },
+            {
+              "name": "Kaazuma",
+              "placement": 2,
+              "record": "3-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/09da3a69842053ac",
+              "tournamentName": "Dark Storm Team testing #8"
+            },
+            {
+              "name": "charpie",
+              "placement": 6,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/196ea024ae1d6bb0",
+              "tournamentName": "The Drywalls Series #5 - Champions!"
+            },
+            {
+              "name": "carlos_012",
+              "placement": 7,
+              "record": "3-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2486fba325870de2",
+              "tournamentName": "[REG M-A] LearningtoSam's Weekly PokéLeague"
+            },
+            {
+              "name": "charpie",
+              "placement": 7,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/bc07144c365724b4",
+              "tournamentName": "Pokepal Smackdown #141 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "Andynito",
+              "placement": 7,
+              "record": "2-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/163c6ffeecd55cd8",
+              "tournamentName": "VGC Factory 1st Edition"
+            },
+            {
+              "name": "Oscar P",
+              "placement": 17,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/36e240fc3584765b",
+              "tournamentName": "10ToesDownVGC #31 Champions $100 Top 4(Late Join)"
+            },
+            {
+              "name": "ZeinYoussef",
+              "placement": 31,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5f06a843fc952e65",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "Abe",
+              "placement": 37,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3decdeedd0103caf",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Jorge_prods",
+              "placement": 43,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Sylveon",
+                "Basculegion-M",
+                "Farigiraf"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e737f76602a9d668",
+              "tournamentName": "Coupe Critique Champions VGC #2 - 200€ prize"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "1018",
+            "149",
+            "212",
+            "279",
+            "902",
+            "903"
+          ],
+          "pokemonNames": [
+            "Archaludon",
+            "Dragonite",
+            "Scizor",
+            "Pelipper",
+            "Basculegion-M",
+            "Sneasler"
+          ],
+          "wins": 168,
+          "losses": 79,
+          "teams": [
+            {
+              "name": "Racka2023",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9e80cb9704c61ac9",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Kumanomi",
+              "placement": 1,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6922a9ea01e44bac",
+              "tournamentName": "Devils Den Tournaments #74"
+            },
+            {
+              "name": "patcon5",
+              "placement": 41,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2b074b2e16e3bbd8",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Raichu123",
+              "placement": 5,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2535cbc1fd236c6c",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            },
+            {
+              "name": "Raichu123",
+              "placement": 2,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/859828511a9199f9",
+              "tournamentName": "Unova Champions League #5 / POKÉMON CHAMPIONS"
+            },
+            {
+              "name": "Raichu123",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fe418678d981393a",
+              "tournamentName": "Boldore's Gate #8 - $5 USD - Champions Weekly 4/27"
+            },
+            {
+              "name": "Puxcci",
+              "placement": 3,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/484669a0f11f0cd9",
+              "tournamentName": "Intimidators Champions Challenge #8 - REG M-A"
+            },
+            {
+              "name": "twlamere",
+              "placement": 12,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1155a9572f42362a",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "RivalAngel",
+              "placement": 12,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/776a22b0d3755a60",
+              "tournamentName": "Chaos League Sunday Slam #100 ($100 Prize Pool)"
+            },
+            {
+              "name": "Kumanomi",
+              "placement": 14,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b152606fe4e6997e",
+              "tournamentName": "The Drywall Series - Champions!"
+            },
+            {
+              "name": "hummus",
+              "placement": 15,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4a0134cfaf5fd8a0",
+              "tournamentName": "Extreme Speed Pokémon Champions #3"
+            },
+            {
+              "name": "Buizom",
+              "placement": 19,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0c84c91cf2bd3f29",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "franidn",
+              "placement": 28,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/773e7b3c8980a63a",
+              "tournamentName": "Coupe Critique Champions VGC #2 - 200€ prize"
+            },
+            {
+              "name": "graysen",
+              "placement": 77,
+              "record": "11-4-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1356ed950a81aee8",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "BlankoLOGEL",
+              "placement": 115,
+              "record": "11-4-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/671f6880abfcb57d",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 3,
+              "record": "6-1-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1b4ca80aaf4dc16b",
+              "tournamentName": "Champions Tour LEPE #3"
+            },
+            {
+              "name": "Puxcci",
+              "placement": 7,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c5bf2fc798b636bc",
+              "tournamentName": "Intimidators Champions Challenge #6 - REG M-A"
+            },
+            {
+              "name": "JeanChasuble",
+              "placement": 10,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d8000af2b8a35c21",
+              "tournamentName": "Champions Collective #8"
+            },
+            {
+              "name": "StrongIndependentBlackCat",
+              "placement": 13,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f36eb0f943f3cc0d",
+              "tournamentName": "Talon's FIGHT CLUB #85 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "PaolosiopaoVGC",
+              "placement": 15,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Archaludon",
+                "Dragonite",
+                "Scizor",
+                "Pelipper",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c124edd86b145090",
+              "tournamentName": "PCP Premier Series: A Champion's Welcome!"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "154",
+            "902",
+            "903",
+            "981",
+            "983"
+          ],
+          "pokemonNames": [
+            "Aerodactyl",
+            "Meganium-Mega",
+            "Basculegion-M",
+            "Sneasler",
+            "Farigiraf",
+            "Kingambit"
+          ],
+          "wins": 135,
+          "losses": 56,
+          "teams": [
+            {
+              "name": "Wb_vg",
+              "placement": 1,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/79f18572188fc823",
+              "tournamentName": "Weekly | Liberation Crusade #1 | $100 |Volticons"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 2,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b74f2a78b533ab2b",
+              "tournamentName": "The Drywall Series - Champions!"
+            },
+            {
+              "name": "JOAO",
+              "placement": 3,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c6eab74bc48b6f8d",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "Z2R caiovibora",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/054ead062b8a2dff",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "Kana Arima",
+              "placement": 5,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a98e852999d94292",
+              "tournamentName": "Pokémon Champions SV #1"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 8,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d34badbafba9ea22",
+              "tournamentName": "VGCA Battle Hall #26"
+            },
+            {
+              "name": "chromeo ",
+              "placement": 8,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7d895bd5b30d3c67",
+              "tournamentName": "Extreme Speed Pokémon Champions #3"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 10,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f3075c9516e6e090",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Altkyle",
+              "placement": 10,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium-Mega",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d8d2af66a6828060",
+              "tournamentName": "Talon's FIGHT CLUB #81 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Hagakury",
+              "placement": 28,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4e18530a0cb9068f",
+              "tournamentName": "LIGA DA COMUNIDADE #3 (R$ 1.000 PRIZE POOL)"
+            },
+            {
+              "name": "SlowSunflower",
+              "placement": 109,
+              "record": "11-4-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/223c8dceb8de9910",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "zL",
+              "placement": 5,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/972f6924ef9ae7f8",
+              "tournamentName": "Friday Fight Night #52 Reg M-A Bo3"
+            },
+            {
+              "name": "Xcyl L",
+              "placement": 5,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d830263e7dfdb0e4",
+              "tournamentName": "WARTORTLE WEDNESDAYS #58 REG M-A BO3 SWISS"
+            },
+            {
+              "name": "Goodsy",
+              "placement": 6,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7f33876f2365148c",
+              "tournamentName": "Devils Den Tournaments #75"
+            },
+            {
+              "name": "Goodsy",
+              "placement": 6,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/505780c285ebf2d4",
+              "tournamentName": "Rookidee VGC Cup 2"
+            },
+            {
+              "name": "Victor Matheus",
+              "placement": 7,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1e2962f48ef20608",
+              "tournamentName": "Intimidators Champions Challenge #9- REG M-A"
+            },
+            {
+              "name": "marksparrow170",
+              "placement": 9,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/04a4de0d6b47a3f5",
+              "tournamentName": "PCP Premier Series: A Champion's Welcome!"
+            },
+            {
+              "name": "Vossi",
+              "placement": 9,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f708fb83b0fdd52f",
+              "tournamentName": "Boldore's Gate #8 - $5 USD - Champions Weekly 4/27"
+            },
+            {
+              "name": "Goodsy",
+              "placement": 14,
+              "record": "3-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/932bc45818e2bd76",
+              "tournamentName": "The Drywalls Series #3 - Champions!"
+            },
+            {
+              "name": "itsGlitzky",
+              "placement": 15,
+              "record": "3-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Basculegion-M",
+                "Sneasler",
+                "Farigiraf",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/96a5c376c003a01c",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "003",
+            "1018",
+            "279",
+            "302",
+            "902",
+            "983"
+          ],
+          "pokemonNames": [
+            "Venusaur",
+            "Archaludon",
+            "Pelipper",
+            "Sableye",
+            "Basculegion-M",
+            "Kingambit"
+          ],
+          "wins": 124,
+          "losses": 56,
+          "teams": [
+            {
+              "name": "Liakos",
+              "placement": 7,
+              "record": "15-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0b2a454f6d5eec5a",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "jthenks",
+              "placement": 4,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/30963f2d9d30c871",
+              "tournamentName": "10ToesDownVGC #31 Champions $100 Top 4(Late Join)"
+            },
+            {
+              "name": "oAsakusa",
+              "placement": 2,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b3f8369dbc0ca2e9",
+              "tournamentName": "VGC Trainer School; champions M/A #5"
+            },
+            {
+              "name": "Xcyl L",
+              "placement": 9,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/006b5de6c280709b",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "Mattivik",
+              "placement": 9,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/140fea16240ca566",
+              "tournamentName": "Coupe Critique Champions VGC #2 - 200€ prize"
+            },
+            {
+              "name": "Hawaii",
+              "placement": 16,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/314e1e5172af5565",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "BahamuthVGC",
+              "placement": 1,
+              "record": "9-0-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/224b27a0b0649c43",
+              "tournamentName": "Frontier Tournament #1"
+            },
+            {
+              "name": "PYH",
+              "placement": 1,
+              "record": "3-1-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/325ce71e09733603",
+              "tournamentName": "[#1] PTC2026 Challengers"
+            },
+            {
+              "name": "Hawaii",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a4d467b880c323f0",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "DarkAmori",
+              "placement": 9,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/89880874e064a08f",
+              "tournamentName": "Talon's FIGHT CLUB #82 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Everett98",
+              "placement": 12,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e4604ee5e72d51de",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Iaoth",
+              "placement": 17,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f4a78eb40ba284cc",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "TheGamerVGC",
+              "placement": 24,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b3cf40b8e26f93b5",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "ARTYCODE1",
+              "placement": 2,
+              "record": "2-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1e950df57daa5cc0",
+              "tournamentName": "DucPokémonChampions#3"
+            },
+            {
+              "name": "ARTYCODE1",
+              "placement": 3,
+              "record": "2-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/120b1833d440622a",
+              "tournamentName": "DucPokémonChampions#2"
+            },
+            {
+              "name": "SuperDialga",
+              "placement": 7,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c931d799ad4e7348",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "heyoalex",
+              "placement": 9,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ea734f06865e6410",
+              "tournamentName": "Friday Fight Night #53 Reg M-A Bo3"
+            },
+            {
+              "name": "Xcyl L",
+              "placement": 10,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9079fd1d36bd29e1",
+              "tournamentName": "Sketch Academy Champions Regulation M-A Tournament"
+            },
+            {
+              "name": "kumazoku",
+              "placement": 15,
+              "record": "3-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d5e5caef480cf7ca",
+              "tournamentName": "Road to Area 229 #2"
+            },
+            {
+              "name": "boonanar",
+              "placement": 20,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Archaludon",
+                "Pelipper",
+                "Sableye",
+                "Basculegion-M",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a4f8f508cdf5a709",
+              "tournamentName": "Alpensee Tour (Reg M-A) #58"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "149",
+            "350",
+            "478",
+            "902",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Dragonite",
+            "Milotic",
+            "Froslass",
+            "Basculegion-M",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 84,
+          "losses": 35,
+          "teams": [
+            {
+              "name": "MegaUmbreonVGC",
+              "placement": 2,
+              "record": "17-3-0",
+              "pokemonNames": [
+                "Dragonite",
+                "Milotic",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fb02b02fc264939b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Connor Sparks",
+              "placement": 1,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Dragonite",
+                "Milotic",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/08b38f8b54ff0372",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            },
+            {
+              "name": "Fosco",
+              "placement": 37,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Dragonite",
+                "Milotic",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/40fd668c3132099f",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Miki_The_Haxed",
+              "placement": 2,
+              "record": "3-0-0",
+              "pokemonNames": [
+                "Dragonite",
+                "Milotic",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c8d3183ece701358",
+              "tournamentName": "Base Camp #1 - Tournament for beginners!"
+            },
+            {
+              "name": "BigNation",
+              "placement": 4,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Dragonite",
+                "Milotic",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6cc3266b66c424c0",
+              "tournamentName": "Road to Area 229 #2"
+            },
+            {
+              "name": "TacCat",
+              "placement": 10,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Dragonite",
+                "Milotic",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8184132205a24211",
+              "tournamentName": "Head Bussa's Hoedown#29 ChampionsReg M-A $25 1st"
+            },
+            {
+              "name": "Cl2m",
+              "placement": 8,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Dragonite",
+                "Milotic",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/91300726b7716bfc",
+              "tournamentName": "Champions Collective #8"
+            },
+            {
+              "name": "Gouillou",
+              "placement": 8,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Dragonite",
+                "Milotic",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/45048932428e0810",
+              "tournamentName": "Champions Collective #9"
+            },
+            {
+              "name": "otuyuopuru",
+              "placement": 6,
+              "record": "4-1-0",
+              "pokemonNames": [
+                "Dragonite",
+                "Milotic",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9097e7d84b561e54",
+              "tournamentName": "Torneo #4 Ranking PokéChampionsDestiny"
+            },
+            {
+              "name": "Cl2m",
+              "placement": 8,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Dragonite",
+                "Milotic",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6559fddb3d252d12",
+              "tournamentName": "Champions Collective #7"
+            },
+            {
+              "name": "otuyuopuru",
+              "placement": 15,
+              "record": "3-2-0",
+              "pokemonNames": [
+                "Dragonite",
+                "Milotic",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/efb6c07288316cb4",
+              "tournamentName": "The Drywalls Series #3 - Champions!"
+            },
+            {
+              "name": "Miki_The_Haxed",
+              "placement": 16,
+              "record": "2-2-0",
+              "pokemonNames": [
+                "Dragonite",
+                "Milotic",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/790acc76262ff756",
+              "tournamentName": "ChampionMads Singles Battle Arena #1 - $50 USD"
+            },
+            {
+              "name": "StoneStormVGC",
+              "placement": 21,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Dragonite",
+                "Milotic",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/09e66771f795d388",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "StoneStormVGC",
+              "placement": 28,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Dragonite",
+                "Milotic",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5ddb5cf281e7abec",
+              "tournamentName": "10ToesDownVGC #31 Champions $100 Top 4(Late Join)"
+            },
+            {
+              "name": "Om3gaVGC",
+              "placement": 58,
+              "record": "2-2-0",
+              "pokemonNames": [
+                "Dragonite",
+                "Milotic",
+                "Froslass",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/88bb805e18840494",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "142",
+            "154",
+            "186",
+            "902",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Aerodactyl",
+            "Meganium",
+            "Politoed",
+            "Basculegion-M",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 79,
+          "losses": 29,
+          "teams": [
+            {
+              "name": "Fluffy_m1n",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ec1822f5d298b94e",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "Kaige",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1187bd89a1f4347c",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "Kaige",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/469c7cca3fddbe19",
+              "tournamentName": "Champions 🇨🇷 tour #1"
+            },
+            {
+              "name": "Fluffy_m1n",
+              "placement": 1,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/afa825915003385a",
+              "tournamentName": "Devils Den Tournaments #77"
+            },
+            {
+              "name": "Kaige",
+              "placement": 5,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/bb33aca675c84fad",
+              "tournamentName": "The Drywall Series - Champions!"
+            },
+            {
+              "name": "Fluffy_m1n",
+              "placement": 8,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/365d925eda28d4aa",
+              "tournamentName": "The Drywall Series - Champions!"
+            },
+            {
+              "name": "Fluffy_m1n",
+              "placement": 1,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5a3ae51e427374ff",
+              "tournamentName": "Pokeacadamy throwdown"
+            },
+            {
+              "name": "Kaige",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c4329e6a9490da7a",
+              "tournamentName": "Pokemon Champions Challenge #4"
+            },
+            {
+              "name": "Kaige",
+              "placement": 32,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3efb341306c58c13",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "seafoamshores",
+              "placement": 3,
+              "record": "3-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/909cc7db300dd767",
+              "tournamentName": "Pokeacadamy throwdown"
+            },
+            {
+              "name": "Fluffy_m1n",
+              "placement": 3,
+              "record": "3-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/07d4ff6d4e2e9ee9",
+              "tournamentName": "BPL LAST DAY CHAMPIONS TOSS DOWN"
+            },
+            {
+              "name": "Kaige",
+              "placement": 5,
+              "record": "3-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/49faf6a7313eacf6",
+              "tournamentName": "Egman Event's $300+ Pokémon Champions May Clash!"
+            },
+            {
+              "name": "Fluffy_m1n",
+              "placement": 11,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/193196614d058f0e",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Fluffy_m1n",
+              "placement": 22,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6fd09c84852493cb",
+              "tournamentName": "Talon's FIGHT CLUB #82 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Kaige",
+              "placement": 29,
+              "record": "2-2-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d53fd1418a9a647f",
+              "tournamentName": "Pokepal Smackdown #137 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "Fluffy_m1n",
+              "placement": 32,
+              "record": "2-1-0",
+              "pokemonNames": [
+                "Aerodactyl",
+                "Meganium",
+                "Politoed",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/38916c94742f8f2d",
+              "tournamentName": "Extreme Speed Pokémon Champions #3"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "1013",
+            "142",
+            "670",
+            "727",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Sinistcha",
+            "Aerodactyl-Mega",
+            "Floette-Mega",
+            "Incineroar",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 89,
+          "losses": 48,
+          "teams": [
+            {
+              "name": "Selahattin Sturm",
+              "placement": 2,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e15c3f2bee0fc373",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "TheBardo",
+              "placement": 7,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0f798ccf85bdc13f",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "Playboi Carti",
+              "placement": 8,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f8aa3c702528d184",
+              "tournamentName": "*Sitrus-Series*|Champions|$100 to 1st"
+            },
+            {
+              "name": "Shark032",
+              "placement": 6,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/02315644e2d9555a",
+              "tournamentName": "Chaos League Sunday Slam #96"
+            },
+            {
+              "name": "CiccioCT29",
+              "placement": 15,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3f18a6c3f4f01a7a",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "gagartoo",
+              "placement": 4,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b14e1217f0da6053",
+              "tournamentName": "POKEMON CHAMPAGNE- LO CAMBIA TODO N°1"
+            },
+            {
+              "name": "kerni361",
+              "placement": 4,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/db0ceccb1a6a2803",
+              "tournamentName": "Wolfey Patreon Tournament - Pokémon Champions #1"
+            },
+            {
+              "name": "Saku_Spl",
+              "placement": 16,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0e1f6048f23cce34",
+              "tournamentName": "VGCA Battle Hall #26"
+            },
+            {
+              "name": "Gayangos2001",
+              "placement": 28,
+              "record": "4-4-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/86f7af70b2e49571",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "Pradkaiser",
+              "placement": 31,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0316f345dea1d33f",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "gagartoo",
+              "placement": 2,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7ef72f1ad86faaf5",
+              "tournamentName": "The Dark League champions pop up! 5$usd"
+            },
+            {
+              "name": "AxoLottie",
+              "placement": 3,
+              "record": "3-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f06eef9cbb754961",
+              "tournamentName": "King's Gambit #1 | Reg M-A"
+            },
+            {
+              "name": "Mhew",
+              "placement": 17,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/18742ae4f8322aa7",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            },
+            {
+              "name": "Shmon",
+              "placement": 20,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3c653e699b52d55b",
+              "tournamentName": "Champions Tour LEPE #1 (5€ to 1st)"
+            },
+            {
+              "name": "KST VGC ",
+              "placement": 25,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Floette",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/15451130eb781509",
+              "tournamentName": "Talon's FIGHT CLUB #81 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "iiSalad",
+              "placement": 30,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl-Mega",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1f24b5d85396361c",
+              "tournamentName": "Talon's FIGHT CLUB #79 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Cyberman152",
+              "placement": 35,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl-Mega",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0b9c6360a7361de6",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "1013",
+            "142",
+            "212",
+            "670",
+            "727",
+            "903"
+          ],
+          "pokemonNames": [
+            "Sinistcha",
+            "Aerodactyl",
+            "Scizor-Mega",
+            "Floette-Mega",
+            "Incineroar",
+            "Sneasler"
+          ],
+          "wins": 72,
+          "losses": 28,
+          "teams": [
+            {
+              "name": "LeCehlou",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Scizor",
+                "Floette",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b1f63b10d89af82e",
+              "tournamentName": "Coupe Critique Champions VGC #1 - 100€ de cp"
+            },
+            {
+              "name": "manuel9519",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Scizor-Mega",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5f080641bfdfe28d",
+              "tournamentName": "Wolfey Patreon Tournament - Pokémon Champions #2"
+            },
+            {
+              "name": "Redsilver",
+              "placement": 1,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Scizor",
+                "Floette",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/963645aef072acf5",
+              "tournamentName": "Head Bussa's Hoedown#29 ChampionsReg M-A $25 1st"
+            },
+            {
+              "name": "LeCehlou",
+              "placement": 7,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Scizor",
+                "Floette",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d51b55229c997bfe",
+              "tournamentName": "CHAMPIONS COLLECTIVE INAUGURAL TOURNAMENT"
+            },
+            {
+              "name": "BaldoVGC",
+              "placement": 10,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Scizor",
+                "Floette",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0eac36aab1b3e81c",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            },
+            {
+              "name": "LeCehlou",
+              "placement": 3,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Scizor",
+                "Floette",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2e8ccfcd8800505f",
+              "tournamentName": "Champions Collective #2"
+            },
+            {
+              "name": "CalcVGC",
+              "placement": 66,
+              "record": "11-4-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Scizor",
+                "Floette",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1b028250c5e54901",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "UnseenVGC",
+              "placement": 8,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Scizor",
+                "Floette",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/060762d7e246de51",
+              "tournamentName": "Northern Ontario VGC Tour - April 29th"
+            },
+            {
+              "name": "delucieous",
+              "placement": 24,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Scizor",
+                "Floette",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/155f870dabb63a23",
+              "tournamentName": "VGCA Battle Hall #26"
+            },
+            {
+              "name": "Asteriio",
+              "placement": 36,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Scizor-Mega",
+                "Floette-Mega",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fd0825dacb3ed392",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "dracojack",
+              "placement": 40,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Sinistcha",
+                "Aerodactyl",
+                "Scizor",
+                "Floette",
+                "Incineroar",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/78df4cc0b0505ddf",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "003",
+            "248",
+            "445",
+            "479-h",
+            "730",
+            "823"
+          ],
+          "pokemonNames": [
+            "Venusaur",
+            "Tyranitar",
+            "Garchomp",
+            "Rotom-Heat",
+            "Primarina",
+            "Corviknight"
+          ],
+          "wins": 105,
+          "losses": 46,
+          "teams": [
+            {
+              "name": "Kabal",
+              "placement": 1,
+              "record": "10-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Tyranitar",
+                "Garchomp",
+                "Rotom-Heat",
+                "Primarina",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ebf4d77d4ac19414",
+              "tournamentName": "Talon's FIGHT CLUB #81 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "mattnot",
+              "placement": 26,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Tyranitar",
+                "Garchomp",
+                "Rotom-Heat",
+                "Primarina",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b5f1ec04180bc230",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Loki_lincurve",
+              "placement": 6,
+              "record": "9-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Tyranitar",
+                "Garchomp",
+                "Rotom-Heat",
+                "Primarina",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e3657381c300473e",
+              "tournamentName": "ZGG #3 Pokemon Champions VGC $100 Tournament!"
+            },
+            {
+              "name": "pontusvgc",
+              "placement": 49,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Tyranitar",
+                "Garchomp",
+                "Rotom-Heat",
+                "Primarina",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a170242a99d36808",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Yaulande",
+              "placement": 15,
+              "record": "4-4-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Tyranitar",
+                "Garchomp",
+                "Rotom-Heat",
+                "Primarina",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5fa3174254fdc4ef",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            },
+            {
+              "name": "jnslgn",
+              "placement": 30,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Tyranitar",
+                "Garchomp",
+                "Rotom-Heat",
+                "Primarina",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4f83072937b44b55",
+              "tournamentName": "Champions Cup"
+            },
+            {
+              "name": "1_MiraidonHater",
+              "placement": 74,
+              "record": "11-4-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Tyranitar",
+                "Garchomp",
+                "Rotom-Heat",
+                "Primarina",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e0591d76dad16393",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "João Paulo Farias Nascimento",
+              "placement": 88,
+              "record": "11-4-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Tyranitar",
+                "Garchomp",
+                "Rotom-Heat",
+                "Primarina",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fd4f780be366d41b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Kabal",
+              "placement": 6,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Tyranitar",
+                "Garchomp",
+                "Rotom-Heat",
+                "Primarina",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8ab395b08680e87e",
+              "tournamentName": "Intimidators Champions Challenge #6 - REG M-A"
+            },
+            {
+              "name": "Brennon H",
+              "placement": 7,
+              "record": "3-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Tyranitar",
+                "Garchomp",
+                "Rotom-Heat",
+                "Primarina",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cf9eb56783160387",
+              "tournamentName": "[REG M-A] LearningtoSam's Weekly PokéLeague"
+            },
+            {
+              "name": "Dubber",
+              "placement": 8,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Tyranitar",
+                "Garchomp",
+                "Rotom-Heat",
+                "Primarina",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/65d5d32158c26e6a",
+              "tournamentName": "HeroicTitan’s VGC Battle Arena"
+            },
+            {
+              "name": "Skyfire",
+              "placement": 4,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Tyranitar",
+                "Garchomp",
+                "Rotom-Heat",
+                "Primarina",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/25095939cf4a5d58",
+              "tournamentName": "Wrokk's Oddball Tour #12"
+            },
+            {
+              "name": "Padula",
+              "placement": 18,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Tyranitar",
+                "Garchomp",
+                "Rotom-Heat",
+                "Primarina",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/57defd32a52f170c",
+              "tournamentName": "*Sitrus-Series*|Champions|#56"
+            },
+            {
+              "name": "Brennon H",
+              "placement": 22,
+              "record": "3-4-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Tyranitar",
+                "Garchomp",
+                "Rotom-Heat",
+                "Primarina",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/574f1247c38190e8",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "kauezaovgc",
+              "placement": 139,
+              "record": "10-5-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Tyranitar",
+                "Garchomp",
+                "Rotom-Heat",
+                "Primarina",
+                "Corviknight"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9b2160be6a9f8cdd",
+              "tournamentName": "The Grand Champions Festival"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "142",
+            "445",
+            "670",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Aerodactyl",
+            "Garchomp",
+            "Floette",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 126,
+          "losses": 42,
+          "teams": [
+            {
+              "name": "Arekusabi",
+              "placement": 12,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b32461d35242dadb",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Nano",
+              "placement": 3,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8c54efc43422ddf9",
+              "tournamentName": "Extreme Speed Pokémon Champions #3"
+            },
+            {
+              "name": "DyeItTight",
+              "placement": 59,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c1a5a1cee801cbf3",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 9,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f418a398741b22cd",
+              "tournamentName": "SpearPillar Champions Tour #5 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Trafalgar_VGC",
+              "placement": 1,
+              "record": "6-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d12e0b8adc667a85",
+              "tournamentName": "POKÉMON CHAMPIONS Circuito VGC #2 | Z2 Gaming"
+            },
+            {
+              "name": "Darkip_8",
+              "placement": 1,
+              "record": "7-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/03be675e2dbe11cd",
+              "tournamentName": "Champions Tour LEPE #3"
+            },
+            {
+              "name": "Jesse504",
+              "placement": 9,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/df64b2c54395305b",
+              "tournamentName": "Talon's FIGHT CLUB #81 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Arekusabi",
+              "placement": 12,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2dca0b01f2f26cc4",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "Arekusabi",
+              "placement": 7,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/83bc04054098155a",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #2 2026"
+            },
+            {
+              "name": "Darkip_8",
+              "placement": 5,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/63e72f8cf4af32de",
+              "tournamentName": "Champions Tour LEPE #2"
+            },
+            {
+              "name": "Waffels27",
+              "placement": 5,
+              "record": "3-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/aa3254e04fa47240",
+              "tournamentName": "Pokepal Smackdown #140 (Champions) (Reg M-A)"
+            },
+            {
+              "name": "Darkip_8",
+              "placement": 10,
+              "record": "3-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8595fc0d8c35d79b",
+              "tournamentName": "Champions Tour LEPE #5"
+            },
+            {
+              "name": "UItraVegito",
+              "placement": 17,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/960a6c9fcf21f329",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "Arnauz10",
+              "placement": 24,
+              "record": "3-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1f1240933b353d12",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "NYR",
+              "placement": 140,
+              "record": "10-5-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/02951239d823546b",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "truevillany",
+              "placement": 142,
+              "record": "10-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c8cd6a1bd327e7f8",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "TT123",
+              "placement": 156,
+              "record": "10-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/86c3ce46d0765ae8",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "OGalbina",
+              "placement": 189,
+              "record": "9-4-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Floette",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3c0881d3ccb51496",
+              "tournamentName": "The Grand Champions Festival"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "003",
+            "006",
+            "445",
+            "727",
+            "902",
+            "903"
+          ],
+          "pokemonNames": [
+            "Venusaur",
+            "Charizard",
+            "Garchomp",
+            "Incineroar",
+            "Basculegion-M",
+            "Sneasler"
+          ],
+          "wins": 96,
+          "losses": 42,
+          "teams": [
+            {
+              "name": "Sanvy",
+              "placement": 3,
+              "record": "10-1-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/28bfa91565bb181f",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "BADM_3",
+              "placement": 1,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e8a9c3fe1cafe141",
+              "tournamentName": "Extreme Speed Pokémon Champions #3"
+            },
+            {
+              "name": "kimi_au",
+              "placement": 10,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/62088f7298767e92",
+              "tournamentName": "*Sitrus-Series*|Champions|$100 to 1st"
+            },
+            {
+              "name": "ZUKY187",
+              "placement": 14,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard-Mega Y",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7e74ec574310896f",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            },
+            {
+              "name": "Scooteezy",
+              "placement": 15,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/680513585ec95801",
+              "tournamentName": "Pokemon Champions Challenge #1"
+            },
+            {
+              "name": "BADM_3",
+              "placement": 15,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/444af00a5cd2b2ee",
+              "tournamentName": "Talon's FIGHT CLUB #80 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "imstone",
+              "placement": 22,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cf3553c0c54eb900",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "failandimprove",
+              "placement": 25,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/4b7aca819830caa9",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "BadBlood2",
+              "placement": 26,
+              "record": "6-4-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a5fd882d89f66c75",
+              "tournamentName": "LIGA DA COMUNIDADE #3 (R$ 1.000 PRIZE POOL)"
+            },
+            {
+              "name": "Aitor54",
+              "placement": 5,
+              "record": "5-1-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3d5f673045f2eb1f",
+              "tournamentName": "POKÉMON CHAMPIONS Circuito VGC #1 | Z2 Gaming"
+            },
+            {
+              "name": "ZUKY187",
+              "placement": 7,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard-Mega Y",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2e93953d0037ab19",
+              "tournamentName": "Pokémon Champions Reg M-A | CGCL Weekly #1"
+            },
+            {
+              "name": "Ace_Ridgeway34",
+              "placement": 8,
+              "record": "3-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard-Mega Y",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/da656609e3c641f1",
+              "tournamentName": "Northern Ontario VGC Tour"
+            },
+            {
+              "name": "Herasitoo",
+              "placement": 18,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6df31043091219ce",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "Luis N",
+              "placement": 19,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard-Mega Y",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/31422ef6f9d575fd",
+              "tournamentName": "Devils Den Tournaments #74"
+            },
+            {
+              "name": "Lyph",
+              "placement": 21,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1b5785a17d1087db",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "Sokolata",
+              "placement": 22,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard-Mega Y",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/08d87ee1acf1c23c",
+              "tournamentName": "Delites Champions Cup #1 (Reg M-A)"
+            },
+            {
+              "name": "MK_Sparkz04",
+              "placement": 24,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/e7c734253b0deb68",
+              "tournamentName": "Talon's FIGHT CLUB #81 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Evergrande .",
+              "placement": 30,
+              "record": "3-1-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Garchomp",
+                "Incineroar",
+                "Basculegion-M",
+                "Sneasler"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5b6fbae5b696e864",
+              "tournamentName": "Extreme Speed Pokémon Champions #2"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "094",
+            "1013",
+            "248",
+            "727",
+            "784",
+            "983"
+          ],
+          "pokemonNames": [
+            "Gengar",
+            "Sinistcha",
+            "Tyranitar",
+            "Incineroar",
+            "Kommo-o",
+            "Kingambit"
+          ],
+          "wins": 76,
+          "losses": 34,
+          "teams": [
+            {
+              "name": "PollitoA7",
+              "placement": 14,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Gengar",
+                "Sinistcha",
+                "Tyranitar",
+                "Incineroar",
+                "Kommo-o",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/fc444acf463edee9",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "PorygonPeo",
+              "placement": 5,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Gengar",
+                "Sinistcha",
+                "Tyranitar",
+                "Incineroar",
+                "Kommo-o",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b57f13dff2a9c3c7",
+              "tournamentName": "Alpensee Anniversary by codecentric AG (500€💰)"
+            },
+            {
+              "name": "CrisVGC",
+              "placement": 40,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Gengar",
+                "Sinistcha",
+                "Tyranitar",
+                "Incineroar",
+                "Kommo-o",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ba00dd65d9b8e8f8",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "shaikhvgc786",
+              "placement": 6,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Gengar-Mega",
+                "Sinistcha",
+                "Tyranitar",
+                "Incineroar",
+                "Kommo-o",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/ffb94793c3e61696",
+              "tournamentName": "Unova Champions League / POKÉMON CHAMPIONS / 30€"
+            },
+            {
+              "name": "EmbyPlays",
+              "placement": 10,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Gengar",
+                "Sinistcha",
+                "Tyranitar",
+                "Incineroar",
+                "Kommo-o",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0b077f64e0227a10",
+              "tournamentName": "VGCA Battle #25"
+            },
+            {
+              "name": "Atomios",
+              "placement": 11,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Gengar",
+                "Sinistcha",
+                "Tyranitar",
+                "Incineroar",
+                "Kommo-o",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/23b2e4886793178b",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #66👑"
+            },
+            {
+              "name": "Alan Ruiz",
+              "placement": 14,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Gengar-Mega",
+                "Sinistcha",
+                "Tyranitar",
+                "Incineroar",
+                "Kommo-o",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/29d9d459d4a46da2",
+              "tournamentName": "Extreme Speed Pokémon Champions"
+            },
+            {
+              "name": "Frostee",
+              "placement": 19,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Gengar",
+                "Sinistcha",
+                "Tyranitar",
+                "Incineroar",
+                "Kommo-o",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8cfb0cc2c0bbe425",
+              "tournamentName": "ZGG #3 Pokemon Champions VGC $100 Tournament!"
+            },
+            {
+              "name": "CrisVGC",
+              "placement": 23,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Gengar",
+                "Sinistcha",
+                "Tyranitar",
+                "Incineroar",
+                "Kommo-o",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/41766f7281efeda8",
+              "tournamentName": "TORNEO SALIDA POKÉMON CHAMPIONS"
+            },
+            {
+              "name": "OneScoopMan",
+              "placement": 41,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Gengar",
+                "Sinistcha",
+                "Tyranitar",
+                "Incineroar",
+                "Kommo-o",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9d0e5986c70aa06f",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "Watashi",
+              "placement": 2,
+              "record": "3-1-0",
+              "pokemonNames": [
+                "Gengar-Mega",
+                "Sinistcha",
+                "Tyranitar",
+                "Incineroar",
+                "Kommo-o",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5095e703e4d75a69",
+              "tournamentName": "🏆Pokémon CHAMPIONS🏆 Mi Dulce Japón Tournament #1"
+            },
+            {
+              "name": "frankina",
+              "placement": 11,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Gengar-Mega",
+                "Sinistcha",
+                "Tyranitar",
+                "Incineroar",
+                "Kommo-o",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/512014fc9354a671",
+              "tournamentName": "POKEMON CHAMPAGNE- LO CAMBIA TODO N°1"
+            },
+            {
+              "name": "Alanbrito",
+              "placement": 26,
+              "record": "3-2-0",
+              "pokemonNames": [
+                "Gengar",
+                "Sinistcha",
+                "Tyranitar",
+                "Incineroar",
+                "Kommo-o",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/46e17035e0114280",
+              "tournamentName": "Extreme Speed Pokémon Champions #3"
+            },
+            {
+              "name": "almondspy",
+              "placement": 35,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Gengar",
+                "Sinistcha",
+                "Tyranitar",
+                "Incineroar",
+                "Kommo-o",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/294cdcda7d9e02b4",
+              "tournamentName": "VGC Trainer school; CHAMPIONS FORMAT! (M/A)"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "038-a",
+            "094",
+            "149",
+            "727",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Ninetales-Alola",
+            "Gengar",
+            "Dragonite",
+            "Incineroar",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 71,
+          "losses": 25,
+          "teams": [
+            {
+              "name": "SupahSanti",
+              "placement": 4,
+              "record": "16-3-0",
+              "pokemonNames": [
+                "Ninetales-Alola",
+                "Gengar",
+                "Dragonite",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1d90697499513e65",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Cnorth26",
+              "placement": 15,
+              "record": "14-3-0",
+              "pokemonNames": [
+                "Ninetales-Alola",
+                "Gengar",
+                "Dragonite",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1501bb0dc22a2012",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "tyk04",
+              "placement": 7,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Ninetales-Alola",
+                "Gengar",
+                "Dragonite",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/65a73dcb333ea66d",
+              "tournamentName": "Talon's FIGHT CLUB #82 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Silo",
+              "placement": 1,
+              "record": "4-0-0",
+              "pokemonNames": [
+                "Ninetales-Alola",
+                "Gengar",
+                "Dragonite",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/65f582ae408c83d5",
+              "tournamentName": "DucPokémonChampions#2"
+            },
+            {
+              "name": "Flafferson",
+              "placement": 8,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Ninetales-Alola",
+                "Gengar",
+                "Dragonite",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6f6cb3b5c7df0df5",
+              "tournamentName": "Champions Tour LEPE #2"
+            },
+            {
+              "name": "Art_Vandelay",
+              "placement": 10,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Ninetales-Alola",
+                "Gengar",
+                "Dragonite",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c260b31f1238ac36",
+              "tournamentName": "Devils Den Tournaments #77"
+            },
+            {
+              "name": "BigSteveJRPG",
+              "placement": 11,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Ninetales-Alola",
+                "Gengar",
+                "Dragonite",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/df7179b10bbd1248",
+              "tournamentName": "Boldore's Gate #8 - $5 USD - Champions Weekly 4/27"
+            },
+            {
+              "name": "Thud124",
+              "placement": 161,
+              "record": "10-5-0",
+              "pokemonNames": [
+                "Ninetales-Alola",
+                "Gengar",
+                "Dragonite",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1a067faaa03c2ae4",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Siddharth S",
+              "placement": 220,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Ninetales-Alola",
+                "Gengar",
+                "Dragonite",
+                "Incineroar",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/feda317e78c9bf8c",
+              "tournamentName": "The Grand Champions Festival"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "006",
+            "142",
+            "445",
+            "571-h",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Charizard",
+            "Aerodactyl",
+            "Garchomp",
+            "Zoroark-Hisui",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 49,
+          "losses": 17,
+          "teams": [
+            {
+              "name": "Shishio_Ax",
+              "placement": 1,
+              "record": "11-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/0d56e21aad4f3505",
+              "tournamentName": "SpearPillar x WonderWorld #1| $300 Prize Reg M-A"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 4,
+              "record": "8-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7b11480dfff39367",
+              "tournamentName": "Coupe Critique Champions VGC #2 - 200€ prize"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/50ab4d9dee0e56d3",
+              "tournamentName": "Tenki's Cart - Champions M-A"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 21,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/286ad4bc4054ac82",
+              "tournamentName": "SpearPillar Champions Tour #4 | Reg M-A $100 Prize"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 3,
+              "record": "7-2-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/de77782c48e6b9c5",
+              "tournamentName": "Flashback Midwest Monthly II! $20 USD to Winner!"
+            },
+            {
+              "name": "Shishio_Ax",
+              "placement": 19,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a67b1778bc4cb372",
+              "tournamentName": "*Sitrus-Series*|Champions|$50 to winner|#58"
+            },
+            {
+              "name": "SKY_SkyWolf93",
+              "placement": 26,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Charizard",
+                "Aerodactyl",
+                "Garchomp",
+                "Zoroark-Hisui",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/800569d0ed6b9947",
+              "tournamentName": "10ToesDownVGC #31 Champions $100 Top 4(Late Join)"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "003",
+            "006",
+            "282",
+            "350",
+            "445",
+            "727"
+          ],
+          "pokemonNames": [
+            "Venusaur",
+            "Charizard-Mega Y",
+            "Gardevoir",
+            "Milotic",
+            "Garchomp",
+            "Incineroar"
+          ],
+          "wins": 100,
+          "losses": 59,
+          "teams": [
+            {
+              "name": "Ahaze13",
+              "placement": 12,
+              "record": "9-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2e0271c472f8fd3e",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "Piedrer",
+              "placement": 30,
+              "record": "7-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/a8c11914fb45aac7",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "Style_VGC",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d4b040dc535f1991",
+              "tournamentName": "Pokémon Champions Reg M-A | CGCL Weekly #1"
+            },
+            {
+              "name": "BrandonOjon",
+              "placement": 2,
+              "record": "6-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5572e5b5ae77f6fd",
+              "tournamentName": "WARTORTLE WEDNESDAYS #56 REG M-A BO3 SWISS"
+            },
+            {
+              "name": "138mysx",
+              "placement": 13,
+              "record": "6-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard-Mega Y",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/1ea09d21f9c7afd6",
+              "tournamentName": "Talon's FIGHT CLUB #81 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "diaaz",
+              "placement": 16,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/b20f8822532ffd84",
+              "tournamentName": "Unova Champions League / POKÉMON CHAMPIONS / 30€"
+            },
+            {
+              "name": "Ahaze13",
+              "placement": 28,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d32e5ca8b1676543",
+              "tournamentName": "*Sitrus-Series*|Champions|$100 to 1st"
+            },
+            {
+              "name": "MiggleVGC",
+              "placement": 63,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard-Mega Y",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5c77242596dc612a",
+              "tournamentName": "Wide League Pokemon Champions SNR #84 $200 Prize"
+            },
+            {
+              "name": "grihzzly",
+              "placement": 93,
+              "record": "5-4-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard-Mega Y",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/03ba5bc996ce6d5c",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "Puxcci",
+              "placement": 102,
+              "record": "5-4-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/2fbd61b2bb99d82f",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            },
+            {
+              "name": "Luca Alarcon",
+              "placement": 7,
+              "record": "5-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/5aedcf3ee9b39435",
+              "tournamentName": "POKEMON CHAMPAGNE- LO CAMBIA TODO N°1"
+            },
+            {
+              "name": "ArchyX",
+              "placement": 7,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/546d7dd53b3f5932",
+              "tournamentName": "POKÉMON CHAMPIONS Circuito VGC #1 | Z2 Gaming"
+            },
+            {
+              "name": "CelVGC",
+              "placement": 5,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard-Mega Y",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c5a10bea047df7a1",
+              "tournamentName": "Cel's Super Slam #15 Reg M-A DAY ONE EU TOUR"
+            },
+            {
+              "name": "Piedrer",
+              "placement": 19,
+              "record": "5-2-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/3c1e0ab61b028db1",
+              "tournamentName": "Unova Champions League / POKÉMON CHAMPIONS / 30€"
+            },
+            {
+              "name": "Fider1435",
+              "placement": 22,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f70bcebf203fd1ff",
+              "tournamentName": "Extreme Speed Pokémon Champions #2"
+            },
+            {
+              "name": "Darkepson",
+              "placement": 24,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/249d9b23e071be08",
+              "tournamentName": "Pokémon Champions SV #1"
+            },
+            {
+              "name": "VermiCL",
+              "placement": 28,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7424924b07f68724",
+              "tournamentName": "Talon's FIGHT CLUB #80 POKEMON CHAMPIONS"
+            },
+            {
+              "name": "Pitron23",
+              "placement": 45,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard-Mega Y",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/07c5b3a25fd07f4c",
+              "tournamentName": "TORNEO SALIDA POKÉMON CHAMPIONS"
+            },
+            {
+              "name": "Bynce",
+              "placement": 51,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/8d9893b1625ae07d",
+              "tournamentName": "TORNEO SALIDA POKÉMON CHAMPIONS"
+            },
+            {
+              "name": "notstan",
+              "placement": 139,
+              "record": "4-5-0",
+              "pokemonNames": [
+                "Venusaur",
+                "Charizard",
+                "Gardevoir",
+                "Milotic",
+                "Garchomp",
+                "Incineroar"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7234ba9d46b499bd",
+              "tournamentName": "Pokemon Champions First Tour $500 Prize Pool"
+            }
+          ]
+        },
+        {
+          "pokemon": [
+            "445",
+            "663",
+            "670",
+            "902",
+            "903",
+            "983"
+          ],
+          "pokemonNames": [
+            "Garchomp",
+            "Talonflame",
+            "Floette",
+            "Basculegion-M",
+            "Sneasler",
+            "Kingambit"
+          ],
+          "wins": 79,
+          "losses": 32,
+          "teams": [
+            {
+              "name": "4lphabet",
+              "placement": 1,
+              "record": "9-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/9ff1b5571adf0ead",
+              "tournamentName": "Rework Esport Champions Talent Cup | 50€ CP"
+            },
+            {
+              "name": "TechnicallyInsane",
+              "placement": 28,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/208f92972f973077",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "4lphabet",
+              "placement": 3,
+              "record": "8-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/999e838891b8264b",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            },
+            {
+              "name": "washy",
+              "placement": 51,
+              "record": "12-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/cf2275d04536a34f",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "riomelaceto92",
+              "placement": 3,
+              "record": "8-1-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/f0bd8eaf89d9d403",
+              "tournamentName": "VGC Trainer School; champions M/A #4"
+            },
+            {
+              "name": "Kyogre",
+              "placement": 84,
+              "record": "11-4-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/744266518b7fdb00",
+              "tournamentName": "The Grand Champions Festival"
+            },
+            {
+              "name": "Veiv98",
+              "placement": 5,
+              "record": "4-2-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/6833bc963389c938",
+              "tournamentName": "Champions Tour LEPE #5"
+            },
+            {
+              "name": "GiovaniVGC",
+              "placement": 8,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/7d78f10c741b5446",
+              "tournamentName": "Intimidators Champions Challenge #5 - REG M-A"
+            },
+            {
+              "name": "ViniFil34",
+              "placement": 16,
+              "record": "2-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/d39d727cd1cd8559",
+              "tournamentName": "Intimidators Champions Challenge #6 - REG M-A"
+            },
+            {
+              "name": "yagosimas",
+              "placement": 18,
+              "record": "3-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/c1db18e92db7579b",
+              "tournamentName": "Mt. Moon Champions VGC Weekly #1 2026"
+            },
+            {
+              "name": "KST VGC ",
+              "placement": 21,
+              "record": "4-3-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/93f1f0b1f44e0ec7",
+              "tournamentName": "CHAMPIONS REG. M-A |👑CROWN FIGHT Bo3 TOUR #67👑"
+            },
+            {
+              "name": "GaahZanelato",
+              "placement": 54,
+              "record": "3-4-0",
+              "pokemonNames": [
+                "Garchomp",
+                "Talonflame",
+                "Floette",
+                "Basculegion-M",
+                "Sneasler",
+                "Kingambit"
+              ],
+              "pokepasteUrl": "https://pokepast.es/81101a908e00b216",
+              "tournamentName": "Devils Den Tournaments #76 - $100 For First"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/frontend/src/data/tournamentTeamsByRegulation.ts
+++ b/frontend/src/data/tournamentTeamsByRegulation.ts
@@ -1,0 +1,45 @@
+import maData from "./tournamentTeams-regM-A.json";
+
+export interface TournamentInnerTeam {
+  name: string;
+  placement: number | null;
+  record: string;
+  pokemonNames: string[];
+  pokepasteUrl: string;
+  tournamentName: string;
+}
+
+export interface TournamentCluster {
+  pokemon: string[];
+  pokemonNames: string[];
+  wins: number;
+  losses: number;
+  teams: TournamentInnerTeam[];
+}
+
+export interface TournamentComposition {
+  size: number;
+  clusters: TournamentCluster[];
+}
+
+export interface TournamentTeamsData {
+  regulation: string;
+  labmausRegulation: string;
+  dateRange: { from: string; to: string };
+  generatedAt: string;
+  compositions: TournamentComposition[];
+}
+
+// Team.regulation is stored as the verbatim NewTeamModal string
+// (e.g. "VGC 2026 Regulation M-A"), so we match on a regex of the
+// trailing regulation code rather than an exact equality check.
+const REGISTRY: Array<{ match: RegExp; data: TournamentTeamsData }> = [
+  { match: /Regulation\s+M-A\b/i, data: maData as TournamentTeamsData },
+];
+
+export function getTournamentTeamsForRegulation(
+  regulation: string | null | undefined,
+): TournamentTeamsData | null {
+  if (!regulation) return null;
+  return REGISTRY.find((r) => r.match.test(regulation))?.data ?? null;
+}

--- a/frontend/src/pages/Team/MatchupPlannerPage.tsx
+++ b/frontend/src/pages/Team/MatchupPlannerPage.tsx
@@ -7,6 +7,7 @@ import {
   ArrowLeft,
   ChevronsUp,
   ChevronsDown,
+  Trophy,
 } from "lucide-react";
 import {
   DndContext,
@@ -29,6 +30,7 @@ import SortableOpponentTeamCard, {
 } from "../../components/team/SortableOpponentTeamCard";
 import LeadGroupCard from "../../components/team/LeadGroupCard";
 import AddOpponentTeamModal from "../../components/modals/AddOpponentTeamModal";
+import RecentTourModal from "../../components/modals/RecentTourModal";
 import TagInput from "../../components/form/TagInput";
 import { useActiveTeam } from "../../context/ActiveTeamContext";
 import { useOpponentTeams } from "../../hooks/useOpponentTeams";
@@ -43,6 +45,7 @@ export default function MatchupPlannerPage() {
   const [parsingPokepaste, setParsingPokepaste] = useState(false);
   const [parseError, setParseError] = useState<string | null>(null);
   const [showAddTeamModal, setShowAddTeamModal] = useState(false);
+  const [showRecentTourModal, setShowRecentTourModal] = useState(false);
   const [searchTags, setSearchTags] = useState<string[]>([]);
   const [groupByLeads, setGroupByLeads] = useState(false);
   const [activeDragId, setActiveDragId] = useState<number | null>(null);
@@ -172,6 +175,13 @@ export default function MatchupPlannerPage() {
     setShowAddTeamModal(false);
   };
 
+  const handleImportFromRecentTour = async (
+    pokepasteUrl: string,
+    notes: string,
+  ) => {
+    await createOpponentTeam({ pokepaste: pokepasteUrl, notes, color: "blue" });
+  };
+
   const handleUpdateNotes = async (
     opponentTeamId: number,
     updates: { pokepaste?: string; notes?: string; color?: string },
@@ -261,6 +271,14 @@ export default function MatchupPlannerPage() {
               >
                 <Layers className="h-4 w-4" />
                 Group By Leads
+              </button>
+              <button
+                onClick={() => setShowRecentTourModal(true)}
+                className="flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+                title="Browse popular teams from recent tournaments"
+              >
+                <Trophy className="h-4 w-4" />
+                Recent Tour
               </button>
               <button
                 onClick={() => setShowAddTeamModal(true)}
@@ -458,6 +476,14 @@ export default function MatchupPlannerPage() {
         isOpen={showAddTeamModal}
         onClose={() => setShowAddTeamModal(false)}
         onSubmit={handleAddOpponentTeam}
+      />
+
+      {/* Recent Tour Modal */}
+      <RecentTourModal
+        isOpen={showRecentTourModal}
+        onClose={() => setShowRecentTourModal(false)}
+        teamRegulation={team?.regulation}
+        onImport={handleImportFromRecentTour}
       />
     </div>
     </>

--- a/frontend/src/services/pokepasteService.ts
+++ b/frontend/src/services/pokepasteService.ts
@@ -288,6 +288,10 @@ function parseNameLine(line: string): {
     name = name.split(" @ ")[0];
   }
 
+  // Strip "Mega " prefix some pastes use (e.g. "Mega Floette @ Floettite").
+  // The mega forme is signaled by the item; the species name should stay base.
+  name = name.replace(/^Mega\s+/i, "");
+
   // Extract gender
   if (name.includes(" (M)")) {
     gender = "M";

--- a/scripts/generate-tournament-teams.js
+++ b/scripts/generate-tournament-teams.js
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+/**
+ * Generate per-regulation tournament team JSON for the Matchup Planner's
+ * "Recent Tour" modal.
+ *
+ * Fetches the last ~60 days of top teams from labmaus.net's public
+ * top_teams endpoint, trims aggressively, and writes one JSON file per
+ * supported regulation.
+ *
+ * Writes:
+ *   - frontend/src/data/tournamentTeams-regM-A.json
+ *
+ * Usage: node scripts/generate-tournament-teams.js
+ *        (or: cd frontend && npm run generate:tournament-teams)
+ */
+
+import { writeFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { execFileSync } from "child_process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+// LabMaus ships this bearer in their public SPA bundle — it is not a secret,
+// every visitor receives it. We treat it as a public anonymous API key.
+// If LabMaus rotates it, this script will start failing with 403; copy the
+// new value from their bundle (`Discord.Api_Key`) and re-run.
+const LABMAUS_TOKEN = "X:F3mz5e4SP6Rcl3co!ou:8y";
+
+// (Code → LabMaus regulation string). Add entries here when expanding
+// coverage to other formats.
+const REGULATIONS = [
+  { code: "M-A", labmaus: "Regulation Set M-A" },
+];
+
+const WINDOW_DAYS = 60;
+
+// LabMaus returns every individual tournament submission per cluster (often
+// 50–100). The UI lists them inline; keeping that many is both wasteful in
+// bundle size and unhelpful in the browse experience. LabMaus already sorts
+// them by score, so the head of the list is the most representative.
+const MAX_INNER_TEAMS_PER_CLUSTER = 20;
+
+function isoDate(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function computeDateRange() {
+  const to = new Date();
+  const from = new Date(to);
+  from.setDate(to.getDate() - WINDOW_DAYS);
+  return { from: isoDate(from), to: isoDate(to) };
+}
+
+function isPokepasteUrl(url) {
+  return typeof url === "string" && /^https?:\/\/(www\.)?pokepast\.es\//.test(url);
+}
+
+// LabMaus encodes gender forms as Unicode "♂"/"♀" suffixes (e.g. "Basculegion ♂").
+// Our Pokemon registry uses Showdown-style "-M"/"-F" suffixes, which already
+// have alias coverage in scripts/pokemon-aliases.json. Normalize at the source
+// so the frontend doesn't need to know about the Unicode form.
+function normalizePokemonName(name) {
+  if (typeof name !== "string") return name;
+  return name.replace(/\s*♂$/u, "-M").replace(/\s*♀$/u, "-F");
+}
+
+function normalizeNames(names) {
+  return Array.isArray(names) ? names.map(normalizePokemonName) : [];
+}
+
+function trimInnerTeam(team) {
+  return {
+    name: team.name ?? "",
+    placement: team.placement ?? null,
+    record: team.record ?? "",
+    pokemonNames: normalizeNames(team.pokemon_names),
+    pokepasteUrl: team.team_url,
+    tournamentName: team.tournament_name ?? "",
+  };
+}
+
+function trimCluster(cluster) {
+  const teams = Array.isArray(cluster.teams)
+    ? cluster.teams
+        .filter((t) => isPokepasteUrl(t.team_url))
+        .slice(0, MAX_INNER_TEAMS_PER_CLUSTER)
+        .map(trimInnerTeam)
+    : [];
+
+  return {
+    pokemon: Array.isArray(cluster.pokemon) ? cluster.pokemon : [],
+    pokemonNames: normalizeNames(cluster.pokemon_names),
+    wins: cluster.wins ?? 0,
+    losses: cluster.losses ?? 0,
+    teams,
+  };
+}
+
+// Use curl for the HTTP request. Node's `fetch` trips over corporate
+// MITM TLS proxies on some dev machines (UNABLE_TO_VERIFY_LEAF_SIGNATURE);
+// curl honors the system trust store and "just works" on every platform
+// we care about (macOS + Linux). The script is run manually by developers,
+// so the curl dependency is fine.
+function fetchTopTeams(labmausRegulation, dateRange) {
+  const url = new URL("https://labmaus.net/api/top_teams");
+  url.searchParams.set("regulation", labmausRegulation);
+  url.searchParams.set("date_range", `${dateRange.from} to ${dateRange.to}`);
+  url.searchParams.set("language", "en");
+
+  const stdout = execFileSync(
+    "curl",
+    [
+      "-sSf",
+      "--max-time", "60",
+      "-H", `authorization: Bearer ${LABMAUS_TOKEN}`,
+      url.toString(),
+    ],
+    { encoding: "utf8", maxBuffer: 50 * 1024 * 1024 },
+  );
+
+  return JSON.parse(stdout);
+}
+
+function generateForRegulation({ code, labmaus }) {
+  const dateRange = computeDateRange();
+  console.log(`Fetching ${labmaus} (${dateRange.from} → ${dateRange.to})…`);
+  const raw = fetchTopTeams(labmaus, dateRange);
+
+  if (!Array.isArray(raw)) {
+    throw new Error(`Unexpected top-level shape for ${code}: expected array`);
+  }
+
+  const compositions = raw
+    .map((bucket) => ({
+      size: bucket.composition,
+      clusters: Array.isArray(bucket.teams) ? bucket.teams.map(trimCluster) : [],
+    }))
+    .filter((c) => typeof c.size === "number")
+    .sort((a, b) => a.size - b.size);
+
+  const totalClusters = compositions.reduce((n, c) => n + c.clusters.length, 0);
+  const totalInnerTeams = compositions.reduce(
+    (n, c) => n + c.clusters.reduce((m, k) => m + k.teams.length, 0),
+    0,
+  );
+
+  const output = {
+    regulation: code,
+    labmausRegulation: labmaus,
+    dateRange,
+    generatedAt: isoDate(new Date()),
+    compositions,
+  };
+
+  const outPath = resolve(ROOT, `frontend/src/data/tournamentTeams-reg${code}.json`);
+  writeFileSync(outPath, JSON.stringify(output, null, 2) + "\n");
+
+  console.log(
+    `  Wrote ${totalClusters} clusters / ${totalInnerTeams} teams → ${outPath}`,
+  );
+}
+
+function main() {
+  for (const reg of REGULATIONS) {
+    generateForRegulation(reg);
+  }
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Adds a **Recent Tour** button on the Matchup Planner that opens a tabbed modal of recent-tournament archetype clusters (4/5/6 Pokémon), sourced from LabMaus's public `top_teams` endpoint. Each cluster expands to show the underlying tournament submissions — with a **View Paste** link and an **Import** button that drops the team straight into the opponent-team list via the existing pokepaste flow.

- Static-JSON pipeline mirrors the speed-tier pattern: `scripts/generate-tournament-teams.js` → `frontend/src/data/tournamentTeams-regM-A.json` (~860 KB after aggressive trim).
- Each cluster keeps the top 20 inner teams. Pokémon names are normalized at generation time (`♂` → `-M`, `♀` → `-F`) so the existing registry resolves all 73 unique names.
- Currently ships Regulation M-A only; teams on other regulations get a friendly empty state. Future regulations get their own JSON + entry in `tournamentTeamsByRegulation.ts`.
- The generator shells out to `curl` instead of Node `fetch` to dodge corporate-MITM TLS issues on some dev boxes.
- Refresh policy: manual regen + commit (run `npm run generate:tournament-teams` from `frontend/`).

## Test plan

- [ ] On a team with `regulation = "VGC 2026 Regulation M-A"`, the **Recent Tour** button is visible in the Matchup Planner toolbar.
- [ ] Clicking it opens the modal, default tab is "6 Pokémon", clusters show sprite strip + W-L + win rate.
- [ ] Switching to the "5" and "4" tabs updates the list.
- [ ] Expanding a cluster shows inner teams with player name, placement, record, tournament name, sprite strip.
- [ ] **View Paste** opens the pokepaste in a new tab.
- [ ] **Import** adds the matchup team to the planner; button shows "Imported ✓" and is disabled to prevent double-imports.
- [ ] On a team with a different regulation (e.g. Reg G) or no regulation set, the modal shows the "Not available yet" empty state.
- [ ] Mobile viewport (~375px): modal goes near-full-width, tab labels collapse to just numbers, action buttons stack vertically, sprite strips wrap cleanly.
- [ ] `npm run build` succeeds; no new lint errors introduced by these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)