### PR TITLE
ci: weekly data-refresh workflow (NCP setdex + LabMaus teams)

### DIFF
--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -1,0 +1,68 @@
+name: Weekly Data Refresh
+
+# Pulls the latest NCP gen-10 setdex and LabMaus top-teams data once a week
+# and opens a single create-or-update PR against develop for review.
+
+on:
+  schedule:
+    - cron: '0 16 * * 1'   # Mondays 16:00 UTC (9am PT / 12pm ET)
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend deps
+        working-directory: frontend
+        run: npm ci
+
+      - name: Refresh NCP setdex (gen 10)
+        run: node scripts/update-setdex-gen10.js
+
+      - name: Regenerate speed tiers
+        run: node scripts/generate-speed-tiers.js
+
+      - name: Refresh tournament teams (LabMaus)
+        run: node scripts/generate-tournament-teams.js
+
+      - name: Open or update PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: develop
+          branch: chore/weekly-data-refresh
+          delete-branch: true
+          commit-message: 'chore: weekly data refresh'
+          title: 'chore: weekly data refresh'
+          body: |
+            Automated weekly refresh.
+
+            **Possible changes:**
+            - `frontend/src/data/setdex-gen10.ts` — pulled from [Nerd-of-Now/NCP-VGC-Damage-Calculator](https://github.com/Nerd-of-Now/NCP-VGC-Damage-Calculator/blob/master/script_res/setdex_ncp-g10.js)
+            - `frontend/src/data/speedTiers-regM-A.json` — regenerated from the setdex above
+            - `frontend/src/data/tournamentTeams-regM-A.json` — pulled from [labmaus.net](https://labmaus.net) (last 60 days, Reg M-A)
+
+            If none of the upstream sources changed, this PR will not be opened.
+
+            > Auto-created PRs do not trigger CI by default. To run the frontend build against these changes, close and reopen the PR, or push an empty commit.
+          add-paths: |
+            frontend/src/data/setdex-gen10.ts
+            frontend/src/data/speedTiers-regM-A.json
+            frontend/src/data/tournamentTeams-regM-A.json
+          labels: |
+            automated
+            data-refresh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,10 @@ Each species gets four rows (252+, 252 neutral, 0 neutral, 0 -Spe). Mega formes 
 
 Re-run after editing `setdex-gen10.ts`, `megaStones.ts`, or `speed-tier-overrides.json`, or when bumping `@smogon/calc`.
 
+### Automated weekly refresh
+
+`.github/workflows/data-refresh.yml` runs every Monday at 16:00 UTC (and on manual `workflow_dispatch`). It mirrors the upstream NCP gen-10 setdex into `setdex-gen10.ts` (via `scripts/update-setdex-gen10.js`), then regenerates `speedTiers-regM-A.json` and `tournamentTeams-regM-A.json` from it. If anything actually changed, a single create-or-update PR is opened against `develop` on the `chore/weekly-data-refresh` branch. No PR is opened when upstream is unchanged.
+
 ## Important Notes
 
 ### Backend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "generate:speed-tiers": "node ../scripts/generate-speed-tiers.js",
-    "generate:tournament-teams": "node ../scripts/generate-tournament-teams.js"
+    "generate:tournament-teams": "node ../scripts/generate-tournament-teams.js",
+    "update:setdex-gen10": "node ../scripts/update-setdex-gen10.js"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/update-setdex-gen10.js
+++ b/scripts/update-setdex-gen10.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+/**
+ * Mirror the upstream NCP-VGC-Damage-Calculator gen-10 setdex into our
+ * local frontend bundle as an ES module.
+ *
+ * Source:
+ *   https://raw.githubusercontent.com/Nerd-of-Now/NCP-VGC-Damage-Calculator/master/script_res/setdex_ncp-g10.js
+ *
+ * Writes:
+ *   frontend/src/data/setdex-gen10.ts
+ *
+ * Transformation is intentionally minimal:
+ *   - Replace the leading `var SETDEX_GEN10 = ` with `export const SETDEX_GEN10 = `.
+ *   - Strip a trailing semicolon if upstream has one (our checked-in file ends
+ *     without `;` after the closing `}`).
+ *
+ * Usage: node scripts/update-setdex-gen10.js
+ *        (or: cd frontend && npm run update:setdex-gen10)
+ */
+
+import { writeFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { execFileSync } from "child_process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+const UPSTREAM_URL =
+  "https://raw.githubusercontent.com/Nerd-of-Now/NCP-VGC-Damage-Calculator/master/script_res/setdex_ncp-g10.js";
+const OUT_PATH = resolve(ROOT, "frontend/src/data/setdex-gen10.ts");
+
+// Use curl for parity with scripts/generate-tournament-teams.js — keeps the
+// developer-local DX consistent across all data-refresh scripts and avoids
+// Node-fetch TLS issues on corporate-MITM dev boxes.
+function fetchUpstream() {
+  const stdout = execFileSync(
+    "curl",
+    ["-sSf", "--max-time", "60", UPSTREAM_URL],
+    { encoding: "utf8", maxBuffer: 50 * 1024 * 1024 },
+  );
+
+  if (!stdout || stdout.length < 100) {
+    throw new Error(
+      `Upstream fetch returned suspiciously short body (${stdout?.length ?? 0} bytes). Aborting.`,
+    );
+  }
+
+  return stdout;
+}
+
+function transformToEsModule(text) {
+  if (!/^var\s+SETDEX_GEN10\s*=\s*/.test(text)) {
+    throw new Error(
+      "Upstream file no longer starts with `var SETDEX_GEN10 = ` — aborting to avoid corrupting the local copy.",
+    );
+  }
+
+  return text
+    .replace(/^var\s+SETDEX_GEN10\s*=\s*/, "export const SETDEX_GEN10 = ")
+    .replace(/;\s*$/, "");
+}
+
+function main() {
+  console.log(`Fetching ${UPSTREAM_URL}…`);
+  const raw = fetchUpstream();
+  const transformed = transformToEsModule(raw);
+  writeFileSync(OUT_PATH, transformed);
+  console.log(`  Wrote ${transformed.length} bytes → ${OUT_PATH}`);
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Automates the manual refresh of three data files on a weekly cadence:

- `frontend/src/data/setdex-gen10.ts` — mirrored from [Nerd-of-Now/NCP-VGC-Damage-Calculator](https://github.com/Nerd-of-Now/NCP-VGC-Damage-Calculator/blob/master/script_res/setdex_ncp-g10.js) by the new `scripts/update-setdex-gen10.js`.
- `frontend/src/data/speedTiers-regM-A.json` — regenerated from the setdex above.
- `frontend/src/data/tournamentTeams-regM-A.json` — pulled from [labmaus.net](https://labmaus.net) (last 60 days, Reg M-A).

Workflow fires every Monday at 16:00 UTC (9am PT / 12pm ET) and is also dispatchable manually from the Actions UI. Uses `peter-evans/create-pull-request@v6` to open or update a single PR on `chore/weekly-data-refresh` against `develop` — no spurious PRs when upstream is unchanged.

Default `GITHUB_TOKEN` is used (no PAT setup required). Caveat: PRs created this way don't auto-trigger CI; the data files have no unit tests so the trade-off is fine.

## Test plan

- [ ] After merge, fire the workflow manually: Actions → "Weekly Data Refresh" → "Run workflow" on `develop`.
- [ ] Confirm all four script steps finish green.
- [ ] If there are upstream changes: confirm `chore: weekly data refresh` PR opens against `develop` with only the three files in `add-paths` and labels `automated` + `data-refresh`.
- [ ] If there are no upstream changes: confirm no PR is opened (peter-evans logs "No changes detected").
- [ ] Trigger a second manual run and verify it updates the existing PR rather than opening a new one.
- [ ] Verify `npm run update:setdex-gen10` works locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)