### PR TITLE
feat: bump team updatedAt on replay, notes, and matchup planner edits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'feature/**'
+      - 'feat/**'
       - 'fix/**'
       - 'bugfix/**'
   pull_request:

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - 'feature/**'
+      - 'feat/**'
       - 'fix/**'
       - 'bugfix/**'
   workflow_dispatch:  # Allow manual trigger from GitHub UI

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/GamePlanService.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/GamePlanService.java
@@ -29,6 +29,17 @@ public class GamePlanService {
     private final GamePlanRepository gamePlanRepository;
     private final GamePlanTeamRepository gamePlanTeamRepository;
     private final UserRepository userRepository;
+    private final TeamService teamService;
+
+    /**
+     * Bump the team's updatedAt when a matchup-planner edit lands. Safe no-op
+     * for legacy/standalone game plans that aren't linked to a team.
+     */
+    private void touchLinkedTeam(GamePlan plan) {
+        if (plan != null && plan.getTeamId() != null) {
+            teamService.touchTeam(plan.getTeamId());
+        }
+    }
 
     // ==================== GamePlan CRUD ====================
 
@@ -115,6 +126,7 @@ public class GamePlanService {
         }
 
         GamePlan savedPlan = gamePlanRepository.save(existingPlan);
+        touchLinkedTeam(savedPlan);
         log.info("Game plan updated successfully: {}", id);
 
         return savedPlan;
@@ -226,6 +238,7 @@ public class GamePlanService {
         team.setPosition(0);
 
         GamePlanTeam savedTeam = gamePlanTeamRepository.save(team);
+        touchLinkedTeam(gamePlan);
         log.info("Team added successfully with ID: {}", savedTeam.getId());
 
         return savedTeam;
@@ -267,9 +280,8 @@ public class GamePlanService {
     public void reorderTeams(Long gamePlanId, Long userId, List<Long> orderedIds) {
         log.info("Reordering {} teams for game plan ID: {}", orderedIds.size(), gamePlanId);
 
-        if (!gamePlanRepository.existsByIdAndUserId(gamePlanId, userId)) {
-            throw new IllegalArgumentException("Game plan not found or not owned by user");
-        }
+        GamePlan plan = gamePlanRepository.findByIdAndUserId(gamePlanId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("Game plan not found or not owned by user"));
 
         List<GamePlanTeam> teams = gamePlanTeamRepository.findByGamePlanIdOrderByPositionAscIdAsc(gamePlanId);
         if (teams.size() != orderedIds.size()) {
@@ -288,6 +300,7 @@ public class GamePlanService {
         }
 
         gamePlanTeamRepository.saveAll(teams);
+        touchLinkedTeam(plan);
         log.info("Reordered teams for game plan ID: {}", gamePlanId);
     }
 
@@ -304,10 +317,8 @@ public class GamePlanService {
     public GamePlanTeam updateGamePlanTeam(Long id, Long gamePlanId, Long userId, GamePlanTeam updates) {
         log.info("Updating game plan team ID: {}", id);
 
-        // Verify game plan ownership
-        if (!gamePlanRepository.existsByIdAndUserId(gamePlanId, userId)) {
-            throw new IllegalArgumentException("Game plan not found or not owned by user");
-        }
+        GamePlan plan = gamePlanRepository.findByIdAndUserId(gamePlanId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("Game plan not found or not owned by user"));
 
         GamePlanTeam existingTeam = gamePlanTeamRepository.findByIdAndGamePlanId(id, gamePlanId)
                 .orElseThrow(() -> new IllegalArgumentException("Team not found in this game plan"));
@@ -324,6 +335,7 @@ public class GamePlanService {
         }
 
         GamePlanTeam savedTeam = gamePlanTeamRepository.save(existingTeam);
+        touchLinkedTeam(plan);
         log.info("Game plan team updated successfully: {}", id);
 
         return savedTeam;
@@ -340,15 +352,14 @@ public class GamePlanService {
     public void deleteGamePlanTeam(Long id, Long gamePlanId, Long userId) {
         log.info("Deleting game plan team ID: {}", id);
 
-        // Verify game plan ownership
-        if (!gamePlanRepository.existsByIdAndUserId(gamePlanId, userId)) {
-            throw new IllegalArgumentException("Game plan not found or not owned by user");
-        }
+        GamePlan plan = gamePlanRepository.findByIdAndUserId(gamePlanId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("Game plan not found or not owned by user"));
 
         GamePlanTeam team = gamePlanTeamRepository.findByIdAndGamePlanId(id, gamePlanId)
                 .orElseThrow(() -> new IllegalArgumentException("Team not found in this game plan"));
 
         gamePlanTeamRepository.delete(team);
+        touchLinkedTeam(plan);
         log.info("Game plan team deleted successfully: {}", id);
     }
 
@@ -368,10 +379,8 @@ public class GamePlanService {
                                        GamePlanTeam.TeamComposition composition) {
         log.info("Adding composition to game plan team ID: {}", teamId);
 
-        // Verify game plan ownership
-        if (!gamePlanRepository.existsByIdAndUserId(gamePlanId, userId)) {
-            throw new IllegalArgumentException("Game plan not found or not owned by user");
-        }
+        GamePlan plan = gamePlanRepository.findByIdAndUserId(gamePlanId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("Game plan not found or not owned by user"));
 
         GamePlanTeam team = gamePlanTeamRepository.findByIdAndGamePlanId(teamId, gamePlanId)
                 .orElseThrow(() -> new IllegalArgumentException("Team not found in this game plan"));
@@ -379,6 +388,7 @@ public class GamePlanService {
         team.addComposition(composition);
 
         GamePlanTeam savedTeam = gamePlanTeamRepository.save(team);
+        touchLinkedTeam(plan);
         log.info("Composition added successfully to team ID: {}", teamId);
 
         return savedTeam;
@@ -399,10 +409,8 @@ public class GamePlanService {
                                           int index, GamePlanTeam.TeamComposition composition) {
         log.info("Updating composition {} in game plan team ID: {}", index, teamId);
 
-        // Verify game plan ownership
-        if (!gamePlanRepository.existsByIdAndUserId(gamePlanId, userId)) {
-            throw new IllegalArgumentException("Game plan not found or not owned by user");
-        }
+        GamePlan plan = gamePlanRepository.findByIdAndUserId(gamePlanId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("Game plan not found or not owned by user"));
 
         GamePlanTeam team = gamePlanTeamRepository.findByIdAndGamePlanId(teamId, gamePlanId)
                 .orElseThrow(() -> new IllegalArgumentException("Team not found in this game plan"));
@@ -414,6 +422,7 @@ public class GamePlanService {
         team.updateComposition(index, composition);
 
         GamePlanTeam savedTeam = gamePlanTeamRepository.save(team);
+        touchLinkedTeam(plan);
         log.info("Composition updated successfully at index {}", index);
 
         return savedTeam;
@@ -432,10 +441,8 @@ public class GamePlanService {
     public GamePlanTeam deleteComposition(Long teamId, Long gamePlanId, Long userId, int index) {
         log.info("Deleting composition {} from game plan team ID: {}", index, teamId);
 
-        // Verify game plan ownership
-        if (!gamePlanRepository.existsByIdAndUserId(gamePlanId, userId)) {
-            throw new IllegalArgumentException("Game plan not found or not owned by user");
-        }
+        GamePlan plan = gamePlanRepository.findByIdAndUserId(gamePlanId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("Game plan not found or not owned by user"));
 
         GamePlanTeam team = gamePlanTeamRepository.findByIdAndGamePlanId(teamId, gamePlanId)
                 .orElseThrow(() -> new IllegalArgumentException("Team not found in this game plan"));
@@ -447,6 +454,7 @@ public class GamePlanService {
         team.removeComposition(index);
 
         GamePlanTeam savedTeam = gamePlanTeamRepository.save(team);
+        touchLinkedTeam(plan);
         log.info("Composition deleted successfully at index {}", index);
 
         return savedTeam;

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/ReplayService.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/ReplayService.java
@@ -77,6 +77,8 @@ public class ReplayService {
             handleBo3Match(savedReplay, matchInfo, team);
         }
 
+        touchTeam(team.getId());
+
         log.info("Replay created successfully with ID: {}", savedReplay.getId());
 
         return savedReplay;
@@ -133,6 +135,8 @@ public class ReplayService {
         if (matchInfo.isBo3()) {
             handleBo3Match(savedReplay, matchInfo, team);
         }
+
+        touchTeam(team.getId());
 
         log.info("Replay created from URL with ID: {}", savedReplay.getId());
         return savedReplay;
@@ -317,6 +321,11 @@ public class ReplayService {
         // Note: battleLog is immutable and should not be updated
 
         Replay savedReplay = replayRepository.save(existingReplay);
+
+        if (savedReplay.getTeam() != null) {
+            touchTeam(savedReplay.getTeam().getId());
+        }
+
         log.info("Replay updated successfully: {}", savedReplay.getId());
 
         return savedReplay;
@@ -374,11 +383,17 @@ public class ReplayService {
     public void deleteReplay(Long id) {
         log.info("Deleting replay ID: {}", id);
 
-        if (!replayRepository.existsById(id)) {
-            throw new IllegalArgumentException("Replay not found with ID: " + id);
+        Replay replay = replayRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Replay not found with ID: " + id));
+
+        Long teamId = replay.getTeam() != null ? replay.getTeam().getId() : null;
+
+        replayRepository.delete(replay);
+
+        if (teamId != null) {
+            touchTeam(teamId);
         }
 
-        replayRepository.deleteById(id);
         log.info("Replay deleted successfully: {}", id);
     }
 
@@ -441,6 +456,19 @@ public class ReplayService {
     @Transactional(readOnly = true)
     public boolean replayUrlExists(String url) {
         return replayRepository.existsByUrl(url);
+    }
+
+    // ==================== Team activity timestamp ====================
+
+    /**
+     * Bump the parent team's updatedAt. Inlined here (rather than calling
+     * TeamService) to avoid a circular bean dependency: TeamService -> ReplayService.
+     */
+    private void touchTeam(Long teamId) {
+        teamRepository.findById(teamId).ifPresent(team -> {
+            team.setUpdatedAt(LocalDateTime.now());
+            teamRepository.save(team);
+        });
     }
 
     // ==================== Replay Reprocessing ====================

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/TeamMemberService.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/TeamMemberService.java
@@ -23,6 +23,7 @@ public class TeamMemberService {
 
     private final TeamMemberRepository teamMemberRepository;
     private final TeamRepository teamRepository;
+    private final TeamService teamService;
 
     public TeamMember createTeamMember(TeamMember teamMember, Long teamId) {
         log.info("Creating team member for team ID: {}", teamId);
@@ -61,7 +62,13 @@ public class TeamMemberService {
             existing.setCalcs(updates.getCalcs());
         }
 
-        return teamMemberRepository.save(existing);
+        TeamMember saved = teamMemberRepository.save(existing);
+
+        if (saved.getTeam() != null) {
+            teamService.touchTeam(saved.getTeam().getId());
+        }
+
+        return saved;
     }
 
     public void deleteTeamMember(Long id) {

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/TeamService.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/TeamService.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -297,6 +298,18 @@ public class TeamService {
     @Transactional(readOnly = true)
     public long countTeamsByUserId(Long userId) {
         return teamRepository.countByUserId(userId);
+    }
+
+    /**
+     * Bump the team's updatedAt timestamp to reflect activity on a child entity
+     * (replay, team member notes, matchup planner). Silently no-ops if the team
+     * does not exist.
+     */
+    public void touchTeam(Long teamId) {
+        teamRepository.findById(teamId).ifPresent(team -> {
+            team.setUpdatedAt(LocalDateTime.now());
+            teamRepository.save(team);
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary
- Team dashboard sorts by `updatedAt`, but child-entity edits (replays, Pokemon notes, matchup planner) weren't bumping the parent team, so active teams didn't surface to the top.
- Adds `TeamService.touchTeam(Long)` and wires it into `ReplayService` create/update/delete, `TeamMemberService.updateTeamMember`, and the `GamePlanService` matchup-planner mutations (plan update, opponent team add/update/delete, reorder, composition add/update/delete).
- `ReplayService` inlines the touch via its existing `TeamRepository` to avoid a circular dependency with `TeamService` (which already depends on `ReplayService` for replay reprocessing).
- Bulk `reprocessReplaysForTeam` is intentionally **not** treated as activity — it's a recompute, not a user action.

## Test plan
- [x] `mvn test` — 156 passed, 0 failures (9 unrelated external-connectivity skips).
- [ ] Add a replay → team jumps to top of dashboard.
- [ ] Edit a replay's notes/opponent/result → team jumps to top.
- [ ] Delete a replay → team jumps to top.
- [ ] Edit a Pokemon note or calc in `PokemonNoteCard` → team jumps to top.
- [ ] Matchup planner: add opponent team, edit its pokepaste/notes, add/edit/delete a composition (pick), reorder teams, edit plan notes → team jumps to top each time.
- [ ] Regression: editing team name/pokepaste/regulation still bumps it.
- [ ] Negative: changing showdown usernames (which triggers replay reprocessing) does not by itself bump `updatedAt` from replay reprocessing (it does still bump from the team save).

🤖 Generated with [Claude Code](https://claude.com/claude-code)