### PR TITLE
feat(collaboration): share team instances with granular permissions

### DIFF
--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/AnalyticsController.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/AnalyticsController.java
@@ -4,7 +4,7 @@ import com.yeskatronics.vs_recorder_backend.dto.AnalyticsDTO;
 import com.yeskatronics.vs_recorder_backend.dto.ErrorResponse;
 import com.yeskatronics.vs_recorder_backend.security.CustomUserDetailsService;
 import com.yeskatronics.vs_recorder_backend.services.AnalyticsService;
-import com.yeskatronics.vs_recorder_backend.services.TeamService;
+import com.yeskatronics.vs_recorder_backend.services.TeamAccessService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -34,7 +34,7 @@ import org.springframework.web.bind.annotation.*;
 public class AnalyticsController {
 
     private final AnalyticsService analyticsService;
-    private final TeamService teamService;
+    private final TeamAccessService teamAccessService;
     private final CustomUserDetailsService userDetailsService;
 
     /**
@@ -46,11 +46,10 @@ public class AnalyticsController {
     }
 
     /**
-     * Helper method to verify team ownership
+     * Verify the caller can read the team (owner or accepted collaborator).
      */
-    private void verifyTeamOwnership(Long teamId, Long userId) {
-        teamService.getTeamByIdAndUserId(teamId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("Team not found or access denied"));
+    private void verifyTeamAccess(Long teamId, Long userId) {
+        teamAccessService.resolve(teamId, userId);
     }
 
     /**
@@ -87,8 +86,7 @@ public class AnalyticsController {
         Long userId = getCurrentUserId(authentication);
         log.debug("Fetching usage stats for team: {} (user: {})", teamId, userId);
 
-        // Verify ownership
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamAccess(teamId, userId);
 
         AnalyticsDTO.UsageStatsResponse stats = analyticsService.getUsageStats(teamId);
         return ResponseEntity.ok(stats);
@@ -128,8 +126,7 @@ public class AnalyticsController {
         Long userId = getCurrentUserId(authentication);
         log.debug("Fetching matchup stats for team: {} (user: {})", teamId, userId);
 
-        // Verify ownership
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamAccess(teamId, userId);
 
         AnalyticsDTO.MatchupStatsResponse stats = analyticsService.getMatchupStats(teamId);
         return ResponseEntity.ok(stats);
@@ -176,8 +173,7 @@ public class AnalyticsController {
         Long userId = getCurrentUserId(authentication);
         log.debug("Analyzing custom matchup for team: {} against: {}", teamId, request.getOpponentPokemon());
 
-        // Verify ownership
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamAccess(teamId, userId);
 
         // Validate request
         if (request.getOpponentPokemon() == null ||
@@ -224,8 +220,7 @@ public class AnalyticsController {
         Long userId = getCurrentUserId(authentication);
         log.debug("Fetching move usage stats for team: {} (user: {})", teamId, userId);
 
-        // Verify ownership
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamAccess(teamId, userId);
 
         AnalyticsDTO.MoveUsageResponse stats = analyticsService.getMoveUsageStats(teamId);
         return ResponseEntity.ok(stats);

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/AuthController.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/AuthController.java
@@ -8,6 +8,7 @@ import com.yeskatronics.vs_recorder_backend.exceptions.RateLimitExceededExceptio
 import com.yeskatronics.vs_recorder_backend.security.CustomUserDetailsService;
 import com.yeskatronics.vs_recorder_backend.security.JwtUtil;
 import com.yeskatronics.vs_recorder_backend.services.PasswordResetService;
+import com.yeskatronics.vs_recorder_backend.services.TeamCollaboratorService;
 import com.yeskatronics.vs_recorder_backend.services.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import io.swagger.v3.oas.annotations.Operation;
@@ -47,6 +48,7 @@ public class AuthController {
     private final CustomUserDetailsService userDetailsService;
     private final JwtUtil jwtUtil;
     private final PasswordResetService passwordResetService;
+    private final TeamCollaboratorService collaboratorService;
 
     /**
      * Register a new user
@@ -84,6 +86,14 @@ public class AuthController {
 
             // Save user
             User savedUser = userService.createUser(user);
+
+            // If this user was invited to any teams (by email) before they registered, auto-accept now.
+            try {
+                collaboratorService.autoAcceptOnSignup(savedUser.getId(), savedUser.getEmail());
+            } catch (RuntimeException e) {
+                log.warn("Auto-accept of pending collaboration invites failed for user {}: {}",
+                        savedUser.getId(), e.getMessage());
+            }
 
             // Generate JWT tokens
             UserDetails userDetails = userDetailsService.loadUserByUsername(savedUser.getUsername());

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.yeskatronics.vs_recorder_backend.controllers;
 
 import com.yeskatronics.vs_recorder_backend.dto.ErrorResponse;
+import com.yeskatronics.vs_recorder_backend.exceptions.TeamAccessDeniedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -61,6 +62,26 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity.badRequest().body(error);
+    }
+
+    /**
+     * Handle team access denied (collaborator missing permission, or non-member access).
+     */
+    @ExceptionHandler(TeamAccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleTeamAccessDenied(
+            TeamAccessDeniedException ex,
+            WebRequest request) {
+
+        log.warn("Team access denied: {}", ex.getMessage());
+
+        ErrorResponse error = new ErrorResponse(
+                HttpStatus.FORBIDDEN.value(),
+                "Forbidden",
+                ex.getMessage(),
+                request.getDescription(false).replace("uri=", "")
+        );
+
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error);
     }
 
     /**

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/MatchController.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/MatchController.java
@@ -6,7 +6,8 @@ import com.yeskatronics.vs_recorder_backend.entities.Match;
 import com.yeskatronics.vs_recorder_backend.mappers.MatchMapper;
 import com.yeskatronics.vs_recorder_backend.security.CustomUserDetailsService;
 import com.yeskatronics.vs_recorder_backend.services.MatchService;
-import com.yeskatronics.vs_recorder_backend.services.TeamService;
+import com.yeskatronics.vs_recorder_backend.services.TeamAccessService;
+import com.yeskatronics.vs_recorder_backend.services.TeamAccessService.Permission;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,23 +33,20 @@ public class MatchController {
 
     private final MatchService matchService;
     private final MatchMapper matchMapper;
-    private final TeamService teamService;
+    private final TeamAccessService teamAccessService;
     private final CustomUserDetailsService userDetailsService;
 
-    /**
-     * Helper method to get user ID from authentication
-     */
     private Long getCurrentUserId(Authentication authentication) {
         String username = authentication.getName();
         return userDetailsService.getUserIdByUsername(username);
     }
 
-    /**
-     * Helper method to verify team ownership
-     */
-    private void verifyTeamOwnership(Long teamId, Long userId) {
-        teamService.getTeamByIdAndUserId(teamId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("Team not found or access denied"));
+    private void verifyTeamAccess(Long teamId, Long userId) {
+        teamAccessService.resolve(teamId, userId);
+    }
+
+    private void verifyTeamPermission(Long teamId, Long userId, Permission permission) {
+        teamAccessService.requirePermission(teamId, userId, permission);
     }
 
     /**
@@ -69,8 +67,7 @@ public class MatchController {
         Long userId = getCurrentUserId(authentication);
         log.info("Creating new match for team: {}", teamId);
 
-        // Verify team ownership
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamPermission(teamId, userId, Permission.ADD_REPLAYS);
 
         Match match = matchMapper.toEntity(request);
         Match savedMatch = matchService.createMatch(match, teamId);
@@ -98,8 +95,12 @@ public class MatchController {
 
         return matchService.getMatchById(id)
                 .filter(match -> {
-                    // Verify user owns the team this match belongs to
-                    return teamService.getTeamByIdAndUserId(match.getTeam().getId(), userId).isPresent();
+                    try {
+                        teamAccessService.resolve(match.getTeam().getId(), userId);
+                        return true;
+                    } catch (Exception e) {
+                        return false;
+                    }
                 })
                 .map(match -> {
                     MatchService.MatchStats stats = matchService.getMatchStats(match.getId());
@@ -125,8 +126,7 @@ public class MatchController {
         Long userId = getCurrentUserId(authentication);
         log.debug("Fetching matches for team: {}", teamId);
 
-        // Verify team ownership
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamAccess(teamId, userId);
 
         List<MatchDTO.Summary> matches = matchService.getMatchesByTeamIdOrderedByDate(teamId).stream()
                 .map(match -> {
@@ -154,8 +154,7 @@ public class MatchController {
         Long userId = getCurrentUserId(authentication);
         log.debug("Fetching matches with replays for team: {}", teamId);
 
-        // Verify team ownership
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamAccess(teamId, userId);
 
         List<MatchDTO.Response> matches = matchService.getMatchesWithReplays(teamId).stream()
                 .map(match -> {
@@ -185,8 +184,7 @@ public class MatchController {
         Long userId = getCurrentUserId(authentication);
         log.debug("Fetching matches for team: {} against opponent: {}", teamId, opponent);
 
-        // Verify team ownership
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamAccess(teamId, userId);
 
         List<MatchDTO.Summary> matches = matchService.getMatchesByTeamIdAndOpponent(teamId, opponent).stream()
                 .map(match -> {
@@ -216,8 +214,7 @@ public class MatchController {
         Long userId = getCurrentUserId(authentication);
         log.debug("Fetching matches for team: {} with tag: {}", teamId, tag);
 
-        // Verify team ownership
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamAccess(teamId, userId);
 
         List<MatchDTO.Summary> matches = matchService.getMatchesByTeamIdAndTag(teamId, tag).stream()
                 .map(match -> {
@@ -247,11 +244,10 @@ public class MatchController {
         Long userId = getCurrentUserId(authentication);
         log.info("Updating match: {}", id);
 
-        // Verify ownership through match's team
         Match existingMatch = matchService.getMatchById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Match not found"));
         Long teamId = existingMatch.getTeam().getId();
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamPermission(teamId, userId, Permission.EDIT_REPLAY_NOTES);
 
         Match updates = matchMapper.toEntity(request);
         Match updatedMatch = matchService.updateMatch(id, teamId, updates);
@@ -279,11 +275,10 @@ public class MatchController {
         Long userId = getCurrentUserId(authentication);
         log.info("Adding tag '{}' to match: {}", request.getTag(), id);
 
-        // Verify ownership through match's team
         Match existingMatch = matchService.getMatchById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Match not found"));
         Long teamId = existingMatch.getTeam().getId();
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamPermission(teamId, userId, Permission.EDIT_REPLAY_NOTES);
 
         Match updatedMatch = matchService.addTag(id, teamId, request.getTag());
         MatchService.MatchStats stats = matchService.getMatchStats(updatedMatch.getId());
@@ -310,11 +305,10 @@ public class MatchController {
         Long userId = getCurrentUserId(authentication);
         log.info("Removing tag '{}' from match: {}", tag, id);
 
-        // Verify ownership through match's team
         Match existingMatch = matchService.getMatchById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Match not found"));
         Long teamId = existingMatch.getTeam().getId();
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamPermission(teamId, userId, Permission.EDIT_REPLAY_NOTES);
 
         Match updatedMatch = matchService.removeTag(id, teamId, tag);
         MatchService.MatchStats stats = matchService.getMatchStats(updatedMatch.getId());
@@ -339,11 +333,10 @@ public class MatchController {
         Long userId = getCurrentUserId(authentication);
         log.info("Deleting match: {}", id);
 
-        // Verify ownership through match's team
         Match existingMatch = matchService.getMatchById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Match not found"));
         Long teamId = existingMatch.getTeam().getId();
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamPermission(teamId, userId, Permission.DELETE_REPLAYS);
 
         matchService.deleteMatch(id, teamId);
         return ResponseEntity.noContent().build();
@@ -365,10 +358,9 @@ public class MatchController {
         Long userId = getCurrentUserId(authentication);
         log.debug("Fetching statistics for match: {}", id);
 
-        // Verify ownership through match's team
         Match existingMatch = matchService.getMatchById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Match not found"));
-        verifyTeamOwnership(existingMatch.getTeam().getId(), userId);
+        verifyTeamAccess(existingMatch.getTeam().getId(), userId);
 
         MatchService.MatchStats stats = matchService.getMatchStats(id);
         MatchDTO.MatchStats response = matchMapper.toStatsDTO(stats);
@@ -392,8 +384,7 @@ public class MatchController {
         Long userId = getCurrentUserId(authentication);
         log.debug("Fetching team match statistics for team: {}", teamId);
 
-        // Verify team ownership
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamAccess(teamId, userId);
 
         MatchService.TeamMatchStats stats = matchService.getTeamMatchStats(teamId);
         MatchDTO.TeamMatchStatsResponse response = matchMapper.toDTO(stats);

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/ReplayController.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/ReplayController.java
@@ -7,7 +7,8 @@ import com.yeskatronics.vs_recorder_backend.entities.Replay;
 import com.yeskatronics.vs_recorder_backend.mappers.ReplayMapper;
 import com.yeskatronics.vs_recorder_backend.security.CustomUserDetailsService;
 import com.yeskatronics.vs_recorder_backend.services.ReplayService;
-import com.yeskatronics.vs_recorder_backend.services.TeamService;
+import com.yeskatronics.vs_recorder_backend.services.TeamAccessService;
+import com.yeskatronics.vs_recorder_backend.services.TeamAccessService.Permission;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +34,7 @@ public class ReplayController {
 
     private final ReplayService replayService;
     private final ReplayMapper replayMapper;
-    private final TeamService teamService;
+    private final TeamAccessService teamAccessService;
     private final CustomUserDetailsService userDetailsService;
 
     /**
@@ -45,11 +46,17 @@ public class ReplayController {
     }
 
     /**
-     * Helper method to verify team ownership
+     * Verify the caller can read the team (owner or accepted collaborator).
      */
-    private void verifyTeamOwnership(Long teamId, Long userId) {
-        teamService.getTeamByIdAndUserId(teamId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("Team not found or access denied"));
+    private void verifyTeamAccess(Long teamId, Long userId) {
+        teamAccessService.resolve(teamId, userId);
+    }
+
+    /**
+     * Verify the caller can perform a specific action on the team.
+     */
+    private void verifyTeamPermission(Long teamId, Long userId, Permission permission) {
+        teamAccessService.requirePermission(teamId, userId, permission);
     }
 
     /**
@@ -70,8 +77,7 @@ public class ReplayController {
         Long userId = getCurrentUserId(authentication);
         log.info("Creating replay from URL for team: {}", teamId);
 
-        // Verify team ownership
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamPermission(teamId, userId, Permission.ADD_REPLAYS);
 
         Replay savedReplay = replayService.createReplayFromUrl(teamId, request.getUrl());
 
@@ -113,8 +119,7 @@ public class ReplayController {
 
         Long userId = getCurrentUserId(authentication);
 
-        // Verify team ownership
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamPermission(teamId, userId, Permission.ADD_REPLAYS);
 
         ShowdownDTO.ReplayPreview preview = replayService.previewReplayFromUrl(teamId, request.getUrl());
         return ResponseEntity.ok(preview);
@@ -138,8 +143,7 @@ public class ReplayController {
         Long userId = getCurrentUserId(authentication);
         log.info("Creating replay for team: {}", teamId);
 
-        // Verify team ownership
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamPermission(teamId, userId, Permission.ADD_REPLAYS);
 
         Replay replay = replayMapper.toEntity(request);
         Replay savedReplay = replayService.createReplay(replay, teamId);
@@ -166,8 +170,12 @@ public class ReplayController {
 
         return replayService.getReplayById(id)
                 .filter(replay -> {
-                    // Verify user owns the team this replay belongs to
-                    return teamService.getTeamByIdAndUserId(replay.getTeam().getId(), userId).isPresent();
+                    try {
+                        teamAccessService.resolve(replay.getTeam().getId(), userId);
+                        return true;
+                    } catch (Exception e) {
+                        return false;
+                    }
                 })
                 .map(replayMapper::toDTO)
                 .map(ResponseEntity::ok)
@@ -190,8 +198,7 @@ public class ReplayController {
         Long userId = getCurrentUserId(authentication);
         log.debug("Fetching replays for team: {}", teamId);
 
-        // Verify team ownership
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamAccess(teamId, userId);
 
         List<ReplayDTO.Summary> replays = replayService.getReplaysByTeamIdOrderedByDate(teamId).stream()
                 .map(replayMapper::toSummaryDTO)
@@ -216,8 +223,7 @@ public class ReplayController {
         Long userId = getCurrentUserId(authentication);
         log.debug("Fetching standalone replays for team: {}", teamId);
 
-        // Verify team ownership
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamAccess(teamId, userId);
 
         List<ReplayDTO.Summary> replays = replayService.getStandaloneReplays(teamId).stream()
                 .map(replayMapper::toSummaryDTO)
@@ -244,10 +250,10 @@ public class ReplayController {
 
         List<Replay> replays = replayService.getReplaysByMatchId(matchId);
 
-        // Verify ownership via first replay's team (all replays in a match belong to same team)
+        // Verify access via first replay's team (all replays in a match belong to same team)
         if (!replays.isEmpty()) {
             Long teamId = replays.get(0).getTeam().getId();
-            verifyTeamOwnership(teamId, userId);
+            verifyTeamAccess(teamId, userId);
         }
 
         List<ReplayDTO.Summary> response = replays.stream()
@@ -275,8 +281,7 @@ public class ReplayController {
         Long userId = getCurrentUserId(authentication);
         log.debug("Fetching replays with filters for team: {}", teamId);
 
-        // Verify team ownership
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamAccess(teamId, userId);
 
         List<ReplayDTO.Summary> replays = replayService.getReplaysWithFilters(
                         teamId,
@@ -310,8 +315,7 @@ public class ReplayController {
         Long userId = getCurrentUserId(authentication);
         log.debug("Fetching replays for team: {} with result: {}", teamId, result);
 
-        // Verify team ownership
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamAccess(teamId, userId);
 
         List<ReplayDTO.Summary> replays = replayService.getReplaysByTeamIdAndResult(teamId, result).stream()
                 .map(replayMapper::toSummaryDTO)
@@ -338,8 +342,7 @@ public class ReplayController {
         Long userId = getCurrentUserId(authentication);
         log.debug("Fetching replays for team: {} against opponent: {}", teamId, opponent);
 
-        // Verify team ownership
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamAccess(teamId, userId);
 
         List<ReplayDTO.Summary> replays = replayService.getReplaysByTeamIdAndOpponent(teamId, opponent).stream()
                 .map(replayMapper::toSummaryDTO)
@@ -366,10 +369,9 @@ public class ReplayController {
         Long userId = getCurrentUserId(authentication);
         log.info("Updating replay: {}", id);
 
-        // Verify ownership through replay's team
         Replay existingReplay = replayService.getReplayById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Replay not found"));
-        verifyTeamOwnership(existingReplay.getTeam().getId(), userId);
+        verifyTeamPermission(existingReplay.getTeam().getId(), userId, Permission.EDIT_REPLAY_NOTES);
 
         Replay updates = replayMapper.toEntity(request);
         Replay updatedReplay = replayService.updateReplay(id, updates);
@@ -396,10 +398,9 @@ public class ReplayController {
         Long userId = getCurrentUserId(authentication);
         log.info("Associating replay: {} with match: {}", id, request.getMatchId());
 
-        // Verify ownership through replay's team
         Replay existingReplay = replayService.getReplayById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Replay not found"));
-        verifyTeamOwnership(existingReplay.getTeam().getId(), userId);
+        verifyTeamPermission(existingReplay.getTeam().getId(), userId, Permission.EDIT_REPLAY_NOTES);
 
         Replay updatedReplay = replayService.associateReplayWithMatch(id, request.getMatchId());
         ReplayDTO.Summary response = replayMapper.toSummaryDTO(updatedReplay);
@@ -423,10 +424,9 @@ public class ReplayController {
         Long userId = getCurrentUserId(authentication);
         log.info("Dissociating replay: {} from its match", id);
 
-        // Verify ownership through replay's team
         Replay existingReplay = replayService.getReplayById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Replay not found"));
-        verifyTeamOwnership(existingReplay.getTeam().getId(), userId);
+        verifyTeamPermission(existingReplay.getTeam().getId(), userId, Permission.EDIT_REPLAY_NOTES);
 
         Replay updatedReplay = replayService.dissociateReplayFromMatch(id);
         ReplayDTO.Summary response = replayMapper.toSummaryDTO(updatedReplay);
@@ -450,10 +450,9 @@ public class ReplayController {
         Long userId = getCurrentUserId(authentication);
         log.info("Deleting replay: {}", id);
 
-        // Verify ownership through replay's team
         Replay existingReplay = replayService.getReplayById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Replay not found"));
-        verifyTeamOwnership(existingReplay.getTeam().getId(), userId);
+        verifyTeamPermission(existingReplay.getTeam().getId(), userId, Permission.DELETE_REPLAYS);
 
         replayService.deleteReplay(id);
         return ResponseEntity.noContent().build();
@@ -490,8 +489,7 @@ public class ReplayController {
         Long userId = getCurrentUserId(authentication);
         log.debug("Calculating win rate for team: {}", teamId);
 
-        // Verify team ownership
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamAccess(teamId, userId);
 
         double winRate = replayService.calculateWinRate(teamId);
         return ResponseEntity.ok(winRate);

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/TeamCollaboratorController.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/TeamCollaboratorController.java
@@ -1,0 +1,175 @@
+package com.yeskatronics.vs_recorder_backend.controllers;
+
+import com.yeskatronics.vs_recorder_backend.dto.TeamCollaboratorDTO;
+import com.yeskatronics.vs_recorder_backend.dto.TeamDTO;
+import com.yeskatronics.vs_recorder_backend.entities.Team;
+import com.yeskatronics.vs_recorder_backend.entities.TeamCollaborator;
+import com.yeskatronics.vs_recorder_backend.mappers.TeamCollaboratorMapper;
+import com.yeskatronics.vs_recorder_backend.mappers.TeamMapper;
+import com.yeskatronics.vs_recorder_backend.security.CustomUserDetailsService;
+import com.yeskatronics.vs_recorder_backend.services.TeamAccessService;
+import com.yeskatronics.vs_recorder_backend.services.TeamCollaboratorService;
+import com.yeskatronics.vs_recorder_backend.services.TeamService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Endpoints for the team-collaboration feature: invites, accept/decline, listing
+ * shared teams. The "manage collaborators" UI calls /api/teams/{id}/collaborators,
+ * while the "Shared" page calls /api/collaborations/*.
+ */
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class TeamCollaboratorController {
+
+    private final TeamCollaboratorService collaboratorService;
+    private final TeamAccessService teamAccessService;
+    private final TeamService teamService;
+    private final TeamCollaboratorMapper collaboratorMapper;
+    private final TeamMapper teamMapper;
+    private final CustomUserDetailsService userDetailsService;
+
+    private Long getCurrentUserId(Authentication authentication) {
+        String username = authentication.getName();
+        return userDetailsService.getUserIdByUsername(username);
+    }
+
+    // ==================== Owner-side endpoints (per team) ====================
+
+    @GetMapping("/api/teams/{teamId}/collaborators")
+    public ResponseEntity<List<TeamCollaboratorDTO.Response>> listCollaborators(
+            @PathVariable Long teamId,
+            Authentication authentication) {
+        Long userId = getCurrentUserId(authentication);
+        teamAccessService.requireOwner(teamId, userId);
+        List<TeamCollaboratorDTO.Response> response = collaboratorService.listForTeam(teamId).stream()
+                .map(collaboratorMapper::toResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/api/teams/{teamId}/collaborators/invite")
+    public ResponseEntity<TeamCollaboratorDTO.Response> invite(
+            @PathVariable Long teamId,
+            Authentication authentication,
+            @Valid @RequestBody TeamCollaboratorDTO.InviteRequest request) {
+        Long userId = getCurrentUserId(authentication);
+        teamAccessService.requireOwner(teamId, userId);
+        log.info("Inviting collaborator {} to team {}", request.getEmail(), teamId);
+        TeamCollaborator created = collaboratorService.invite(teamId, userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(collaboratorMapper.toResponse(created));
+    }
+
+    @PatchMapping("/api/teams/{teamId}/collaborators/{collaboratorId}")
+    public ResponseEntity<TeamCollaboratorDTO.Response> updatePermissions(
+            @PathVariable Long teamId,
+            @PathVariable Long collaboratorId,
+            Authentication authentication,
+            @Valid @RequestBody TeamCollaboratorDTO.UpdatePermissionsRequest request) {
+        Long userId = getCurrentUserId(authentication);
+        teamAccessService.requireOwner(teamId, userId);
+        TeamCollaborator updated = collaboratorService.updatePermissions(collaboratorId, request);
+        return ResponseEntity.ok(collaboratorMapper.toResponse(updated));
+    }
+
+    @DeleteMapping("/api/teams/{teamId}/collaborators/{collaboratorId}")
+    public ResponseEntity<Void> remove(
+            @PathVariable Long teamId,
+            @PathVariable Long collaboratorId,
+            Authentication authentication) {
+        Long userId = getCurrentUserId(authentication);
+        teamAccessService.requireOwner(teamId, userId);
+        collaboratorService.remove(collaboratorId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/api/teams/{teamId}/collaborators/me")
+    public ResponseEntity<Void> leave(
+            @PathVariable Long teamId,
+            Authentication authentication) {
+        Long userId = getCurrentUserId(authentication);
+        collaboratorService.leave(teamId, userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ==================== Caller-side endpoints (current user) ====================
+
+    @GetMapping("/api/collaborations/shared-with-me")
+    public ResponseEntity<List<TeamDTO.Summary>> sharedWithMe(Authentication authentication) {
+        Long userId = getCurrentUserId(authentication);
+        List<Team> teams = collaboratorService.listSharedTeams(userId);
+        List<TeamDTO.Summary> response = teams.stream()
+                .map(team -> toSummaryWithRole(team, /*owner*/ false))
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/api/collaborations/sharing")
+    public ResponseEntity<List<TeamDTO.Summary>> teamsIAmSharing(Authentication authentication) {
+        Long userId = getCurrentUserId(authentication);
+        List<Team> teams = collaboratorService.listTeamsOwnerIsSharing(userId);
+        List<TeamDTO.Summary> response = teams.stream()
+                .map(team -> toSummaryWithRole(team, /*owner*/ true))
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/api/collaborations/pending-invites")
+    public ResponseEntity<List<TeamCollaboratorDTO.Response>> myPendingInvites(Authentication authentication) {
+        Long userId = getCurrentUserId(authentication);
+        String email = userDetailsService.getUserEmailById(userId);
+        List<TeamCollaboratorDTO.Response> response = collaboratorService
+                .listPendingInvitesForUser(userId, email).stream()
+                .map(collaboratorMapper::toResponse)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/api/collaborations/invites/{token}/accept")
+    public ResponseEntity<TeamCollaboratorDTO.Response> accept(
+            @PathVariable String token,
+            Authentication authentication) {
+        Long userId = getCurrentUserId(authentication);
+        TeamCollaborator accepted = collaboratorService.accept(token, userId);
+        return ResponseEntity.ok(collaboratorMapper.toResponse(accepted));
+    }
+
+    @PostMapping("/api/collaborations/invites/{token}/decline")
+    public ResponseEntity<TeamCollaboratorDTO.Response> decline(
+            @PathVariable String token,
+            Authentication authentication) {
+        Long userId = getCurrentUserId(authentication);
+        TeamCollaborator declined = collaboratorService.decline(token, userId);
+        return ResponseEntity.ok(collaboratorMapper.toResponse(declined));
+    }
+
+    /**
+     * Public preview of an invite — used by the accept page to show team/owner info
+     * before the recipient signs in. Returns 404 if the token doesn't exist.
+     */
+    @GetMapping("/api/collaborations/invites/{token}")
+    public ResponseEntity<TeamCollaboratorDTO.InvitePreview> previewInvite(@PathVariable String token) {
+        return collaboratorService.findByToken(token)
+                .map(collaboratorMapper::toPreview)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    private TeamDTO.Summary toSummaryWithRole(Team team, boolean isOwner) {
+        int replayCount = team.getReplays() != null ? team.getReplays().size() : 0;
+        int matchCount = team.getMatches() != null ? team.getMatches().size() : 0;
+        double winRate = teamService.getTeamStats(team.getId()).winRate();
+        TeamDTO.Summary summary = teamMapper.toSummaryDTO(team, replayCount, matchCount, winRate);
+        summary.setRole(isOwner ? "OWNER" : "COLLABORATOR");
+        return summary;
+    }
+}

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/TeamController.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/TeamController.java
@@ -5,6 +5,10 @@ import com.yeskatronics.vs_recorder_backend.dto.TeamDTO;
 import com.yeskatronics.vs_recorder_backend.entities.Team;
 import com.yeskatronics.vs_recorder_backend.mappers.TeamMapper;
 import com.yeskatronics.vs_recorder_backend.security.CustomUserDetailsService;
+import com.yeskatronics.vs_recorder_backend.services.TeamAccessService;
+import com.yeskatronics.vs_recorder_backend.services.TeamAccessService.Permission;
+import com.yeskatronics.vs_recorder_backend.services.TeamAccessService.Role;
+import com.yeskatronics.vs_recorder_backend.services.TeamAccessService.TeamAccess;
 import com.yeskatronics.vs_recorder_backend.services.TeamService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +36,7 @@ import java.util.stream.Collectors;
 public class TeamController {
 
     private final TeamService teamService;
+    private final TeamAccessService teamAccessService;
     private final TeamMapper teamMapper;
     private final CustomUserDetailsService userDetailsService;
 
@@ -41,6 +46,36 @@ public class TeamController {
     private Long getCurrentUserId(Authentication authentication) {
         String username = authentication.getName();
         return userDetailsService.getUserIdByUsername(username);
+    }
+
+    /**
+     * Attach role + permissions to a Response based on the caller's resolved access.
+     */
+    private void applyAccessToDto(TeamDTO.Response response, TeamAccess access) {
+        response.setRole(access.getRole().name());
+        TeamDTO.Permissions perms = new TeamDTO.Permissions();
+        perms.setCanAddReplays(teamAccessService.has(access, Permission.ADD_REPLAYS));
+        perms.setCanDeleteReplays(teamAccessService.has(access, Permission.DELETE_REPLAYS));
+        perms.setCanEditReplayNotes(teamAccessService.has(access, Permission.EDIT_REPLAY_NOTES));
+        perms.setCanEditTeamMemberNotes(teamAccessService.has(access, Permission.EDIT_TEAM_MEMBER_NOTES));
+        perms.setCanEditTeamMemberCalcs(teamAccessService.has(access, Permission.EDIT_TEAM_MEMBER_CALCS));
+        perms.setCanEditTeamDetails(teamAccessService.has(access, Permission.EDIT_TEAM_DETAILS));
+        perms.setCanEditGamePlans(teamAccessService.has(access, Permission.EDIT_GAME_PLANS));
+        response.setPermissions(perms);
+    }
+
+    /**
+     * Build a Summary DTO for a team and tag it with the caller's role. Owners get OWNER;
+     * accepted collaborators get COLLABORATOR. Used by list endpoints.
+     */
+    private TeamDTO.Summary toSummaryDtoWithRole(Team team, Long userId) {
+        int replayCount = team.getReplays() != null ? team.getReplays().size() : 0;
+        int matchCount = team.getMatches() != null ? team.getMatches().size() : 0;
+        double winRate = teamService.getTeamStats(team.getId()).winRate();
+        TeamDTO.Summary summary = teamMapper.toSummaryDTO(team, replayCount, matchCount, winRate);
+        boolean isOwner = team.getUser() != null && userId.equals(team.getUser().getId());
+        summary.setRole(isOwner ? Role.OWNER.name() : Role.COLLABORATOR.name());
+        return summary;
     }
 
     /**
@@ -63,6 +98,8 @@ public class TeamController {
         Team savedTeam = teamService.createTeam(team, userId);
         TeamService.TeamStats stats = teamService.getTeamStats(savedTeam.getId());
         TeamDTO.Response response = teamMapper.toDTO(savedTeam, stats);
+        TeamAccess access = teamAccessService.resolve(savedTeam.getId(), userId);
+        applyAccessToDto(response, access);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
@@ -83,13 +120,11 @@ public class TeamController {
         log.debug("Fetching team by ID: {}", id);
         Long userId = getCurrentUserId(authentication);
 
-        return teamService.getTeamByIdAndUserId(id, userId)
-                .map(team -> {
-                    TeamService.TeamStats stats = teamService.getTeamStats(team.getId());
-                    return teamMapper.toDTO(team, stats);
-                })
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+        TeamAccess access = teamAccessService.resolve(id, userId);
+        TeamService.TeamStats stats = teamService.getTeamStats(access.getTeam().getId());
+        TeamDTO.Response response = teamMapper.toDTO(access.getTeam(), stats);
+        applyAccessToDto(response, access);
+        return ResponseEntity.ok(response);
     }
 
     /**
@@ -102,16 +137,11 @@ public class TeamController {
     @GetMapping
     public ResponseEntity<List<TeamDTO.Summary>> getTeamsByUserId(Authentication authentication) {
         Long userId = getCurrentUserId(authentication);
-        log.debug("Fetching teams for user: {}", userId);
+        log.debug("Fetching accessible teams for user: {}", userId);
 
-        List<Team> teams = teamService.getTeamsByUserId(userId);
+        List<Team> teams = teamService.getAccessibleTeams(userId);
         List<TeamDTO.Summary> summaries = teams.stream()
-                .map(team -> {
-                    int replayCount = team.getReplays() != null ? team.getReplays().size() : 0;
-                    int matchCount = team.getMatches() != null ? team.getMatches().size() : 0;
-                    double winRate = teamService.getTeamStats(team.getId()).winRate();
-                    return teamMapper.toSummaryDTO(team, replayCount, matchCount, winRate);
-                })
+                .map(team -> toSummaryDtoWithRole(team, userId))
                 .collect(Collectors.toList());
 
         return ResponseEntity.ok(summaries);
@@ -135,12 +165,7 @@ public class TeamController {
 
         List<Team> teams = teamService.getTeamsByUserIdAndRegulation(userId, regulation);
         List<TeamDTO.Summary> summaries = teams.stream()
-                .map(team -> {
-                    int replayCount = team.getReplays() != null ? team.getReplays().size() : 0;
-                    int matchCount = team.getMatches() != null ? team.getMatches().size() : 0;
-                    double winRate = teamService.getTeamStats(team.getId()).winRate();
-                    return teamMapper.toSummaryDTO(team, replayCount, matchCount, winRate);
-                })
+                .map(team -> toSummaryDtoWithRole(team, userId))
                 .collect(Collectors.toList());
 
         return ResponseEntity.ok(summaries);
@@ -164,10 +189,13 @@ public class TeamController {
         Long userId = getCurrentUserId(authentication);
         log.info("Updating team: {} for user: {}", id, userId);
 
+        TeamAccess access = teamAccessService.requirePermission(id, userId, Permission.EDIT_TEAM_DETAILS);
+
         Team updates = teamMapper.toEntity(request);
         Team updatedTeam = teamService.updateTeam(id, userId, updates);
         TeamService.TeamStats stats = teamService.getTeamStats(updatedTeam.getId());
         TeamDTO.Response response = teamMapper.toDTO(updatedTeam, stats);
+        applyAccessToDto(response, access);
 
         return ResponseEntity.ok(response);
     }
@@ -188,6 +216,7 @@ public class TeamController {
         Long userId = getCurrentUserId(authentication);
         log.info("Deleting team: {} for user: {}", id, userId);
 
+        teamAccessService.requireOwner(id, userId);
         teamService.deleteTeam(id, userId);
         return ResponseEntity.noContent().build();
     }
@@ -208,10 +237,7 @@ public class TeamController {
         Long userId = getCurrentUserId(authentication);
         log.debug("Fetching statistics for team: {}", id);
 
-        // Verify ownership
-        if (!teamService.getTeamByIdAndUserId(id, userId).isPresent()) {
-            return ResponseEntity.notFound().build();
-        }
+        teamAccessService.resolve(id, userId);
 
         TeamService.TeamStats stats = teamService.getTeamStats(id);
         TeamDTO.TeamStats response = teamMapper.toStatsDTO(stats);
@@ -237,9 +263,11 @@ public class TeamController {
         Long userId = getCurrentUserId(authentication);
         log.info("Adding showdown username '{}' to team: {}", request.getUsername(), id);
 
+        TeamAccess access = teamAccessService.requirePermission(id, userId, Permission.EDIT_TEAM_DETAILS);
         Team updatedTeam = teamService.addShowdownUsername(id, userId, request.getUsername());
         TeamService.TeamStats stats = teamService.getTeamStats(updatedTeam.getId());
         TeamDTO.Response response = teamMapper.toDTO(updatedTeam, stats);
+        applyAccessToDto(response, access);
 
         return ResponseEntity.ok(response);
     }
@@ -262,9 +290,11 @@ public class TeamController {
         Long userId = getCurrentUserId(authentication);
         log.info("Removing showdown username '{}' from team: {}", username, id);
 
+        TeamAccess access = teamAccessService.requirePermission(id, userId, Permission.EDIT_TEAM_DETAILS);
         Team updatedTeam = teamService.removeShowdownUsername(id, userId, username);
         TeamService.TeamStats stats = teamService.getTeamStats(updatedTeam.getId());
         TeamDTO.Response response = teamMapper.toDTO(updatedTeam, stats);
+        applyAccessToDto(response, access);
 
         return ResponseEntity.ok(response);
     }
@@ -281,6 +311,7 @@ public class TeamController {
 
         Long userId = getCurrentUserId(authentication);
         log.info("Adding team {} to folder {}", id, folderId);
+        teamAccessService.resolve(id, userId); // any access — folders are per-caller
         teamService.addTeamToFolder(id, folderId, userId);
         return ResponseEntity.ok().build();
     }
@@ -297,6 +328,7 @@ public class TeamController {
 
         Long userId = getCurrentUserId(authentication);
         log.info("Removing team {} from folder {}", id, folderId);
+        teamAccessService.resolve(id, userId); // any access
         teamService.removeTeamFromFolder(id, folderId, userId);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/TeamMemberController.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/controllers/TeamMemberController.java
@@ -5,6 +5,8 @@ import com.yeskatronics.vs_recorder_backend.dto.TeamMemberDTO;
 import com.yeskatronics.vs_recorder_backend.entities.TeamMember;
 import com.yeskatronics.vs_recorder_backend.mappers.TeamMemberMapper;
 import com.yeskatronics.vs_recorder_backend.security.CustomUserDetailsService;
+import com.yeskatronics.vs_recorder_backend.services.TeamAccessService;
+import com.yeskatronics.vs_recorder_backend.services.TeamAccessService.Permission;
 import com.yeskatronics.vs_recorder_backend.services.TeamMemberService;
 import com.yeskatronics.vs_recorder_backend.services.TeamService;
 import jakarta.validation.Valid;
@@ -30,6 +32,7 @@ public class TeamMemberController {
     private final TeamMemberService teamMemberService;
     private final TeamMemberMapper teamMemberMapper;
     private final TeamService teamService;
+    private final TeamAccessService teamAccessService;
     private final CustomUserDetailsService userDetailsService;
 
     private Long getCurrentUserId(Authentication authentication) {
@@ -37,9 +40,12 @@ public class TeamMemberController {
         return userDetailsService.getUserIdByUsername(username);
     }
 
-    private void verifyTeamOwnership(Long teamId, Long userId) {
-        teamService.getTeamByIdAndUserId(teamId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("Team not found or access denied"));
+    private void verifyTeamAccess(Long teamId, Long userId) {
+        teamAccessService.resolve(teamId, userId);
+    }
+
+    private void verifyTeamPermission(Long teamId, Long userId, Permission permission) {
+        teamAccessService.requirePermission(teamId, userId, permission);
     }
 
     /**
@@ -53,7 +59,7 @@ public class TeamMemberController {
             @Valid @RequestBody TeamMemberDTO.CreateRequest request) {
 
         Long userId = getCurrentUserId(authentication);
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamPermission(teamId, userId, Permission.EDIT_TEAM_DETAILS);
 
         TeamMember teamMember = teamMemberMapper.toEntity(request);
         TeamMember saved = teamMemberService.createTeamMember(teamMember, teamId);
@@ -71,7 +77,7 @@ public class TeamMemberController {
             Authentication authentication) {
 
         Long userId = getCurrentUserId(authentication);
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamAccess(teamId, userId);
 
         List<TeamMember> members = teamMemberService.getTeamMembersByTeamId(teamId);
         return ResponseEntity.ok(teamMemberMapper.toResponseList(members));
@@ -91,7 +97,18 @@ public class TeamMemberController {
 
         TeamMember existing = teamMemberService.getTeamMemberById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Team member not found"));
-        verifyTeamOwnership(existing.getTeam().getId(), userId);
+        Long teamId = existing.getTeam().getId();
+
+        // Gate notes and calcs separately — frontend disables whichever the caller can't edit.
+        if (request.getNotes() != null) {
+            verifyTeamPermission(teamId, userId, Permission.EDIT_TEAM_MEMBER_NOTES);
+        }
+        if (request.getCalcs() != null) {
+            verifyTeamPermission(teamId, userId, Permission.EDIT_TEAM_MEMBER_CALCS);
+        }
+        if (request.getNotes() == null && request.getCalcs() == null) {
+            verifyTeamAccess(teamId, userId);
+        }
 
         TeamMember updates = new TeamMember();
         teamMemberMapper.updateEntityFromDto(request, updates);
@@ -115,7 +132,7 @@ public class TeamMemberController {
             Authentication authentication) {
 
         Long userId = getCurrentUserId(authentication);
-        verifyTeamOwnership(teamId, userId);
+        verifyTeamPermission(teamId, userId, Permission.EDIT_TEAM_DETAILS);
 
         TeamService.SyncResult result = teamService.syncTeamMembersFromPokepaste(teamId, userId);
 
@@ -142,7 +159,7 @@ public class TeamMemberController {
 
         TeamMember existing = teamMemberService.getTeamMemberById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Team member not found"));
-        verifyTeamOwnership(existing.getTeam().getId(), userId);
+        verifyTeamPermission(existing.getTeam().getId(), userId, Permission.EDIT_TEAM_DETAILS);
 
         teamMemberService.deleteTeamMember(id);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/dto/TeamCollaboratorDTO.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/dto/TeamCollaboratorDTO.java
@@ -1,0 +1,93 @@
+package com.yeskatronics.vs_recorder_backend.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * DTOs for team collaboration API operations.
+ */
+public class TeamCollaboratorDTO {
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Response {
+        private Long id;
+        private Long teamId;
+        private String teamName;
+        private Long userId;
+        private String username;
+        private String userEmail;
+        private String inviteEmail;
+        /**
+         * Active invite token for PENDING rows. Owners and the invitee themselves see this
+         * (returned only via owner-scoped or self-scoped endpoints).
+         */
+        private String inviteToken;
+        private String status;
+        private LocalDateTime acceptedAt;
+        private LocalDateTime inviteExpiresAt;
+        private LocalDateTime createdAt;
+        private boolean canAddReplays;
+        private boolean canDeleteReplays;
+        private boolean canEditReplayNotes;
+        private boolean canEditTeamMemberNotes;
+        private boolean canEditTeamMemberCalcs;
+        private boolean canEditTeamDetails;
+        private boolean canEditGamePlans;
+    }
+
+    /**
+     * Owner sends this to invite a collaborator. Permissions default to false if omitted.
+     */
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class InviteRequest {
+        @NotBlank(message = "Email is required")
+        @Email(message = "Email must be valid")
+        private String email;
+
+        private boolean canAddReplays = true;
+        private boolean canDeleteReplays = false;
+        private boolean canEditReplayNotes = true;
+        private boolean canEditTeamMemberNotes = true;
+        private boolean canEditTeamMemberCalcs = true;
+        private boolean canEditTeamDetails = false;
+        private boolean canEditGamePlans = true;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdatePermissionsRequest {
+        private boolean canAddReplays;
+        private boolean canDeleteReplays;
+        private boolean canEditReplayNotes;
+        private boolean canEditTeamMemberNotes;
+        private boolean canEditTeamMemberCalcs;
+        private boolean canEditTeamDetails;
+        private boolean canEditGamePlans;
+    }
+
+    /**
+     * Public preview of an invite token. Returned by the unauthenticated preview endpoint
+     * so the accept page can show team/owner details before the user logs in.
+     */
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class InvitePreview {
+        private String teamName;
+        private String ownerUsername;
+        private String inviteEmail;
+        private String status;
+        private LocalDateTime inviteExpiresAt;
+        private boolean expired;
+    }
+}

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/dto/TeamDTO.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/dto/TeamDTO.java
@@ -69,6 +69,10 @@ public class TeamDTO {
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
         private TeamStats stats;
+        /** "OWNER" or "COLLABORATOR" — derived per-request from the caller's access. */
+        private String role;
+        /** Permission set the caller has on this team. Owners get all booleans true. */
+        private Permissions permissions;
     }
 
     /**
@@ -88,6 +92,24 @@ public class TeamDTO {
         private int replayCount;
         private int matchCount;
         private Double winRate;
+        /** "OWNER" or "COLLABORATOR" */
+        private String role;
+    }
+
+    /**
+     * Per-collaborator permission flags. Owners receive this with every flag true.
+     */
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Permissions {
+        private boolean canAddReplays;
+        private boolean canDeleteReplays;
+        private boolean canEditReplayNotes;
+        private boolean canEditTeamMemberNotes;
+        private boolean canEditTeamMemberCalcs;
+        private boolean canEditTeamDetails;
+        private boolean canEditGamePlans;
     }
 
     /**

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/entities/TeamCollaborator.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/entities/TeamCollaborator.java
@@ -1,0 +1,132 @@
+package com.yeskatronics.vs_recorder_backend.entities;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * Grants a User collaborative access to a Team they don't own.
+ *
+ * Lifecycle:
+ *   PENDING   - invite emailed, awaiting acceptance. user may be null if the invitee
+ *               doesn't yet have an account (auto-linked on signup by matching email).
+ *   ACCEPTED  - user accepted; permissions are live.
+ *   REVOKED   - declined or owner-revoked; row kept for history but blocks re-use of the token.
+ *
+ * Per-collaborator permission booleans gate UI affordances and API mutations.
+ * The team owner always has all permissions implicitly (no row here for the owner).
+ */
+@Entity
+@Table(name = "team_collaborators",
+    indexes = {
+        @Index(name = "idx_team_collaborators_team_id", columnList = "team_id"),
+        @Index(name = "idx_team_collaborators_user_id", columnList = "user_id"),
+        @Index(name = "idx_team_collaborators_invite_token", columnList = "invite_token", unique = true),
+        @Index(name = "idx_team_collaborators_invite_email", columnList = "invite_email")
+    },
+    uniqueConstraints = {
+        // NULL user_ids are treated as distinct by SQL, so multiple pending invites for the
+        // same team but different emails are allowed; only one accepted row per (team, user).
+        @UniqueConstraint(name = "uk_team_collaborators_team_user", columnNames = {"team_id", "user_id"})
+    })
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TeamCollaborator {
+
+    public enum Status {
+        PENDING,
+        ACCEPTED,
+        REVOKED
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "team_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Team team;
+
+    /**
+     * Null until the invitee accepts (and registers if needed).
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User user;
+
+    /**
+     * Lowercased at the service layer for case-insensitive matching against User.email.
+     */
+    @NotBlank(message = "Invite email is required")
+    @Email(message = "Invite email must be valid")
+    @Column(name = "invite_email", nullable = false)
+    private String inviteEmail;
+
+    /**
+     * Secure random token used in the accept link. Nulled after acceptance so an
+     * intercepted token can't be reused.
+     */
+    @Column(name = "invite_token", length = 64, unique = true)
+    private String inviteToken;
+
+    @Column(name = "invite_expires_at", nullable = false)
+    private LocalDateTime inviteExpiresAt;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private Status status = Status.PENDING;
+
+    @Column(name = "accepted_at")
+    private LocalDateTime acceptedAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "can_add_replays", nullable = false)
+    private boolean canAddReplays = false;
+
+    @Column(name = "can_delete_replays", nullable = false)
+    private boolean canDeleteReplays = false;
+
+    @Column(name = "can_edit_replay_notes", nullable = false)
+    private boolean canEditReplayNotes = false;
+
+    @Column(name = "can_edit_team_member_notes", nullable = false)
+    private boolean canEditTeamMemberNotes = false;
+
+    @Column(name = "can_edit_team_member_calcs", nullable = false)
+    private boolean canEditTeamMemberCalcs = false;
+
+    @Column(name = "can_edit_team_details", nullable = false)
+    private boolean canEditTeamDetails = false;
+
+    @Column(name = "can_edit_game_plans", nullable = false)
+    private boolean canEditGamePlans = false;
+
+    public boolean isExpired() {
+        return inviteExpiresAt != null && LocalDateTime.now().isAfter(inviteExpiresAt);
+    }
+
+    public boolean isAcceptable() {
+        return status == Status.PENDING && !isExpired();
+    }
+}

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/exceptions/TeamAccessDeniedException.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/exceptions/TeamAccessDeniedException.java
@@ -1,0 +1,12 @@
+package com.yeskatronics.vs_recorder_backend.exceptions;
+
+/**
+ * Thrown when the current user lacks the required permission on a team
+ * (either because they are not a member at all, or because their collaborator
+ * permissions don't grant the requested action). Translates to HTTP 403.
+ */
+public class TeamAccessDeniedException extends RuntimeException {
+    public TeamAccessDeniedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/mappers/TeamCollaboratorMapper.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/mappers/TeamCollaboratorMapper.java
@@ -1,0 +1,49 @@
+package com.yeskatronics.vs_recorder_backend.mappers;
+
+import com.yeskatronics.vs_recorder_backend.dto.TeamCollaboratorDTO;
+import com.yeskatronics.vs_recorder_backend.entities.TeamCollaborator;
+import com.yeskatronics.vs_recorder_backend.entities.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TeamCollaboratorMapper {
+
+    public TeamCollaboratorDTO.Response toResponse(TeamCollaborator c) {
+        TeamCollaboratorDTO.Response r = new TeamCollaboratorDTO.Response();
+        r.setId(c.getId());
+        r.setTeamId(c.getTeam() != null ? c.getTeam().getId() : null);
+        r.setTeamName(c.getTeam() != null ? c.getTeam().getName() : null);
+        User user = c.getUser();
+        if (user != null) {
+            r.setUserId(user.getId());
+            r.setUsername(user.getUsername());
+            r.setUserEmail(user.getEmail());
+        }
+        r.setInviteEmail(c.getInviteEmail());
+        r.setInviteToken(c.getInviteToken());
+        r.setStatus(c.getStatus() != null ? c.getStatus().name() : null);
+        r.setAcceptedAt(c.getAcceptedAt());
+        r.setInviteExpiresAt(c.getInviteExpiresAt());
+        r.setCreatedAt(c.getCreatedAt());
+        r.setCanAddReplays(c.isCanAddReplays());
+        r.setCanDeleteReplays(c.isCanDeleteReplays());
+        r.setCanEditReplayNotes(c.isCanEditReplayNotes());
+        r.setCanEditTeamMemberNotes(c.isCanEditTeamMemberNotes());
+        r.setCanEditTeamMemberCalcs(c.isCanEditTeamMemberCalcs());
+        r.setCanEditTeamDetails(c.isCanEditTeamDetails());
+        r.setCanEditGamePlans(c.isCanEditGamePlans());
+        return r;
+    }
+
+    public TeamCollaboratorDTO.InvitePreview toPreview(TeamCollaborator c) {
+        TeamCollaboratorDTO.InvitePreview p = new TeamCollaboratorDTO.InvitePreview();
+        p.setTeamName(c.getTeam() != null ? c.getTeam().getName() : null);
+        p.setOwnerUsername(c.getTeam() != null && c.getTeam().getUser() != null
+                ? c.getTeam().getUser().getUsername() : null);
+        p.setInviteEmail(c.getInviteEmail());
+        p.setStatus(c.getStatus() != null ? c.getStatus().name() : null);
+        p.setInviteExpiresAt(c.getInviteExpiresAt());
+        p.setExpired(c.isExpired());
+        return p;
+    }
+}

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/repositories/GamePlanRepository.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/repositories/GamePlanRepository.java
@@ -52,6 +52,12 @@ public interface GamePlanRepository extends JpaRepository<GamePlan, Long> {
     Optional<GamePlan> findFirstByTeamIdAndUserId(Long teamId, Long userId);
 
     /**
+     * Find any game plan attached to the team, regardless of creator. Used when serving
+     * collaborators: the team has a single shared plan, not one per user.
+     */
+    Optional<GamePlan> findFirstByTeamId(Long teamId);
+
+    /**
      * Check if a game plan already exists for a team and user
      * @param teamId the team ID
      * @param userId the user ID

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/repositories/TeamCollaboratorRepository.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/repositories/TeamCollaboratorRepository.java
@@ -1,0 +1,50 @@
+package com.yeskatronics.vs_recorder_backend.repositories;
+
+import com.yeskatronics.vs_recorder_backend.entities.Team;
+import com.yeskatronics.vs_recorder_backend.entities.TeamCollaborator;
+import com.yeskatronics.vs_recorder_backend.entities.TeamCollaborator.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TeamCollaboratorRepository extends JpaRepository<TeamCollaborator, Long> {
+
+    List<TeamCollaborator> findByTeamId(Long teamId);
+
+    List<TeamCollaborator> findByTeamIdAndStatus(Long teamId, Status status);
+
+    Optional<TeamCollaborator> findByTeamIdAndUserIdAndStatus(Long teamId, Long userId, Status status);
+
+    Optional<TeamCollaborator> findByInviteToken(String inviteToken);
+
+    List<TeamCollaborator> findByUserIdAndStatus(Long userId, Status status);
+
+    @Query("SELECT c FROM TeamCollaborator c WHERE LOWER(c.inviteEmail) = LOWER(:email) AND c.status = :status")
+    List<TeamCollaborator> findByInviteEmailIgnoreCaseAndStatus(@Param("email") String email,
+                                                                @Param("status") Status status);
+
+    @Query("SELECT c FROM TeamCollaborator c WHERE c.team.id = :teamId AND LOWER(c.inviteEmail) = LOWER(:email) AND c.status = :status")
+    Optional<TeamCollaborator> findByTeamIdAndInviteEmailIgnoreCaseAndStatus(@Param("teamId") Long teamId,
+                                                                             @Param("email") String email,
+                                                                             @Param("status") Status status);
+
+    boolean existsByTeamIdAndUserIdAndStatus(Long teamId, Long userId, Status status);
+
+    /**
+     * Teams the user has accepted access to (does not include teams the user owns).
+     */
+    @Query("SELECT c.team FROM TeamCollaborator c WHERE c.user.id = :userId AND c.status = 'ACCEPTED'")
+    List<Team> findAcceptedTeamsByUserId(@Param("userId") Long userId);
+
+    /**
+     * Teams the user owns that have at least one active (PENDING or ACCEPTED) collaborator row.
+     */
+    @Query("SELECT DISTINCT c.team FROM TeamCollaborator c " +
+           "WHERE c.team.user.id = :ownerUserId AND c.status IN ('PENDING','ACCEPTED')")
+    List<Team> findTeamsOwnedByUserWithCollaborators(@Param("ownerUserId") Long ownerUserId);
+}

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/repositories/TeamRepository.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/repositories/TeamRepository.java
@@ -65,4 +65,12 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 
     @Query("SELECT t FROM Team t JOIN t.folders f WHERE f.id = :folderId")
     List<Team> findByFolderId(Long folderId);
+
+    /**
+     * All teams the user can access: those they own plus those they are an accepted collaborator on.
+     */
+    @Query("SELECT DISTINCT t FROM Team t WHERE t.user.id = :userId " +
+           "OR EXISTS (SELECT 1 FROM TeamCollaborator c " +
+           "           WHERE c.team = t AND c.user.id = :userId AND c.status = 'ACCEPTED')")
+    List<Team> findAllAccessibleByUserId(Long userId);
 }

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/security/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/security/CustomUserDetailsService.java
@@ -47,4 +47,13 @@ public class CustomUserDetailsService implements UserDetailsService {
                 .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
         return user.getId();
     }
+
+    /**
+     * Get user email by ID
+     */
+    public String getUserEmailById(Long userId) {
+        return userRepository.findById(userId)
+                .map(User::getEmail)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + userId));
+    }
 }

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/security/SecurityConfig.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/security/SecurityConfig.java
@@ -55,6 +55,10 @@ public class SecurityConfig {
                         // Public export code lookup (read-only, import still requires auth)
                         .requestMatchers(HttpMethod.GET, "/api/export/{code}").permitAll()
 
+                        // Public invite preview — the accept page calls this before login
+                        // so it can show team/owner details. The accept POST still needs auth.
+                        .requestMatchers(HttpMethod.GET, "/api/collaborations/invites/{token}").permitAll()
+
                         // All other endpoints require authentication
                         .anyRequest().authenticated()
                 )

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/EmailService.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/EmailService.java
@@ -50,6 +50,20 @@ public class EmailService {
         log.info("Password changed confirmation sent to: {}***", maskEmail(toEmail));
     }
 
+    /**
+     * Send a team collaboration invite. {@code acceptUrl} is the deep link to the accept
+     * page (e.g. {frontend-url}/invites/{token}); the page lets the recipient sign in or
+     * create an account before accepting.
+     */
+    public void sendCollaborationInvite(String toEmail, String ownerUsername, String teamName,
+                                        String acceptUrl) {
+        String subject = appName + " - " + ownerUsername + " invited you to collaborate on " + teamName;
+        String htmlBody = buildCollaborationInviteHtmlEmail(ownerUsername, teamName, acceptUrl);
+
+        sendEmail(toEmail, subject, htmlBody);
+        log.info("Collaboration invite for team '{}' sent to: {}***", teamName, maskEmail(toEmail));
+    }
+
     private void sendEmail(String toEmail, String subject, String htmlBody) {
         try {
             CreateEmailOptions options = CreateEmailOptions.builder()
@@ -125,6 +139,55 @@ public class EmailService {
             </body>
             </html>
             """.formatted(username, resetUrl, resetUrl, resetUrl);
+    }
+
+    private String buildCollaborationInviteHtmlEmail(String ownerUsername, String teamName, String acceptUrl) {
+        return """
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta charset="UTF-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            </head>
+            <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;\s
+                         line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+                <div style="background: linear-gradient(135deg, #667eea 0%%, #764ba2 100%%);\s
+                            padding: 30px; border-radius: 10px 10px 0 0; text-align: center;">
+                    <h1 style="color: white; margin: 0; font-size: 28px;">VS Recorder</h1>
+                </div>
+                <div style="background: #ffffff; padding: 30px; border: 1px solid #e0e0e0;\s
+                            border-top: none; border-radius: 0 0 10px 10px;">
+                    <h2 style="color: #333; margin-top: 0;">You've been invited to collaborate</h2>
+                    <p><strong>%s</strong> invited you to collaborate on the VS Recorder team\s
+                       <strong>%s</strong>. You'll be able to view replays, stats, notes, and damage calcs,
+                       and add to the team based on the permissions %s grants you.</p>
+                    <div style="text-align: center; margin: 30px 0;">
+                        <a href="%s"\s
+                           style="background: linear-gradient(135deg, #667eea 0%%, #764ba2 100%%);\s
+                                  color: white; padding: 14px 30px; text-decoration: none;\s
+                                  border-radius: 5px; font-weight: bold; display: inline-block;">
+                            Accept invite
+                        </a>
+                    </div>
+                    <p style="color: #666; font-size: 14px;">
+                        This invite expires in <strong>7 days</strong>. If you don't have a VS Recorder
+                        account yet, you'll be prompted to sign up — your invite will accept automatically.
+                    </p>
+                    <p style="color: #666; font-size: 14px;">
+                        If you weren't expecting this, you can ignore the email — no action is required.
+                    </p>
+                    <hr style="border: none; border-top: 1px solid #e0e0e0; margin: 30px 0;">
+                    <p style="color: #999; font-size: 12px; text-align: center;">
+                        If the button doesn't work, copy and paste this link into your browser:<br>
+                        <a href="%s" style="color: #667eea; word-break: break-all;">%s</a>
+                    </p>
+                </div>
+                <p style="color: #999; font-size: 12px; text-align: center; margin-top: 20px;">
+                    VS Recorder - Pokemon VGC Replay Analysis
+                </p>
+            </body>
+            </html>
+            """.formatted(ownerUsername, teamName, ownerUsername, acceptUrl, acceptUrl, acceptUrl);
     }
 
     private String buildPasswordChangedHtmlEmail(String username) {

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/GamePlanService.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/GamePlanService.java
@@ -3,9 +3,11 @@ package com.yeskatronics.vs_recorder_backend.services;
 import com.yeskatronics.vs_recorder_backend.entities.GamePlan;
 import com.yeskatronics.vs_recorder_backend.entities.GamePlanTeam;
 import com.yeskatronics.vs_recorder_backend.entities.User;
+import com.yeskatronics.vs_recorder_backend.exceptions.TeamAccessDeniedException;
 import com.yeskatronics.vs_recorder_backend.repositories.GamePlanRepository;
 import com.yeskatronics.vs_recorder_backend.repositories.GamePlanTeamRepository;
 import com.yeskatronics.vs_recorder_backend.repositories.UserRepository;
+import com.yeskatronics.vs_recorder_backend.services.TeamAccessService.Permission;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,6 +32,36 @@ public class GamePlanService {
     private final GamePlanTeamRepository gamePlanTeamRepository;
     private final UserRepository userRepository;
     private final TeamService teamService;
+    private final TeamAccessService teamAccessService;
+
+    /**
+     * Resolve a game plan and verify the caller can access it.
+     *
+     * Access rules (a) the caller created the plan, OR (b) the plan is attached to a
+     * team and the caller is owner/accepted-collaborator of that team. For mutations
+     * (requireEdit=true) collaborators must additionally have {@link Permission#EDIT_GAME_PLANS}.
+     */
+    private GamePlan requirePlanAccess(Long planId, Long userId, boolean requireEdit) {
+        GamePlan plan = gamePlanRepository.findById(planId)
+                .orElseThrow(() -> new IllegalArgumentException("Game plan not found"));
+
+        boolean isCreator = plan.getUser() != null && userId.equals(plan.getUser().getId());
+        if (isCreator) {
+            return plan;
+        }
+
+        Long teamId = plan.getTeamId();
+        if (teamId == null) {
+            throw new TeamAccessDeniedException("Game plan not accessible to user " + userId);
+        }
+
+        if (requireEdit) {
+            teamAccessService.requirePermission(teamId, userId, Permission.EDIT_GAME_PLANS);
+        } else {
+            teamAccessService.resolve(teamId, userId);
+        }
+        return plan;
+    }
 
     /**
      * Bump the team's updatedAt when a matchup-planner edit lands. Safe no-op
@@ -87,7 +119,11 @@ public class GamePlanService {
     @Transactional(readOnly = true)
     public Optional<GamePlan> getGamePlanByIdAndUserId(Long id, Long userId) {
         log.debug("Fetching game plan by ID: {} for user: {}", id, userId);
-        return gamePlanRepository.findByIdAndUserId(id, userId);
+        try {
+            return Optional.of(requirePlanAccess(id, userId, false));
+        } catch (IllegalArgumentException | TeamAccessDeniedException e) {
+            return Optional.empty();
+        }
     }
 
     /**
@@ -114,8 +150,7 @@ public class GamePlanService {
     public GamePlan updateGamePlan(Long id, Long userId, GamePlan updates) {
         log.info("Updating game plan ID: {}", id);
 
-        GamePlan existingPlan = gamePlanRepository.findByIdAndUserId(id, userId)
-                .orElseThrow(() -> new IllegalArgumentException("Game plan not found or not owned by user"));
+        GamePlan existingPlan = requirePlanAccess(id, userId, true);
 
         // Update fields
         if (updates.getName() != null) {
@@ -142,9 +177,7 @@ public class GamePlanService {
     public void deleteGamePlan(Long id, Long userId) {
         log.info("Deleting game plan ID: {}", id);
 
-        GamePlan gamePlan = gamePlanRepository.findByIdAndUserId(id, userId)
-                .orElseThrow(() -> new IllegalArgumentException("Game plan not found or not owned by user"));
-
+        GamePlan gamePlan = requirePlanAccess(id, userId, true);
         gamePlanRepository.delete(gamePlan);
         log.info("Game plan deleted successfully: {}", id);
     }
@@ -169,8 +202,10 @@ public class GamePlanService {
      */
     @Transactional(readOnly = true)
     public Optional<GamePlan> getGamePlanByTeamIdAndUserId(Long teamId, Long userId) {
-        log.debug("Fetching game plan for team ID: {} and user ID: {}", teamId, userId);
-        return gamePlanRepository.findFirstByTeamIdAndUserId(teamId, userId);
+        log.debug("Fetching game plan for team ID: {} (caller: {})", teamId, userId);
+        // Shared semantics: any caller with team access sees the team's plan, not their own.
+        teamAccessService.resolve(teamId, userId);
+        return gamePlanRepository.findFirstByTeamId(teamId);
     }
 
     /**
@@ -184,16 +219,18 @@ public class GamePlanService {
      * @return the existing or newly created game plan
      */
     public GamePlan getOrCreateGamePlanForTeam(Long teamId, Long userId, String defaultName) {
-        log.info("Getting or creating game plan for team ID: {} and user ID: {}", teamId, userId);
+        log.info("Getting or creating game plan for team ID: {} (caller: {})", teamId, userId);
 
-        // Check if a game plan already exists for this team
-        Optional<GamePlan> existingPlan = gamePlanRepository.findFirstByTeamIdAndUserId(teamId, userId);
+        // Reading is gated on team access; creating additionally requires EDIT_GAME_PLANS for collaborators.
+        Optional<GamePlan> existingPlan = gamePlanRepository.findFirstByTeamId(teamId);
         if (existingPlan.isPresent()) {
+            teamAccessService.resolve(teamId, userId);
             log.info("Found existing game plan ID: {} for team ID: {}", existingPlan.get().getId(), teamId);
             return existingPlan.get();
         }
 
-        // Create a new game plan
+        teamAccessService.requirePermission(teamId, userId, Permission.EDIT_GAME_PLANS);
+
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found with ID: " + userId));
 
@@ -221,8 +258,7 @@ public class GamePlanService {
     public GamePlanTeam addTeamToGamePlan(Long gamePlanId, Long userId, GamePlanTeam team) {
         log.info("Adding team to game plan ID: {}", gamePlanId);
 
-        GamePlan gamePlan = gamePlanRepository.findByIdAndUserId(gamePlanId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("Game plan not found or not owned by user"));
+        GamePlan gamePlan = requirePlanAccess(gamePlanId, userId, true);
 
         // New teams go to position 0; shift existing teams down by 1.
         List<GamePlanTeam> existing = gamePlanTeamRepository.findByGamePlanIdOrderByPositionAscIdAsc(gamePlanId);
@@ -280,8 +316,7 @@ public class GamePlanService {
     public void reorderTeams(Long gamePlanId, Long userId, List<Long> orderedIds) {
         log.info("Reordering {} teams for game plan ID: {}", orderedIds.size(), gamePlanId);
 
-        GamePlan plan = gamePlanRepository.findByIdAndUserId(gamePlanId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("Game plan not found or not owned by user"));
+        GamePlan plan = requirePlanAccess(gamePlanId, userId, true);
 
         List<GamePlanTeam> teams = gamePlanTeamRepository.findByGamePlanIdOrderByPositionAscIdAsc(gamePlanId);
         if (teams.size() != orderedIds.size()) {
@@ -317,8 +352,7 @@ public class GamePlanService {
     public GamePlanTeam updateGamePlanTeam(Long id, Long gamePlanId, Long userId, GamePlanTeam updates) {
         log.info("Updating game plan team ID: {}", id);
 
-        GamePlan plan = gamePlanRepository.findByIdAndUserId(gamePlanId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("Game plan not found or not owned by user"));
+        GamePlan plan = requirePlanAccess(gamePlanId, userId, true);
 
         GamePlanTeam existingTeam = gamePlanTeamRepository.findByIdAndGamePlanId(id, gamePlanId)
                 .orElseThrow(() -> new IllegalArgumentException("Team not found in this game plan"));
@@ -352,8 +386,7 @@ public class GamePlanService {
     public void deleteGamePlanTeam(Long id, Long gamePlanId, Long userId) {
         log.info("Deleting game plan team ID: {}", id);
 
-        GamePlan plan = gamePlanRepository.findByIdAndUserId(gamePlanId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("Game plan not found or not owned by user"));
+        GamePlan plan = requirePlanAccess(gamePlanId, userId, true);
 
         GamePlanTeam team = gamePlanTeamRepository.findByIdAndGamePlanId(id, gamePlanId)
                 .orElseThrow(() -> new IllegalArgumentException("Team not found in this game plan"));
@@ -379,8 +412,7 @@ public class GamePlanService {
                                        GamePlanTeam.TeamComposition composition) {
         log.info("Adding composition to game plan team ID: {}", teamId);
 
-        GamePlan plan = gamePlanRepository.findByIdAndUserId(gamePlanId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("Game plan not found or not owned by user"));
+        GamePlan plan = requirePlanAccess(gamePlanId, userId, true);
 
         GamePlanTeam team = gamePlanTeamRepository.findByIdAndGamePlanId(teamId, gamePlanId)
                 .orElseThrow(() -> new IllegalArgumentException("Team not found in this game plan"));
@@ -409,8 +441,7 @@ public class GamePlanService {
                                           int index, GamePlanTeam.TeamComposition composition) {
         log.info("Updating composition {} in game plan team ID: {}", index, teamId);
 
-        GamePlan plan = gamePlanRepository.findByIdAndUserId(gamePlanId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("Game plan not found or not owned by user"));
+        GamePlan plan = requirePlanAccess(gamePlanId, userId, true);
 
         GamePlanTeam team = gamePlanTeamRepository.findByIdAndGamePlanId(teamId, gamePlanId)
                 .orElseThrow(() -> new IllegalArgumentException("Team not found in this game plan"));
@@ -441,8 +472,7 @@ public class GamePlanService {
     public GamePlanTeam deleteComposition(Long teamId, Long gamePlanId, Long userId, int index) {
         log.info("Deleting composition {} from game plan team ID: {}", index, teamId);
 
-        GamePlan plan = gamePlanRepository.findByIdAndUserId(gamePlanId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("Game plan not found or not owned by user"));
+        GamePlan plan = requirePlanAccess(gamePlanId, userId, true);
 
         GamePlanTeam team = gamePlanTeamRepository.findByIdAndGamePlanId(teamId, gamePlanId)
                 .orElseThrow(() -> new IllegalArgumentException("Team not found in this game plan"));

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/TeamAccessService.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/TeamAccessService.java
@@ -1,0 +1,127 @@
+package com.yeskatronics.vs_recorder_backend.services;
+
+import com.yeskatronics.vs_recorder_backend.entities.Team;
+import com.yeskatronics.vs_recorder_backend.entities.TeamCollaborator;
+import com.yeskatronics.vs_recorder_backend.entities.TeamCollaborator.Status;
+import com.yeskatronics.vs_recorder_backend.exceptions.TeamAccessDeniedException;
+import com.yeskatronics.vs_recorder_backend.repositories.TeamCollaboratorRepository;
+import com.yeskatronics.vs_recorder_backend.repositories.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Central authority for "can this user do X on this team?"
+ *
+ * Replaces the scattered {@code teamRepository.findByIdAndUserId(...)} pattern with a
+ * single check that knows about both ownership and collaborator membership.
+ *
+ * The owner of a team always has all permissions; collaborators get the booleans on
+ * their {@link TeamCollaborator} row.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class TeamAccessService {
+
+    public enum Role { OWNER, COLLABORATOR }
+
+    public enum Permission {
+        ADD_REPLAYS,
+        DELETE_REPLAYS,
+        EDIT_REPLAY_NOTES,
+        EDIT_TEAM_MEMBER_NOTES,
+        EDIT_TEAM_MEMBER_CALCS,
+        EDIT_TEAM_DETAILS,
+        EDIT_GAME_PLANS
+    }
+
+    private final TeamRepository teamRepository;
+    private final TeamCollaboratorRepository collaboratorRepository;
+
+    /**
+     * Look up the team and verify the user has at least read access. Throws
+     * {@link TeamAccessDeniedException} if the team doesn't exist or the user is
+     * neither owner nor an accepted collaborator.
+     */
+    public TeamAccess resolve(Long teamId, Long userId) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new TeamAccessDeniedException(
+                        "Team not found or access denied: " + teamId));
+
+        if (team.getUser() != null && userId.equals(team.getUser().getId())) {
+            return new TeamAccess(team, Role.OWNER, null);
+        }
+
+        TeamCollaborator membership = collaboratorRepository
+                .findByTeamIdAndUserIdAndStatus(teamId, userId, Status.ACCEPTED)
+                .orElseThrow(() -> new TeamAccessDeniedException(
+                        "User " + userId + " does not have access to team " + teamId));
+
+        return new TeamAccess(team, Role.COLLABORATOR, membership);
+    }
+
+    /**
+     * Owner-only gate. Throws if the caller is not the team owner.
+     */
+    public TeamAccess requireOwner(Long teamId, Long userId) {
+        TeamAccess access = resolve(teamId, userId);
+        if (access.getRole() != Role.OWNER) {
+            throw new TeamAccessDeniedException(
+                    "Owner-only action attempted by collaborator on team " + teamId);
+        }
+        return access;
+    }
+
+    public void requirePermission(TeamAccess access, Permission permission) {
+        if (!has(access, permission)) {
+            throw new TeamAccessDeniedException(
+                    "Missing permission " + permission + " on team " + access.getTeam().getId());
+        }
+    }
+
+    /**
+     * Convenience: look up + check in one call.
+     */
+    public TeamAccess requirePermission(Long teamId, Long userId, Permission permission) {
+        TeamAccess access = resolve(teamId, userId);
+        requirePermission(access, permission);
+        return access;
+    }
+
+    public boolean has(TeamAccess access, Permission permission) {
+        if (access.getRole() == Role.OWNER) {
+            return true;
+        }
+        TeamCollaborator m = access.getMembership();
+        if (m == null) {
+            return false;
+        }
+        return switch (permission) {
+            case ADD_REPLAYS -> m.isCanAddReplays();
+            case DELETE_REPLAYS -> m.isCanDeleteReplays();
+            case EDIT_REPLAY_NOTES -> m.isCanEditReplayNotes();
+            case EDIT_TEAM_MEMBER_NOTES -> m.isCanEditTeamMemberNotes();
+            case EDIT_TEAM_MEMBER_CALCS -> m.isCanEditTeamMemberCalcs();
+            case EDIT_TEAM_DETAILS -> m.isCanEditTeamDetails();
+            case EDIT_GAME_PLANS -> m.isCanEditGamePlans();
+        };
+    }
+
+    @Value
+    public static class TeamAccess {
+        Team team;
+        Role role;
+        /**
+         * Null when the caller is the owner.
+         */
+        TeamCollaborator membership;
+
+        public boolean isOwner() {
+            return role == Role.OWNER;
+        }
+    }
+}

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/TeamCollaboratorService.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/TeamCollaboratorService.java
@@ -1,0 +1,271 @@
+package com.yeskatronics.vs_recorder_backend.services;
+
+import com.yeskatronics.vs_recorder_backend.dto.TeamCollaboratorDTO;
+import com.yeskatronics.vs_recorder_backend.entities.Team;
+import com.yeskatronics.vs_recorder_backend.entities.TeamCollaborator;
+import com.yeskatronics.vs_recorder_backend.entities.TeamCollaborator.Status;
+import com.yeskatronics.vs_recorder_backend.entities.User;
+import com.yeskatronics.vs_recorder_backend.exceptions.TeamAccessDeniedException;
+import com.yeskatronics.vs_recorder_backend.repositories.TeamCollaboratorRepository;
+import com.yeskatronics.vs_recorder_backend.repositories.TeamRepository;
+import com.yeskatronics.vs_recorder_backend.repositories.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Business logic for team collaborator invites and memberships.
+ *
+ * Owner actions (invite, update permissions, remove) are owner-gated; the controller
+ * verifies ownership before calling. Accept/decline are caller-scoped via the token.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class TeamCollaboratorService {
+
+    private static final int INVITE_TOKEN_BYTES = 32;
+    private static final int INVITE_TTL_DAYS = 7;
+
+    private final TeamCollaboratorRepository collaboratorRepository;
+    private final TeamRepository teamRepository;
+    private final UserRepository userRepository;
+    private final EmailService emailService;
+
+    @Value("${app.frontend-url:http://localhost:3000}")
+    private String frontendUrl;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    /**
+     * Invite (or re-invite) a user by email. Idempotent: if a PENDING invite already exists
+     * for the same email on this team, re-send the email without creating a duplicate row.
+     * If the email belongs to the team owner, reject as a self-invite.
+     */
+    public TeamCollaborator invite(Long teamId, Long ownerUserId,
+                                   TeamCollaboratorDTO.InviteRequest request) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new IllegalArgumentException("Team not found: " + teamId));
+
+        String email = request.getEmail().trim().toLowerCase();
+
+        // Self-invite guard
+        User owner = team.getUser();
+        if (owner != null && owner.getEmail() != null && owner.getEmail().equalsIgnoreCase(email)) {
+            throw new IllegalArgumentException("Cannot invite the team owner");
+        }
+
+        // If the invitee already has an accepted membership, reject as a duplicate
+        Optional<User> existingUser = userRepository.findByEmail(email);
+        if (existingUser.isPresent()) {
+            boolean alreadyMember = collaboratorRepository.existsByTeamIdAndUserIdAndStatus(
+                    teamId, existingUser.get().getId(), Status.ACCEPTED);
+            if (alreadyMember) {
+                throw new IllegalArgumentException("User is already a collaborator on this team");
+            }
+        }
+
+        // Re-use an existing PENDING row for this email/team to keep invites idempotent
+        Optional<TeamCollaborator> existingPending = collaboratorRepository
+                .findByTeamIdAndInviteEmailIgnoreCaseAndStatus(teamId, email, Status.PENDING);
+
+        TeamCollaborator collaborator = existingPending.orElseGet(TeamCollaborator::new);
+        collaborator.setTeam(team);
+        collaborator.setInviteEmail(email);
+        collaborator.setStatus(Status.PENDING);
+        collaborator.setInviteToken(generateInviteToken());
+        collaborator.setInviteExpiresAt(LocalDateTime.now().plusDays(INVITE_TTL_DAYS));
+        existingUser.ifPresent(collaborator::setUser);
+        applyPermissions(collaborator, request);
+
+        TeamCollaborator saved = collaboratorRepository.save(collaborator);
+        sendInviteEmail(saved, team, owner);
+        return saved;
+    }
+
+    /**
+     * Accept an invite using the token. The caller must be either (a) the registered user
+     * already attached to the row, or (b) anyone whose email matches the invite email.
+     */
+    public TeamCollaborator accept(String token, Long currentUserId) {
+        TeamCollaborator invite = collaboratorRepository.findByInviteToken(token)
+                .orElseThrow(() -> new IllegalArgumentException("Invite not found or already used"));
+
+        if (invite.getStatus() != Status.PENDING) {
+            throw new IllegalArgumentException("Invite is no longer pending (status: " + invite.getStatus() + ")");
+        }
+        if (invite.isExpired()) {
+            throw new IllegalArgumentException("Invite has expired");
+        }
+
+        User user = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found: " + currentUserId));
+
+        // If row is locked to a specific user (auto-attached on signup or previous invite), enforce that.
+        if (invite.getUser() != null && !Objects.equals(invite.getUser().getId(), user.getId())) {
+            throw new TeamAccessDeniedException("Invite is for a different user");
+        }
+        // Otherwise require email match
+        if (invite.getUser() == null && !invite.getInviteEmail().equalsIgnoreCase(user.getEmail())) {
+            throw new TeamAccessDeniedException("Invite email does not match your account email");
+        }
+
+        invite.setUser(user);
+        invite.setStatus(Status.ACCEPTED);
+        invite.setAcceptedAt(LocalDateTime.now());
+        invite.setInviteToken(null); // burn the token so it can't be replayed
+        return collaboratorRepository.save(invite);
+    }
+
+    public TeamCollaborator decline(String token, Long currentUserId) {
+        TeamCollaborator invite = collaboratorRepository.findByInviteToken(token)
+                .orElseThrow(() -> new IllegalArgumentException("Invite not found or already used"));
+        if (invite.getStatus() != Status.PENDING) {
+            throw new IllegalArgumentException("Invite is no longer pending");
+        }
+        // Allow the recipient (matched by email or attached user) to decline.
+        if (currentUserId != null) {
+            userRepository.findById(currentUserId).ifPresent(user -> {
+                if (invite.getUser() != null && !Objects.equals(invite.getUser().getId(), user.getId())) {
+                    throw new TeamAccessDeniedException("Invite is for a different user");
+                }
+                if (invite.getUser() == null && !invite.getInviteEmail().equalsIgnoreCase(user.getEmail())) {
+                    throw new TeamAccessDeniedException("Invite email does not match your account email");
+                }
+            });
+        }
+        invite.setStatus(Status.REVOKED);
+        invite.setInviteToken(null);
+        return collaboratorRepository.save(invite);
+    }
+
+    public TeamCollaborator updatePermissions(Long collaboratorId,
+                                              TeamCollaboratorDTO.UpdatePermissionsRequest request) {
+        TeamCollaborator collaborator = collaboratorRepository.findById(collaboratorId)
+                .orElseThrow(() -> new IllegalArgumentException("Collaborator not found"));
+        collaborator.setCanAddReplays(request.isCanAddReplays());
+        collaborator.setCanDeleteReplays(request.isCanDeleteReplays());
+        collaborator.setCanEditReplayNotes(request.isCanEditReplayNotes());
+        collaborator.setCanEditTeamMemberNotes(request.isCanEditTeamMemberNotes());
+        collaborator.setCanEditTeamMemberCalcs(request.isCanEditTeamMemberCalcs());
+        collaborator.setCanEditTeamDetails(request.isCanEditTeamDetails());
+        collaborator.setCanEditGamePlans(request.isCanEditGamePlans());
+        return collaboratorRepository.save(collaborator);
+    }
+
+    public void remove(Long collaboratorId) {
+        if (!collaboratorRepository.existsById(collaboratorId)) {
+            throw new IllegalArgumentException("Collaborator not found");
+        }
+        collaboratorRepository.deleteById(collaboratorId);
+    }
+
+    /**
+     * Collaborator removes themselves from a team they no longer want to be part of.
+     */
+    public void leave(Long teamId, Long userId) {
+        TeamCollaborator membership = collaboratorRepository
+                .findByTeamIdAndUserIdAndStatus(teamId, userId, Status.ACCEPTED)
+                .orElseThrow(() -> new IllegalArgumentException("You are not a collaborator on this team"));
+        collaboratorRepository.delete(membership);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TeamCollaborator> listForTeam(Long teamId) {
+        return collaboratorRepository.findByTeamId(teamId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Team> listSharedTeams(Long userId) {
+        return collaboratorRepository.findAcceptedTeamsByUserId(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Team> listTeamsOwnerIsSharing(Long ownerUserId) {
+        return collaboratorRepository.findTeamsOwnedByUserWithCollaborators(ownerUserId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TeamCollaborator> listPendingInvitesForUser(Long userId, String email) {
+        // Two ways pending invites can match the current user:
+        //   1. the row was pre-linked to user_id (a previous accept attempt or admin link)
+        //   2. invite_email matches the user's email (most common path)
+        List<TeamCollaborator> byUser = collaboratorRepository.findByUserIdAndStatus(userId, Status.PENDING);
+        List<TeamCollaborator> byEmail = collaboratorRepository
+                .findByInviteEmailIgnoreCaseAndStatus(email, Status.PENDING);
+        // Merge, deduping by id
+        return java.util.stream.Stream.concat(byUser.stream(), byEmail.stream())
+                .collect(java.util.stream.Collectors.toMap(TeamCollaborator::getId, c -> c, (a, b) -> a))
+                .values()
+                .stream()
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<TeamCollaborator> findByToken(String token) {
+        return collaboratorRepository.findByInviteToken(token);
+    }
+
+    /**
+     * Called from AuthService.register so that anyone who was invited before they had an
+     * account is auto-added to the team when they sign up with the matching email.
+     */
+    public void autoAcceptOnSignup(Long userId, String email) {
+        if (email == null) return;
+        List<TeamCollaborator> pending = collaboratorRepository
+                .findByInviteEmailIgnoreCaseAndStatus(email, Status.PENDING);
+        if (pending.isEmpty()) return;
+
+        User user = userRepository.findById(userId).orElse(null);
+        if (user == null) return;
+
+        LocalDateTime now = LocalDateTime.now();
+        for (TeamCollaborator invite : pending) {
+            if (invite.isExpired()) continue;
+            invite.setUser(user);
+            invite.setStatus(Status.ACCEPTED);
+            invite.setAcceptedAt(now);
+            invite.setInviteToken(null);
+            collaboratorRepository.save(invite);
+            log.info("Auto-accepted invite {} for new user {} on team {}",
+                    invite.getId(), userId, invite.getTeam().getId());
+        }
+    }
+
+    private void applyPermissions(TeamCollaborator c, TeamCollaboratorDTO.InviteRequest r) {
+        c.setCanAddReplays(r.isCanAddReplays());
+        c.setCanDeleteReplays(r.isCanDeleteReplays());
+        c.setCanEditReplayNotes(r.isCanEditReplayNotes());
+        c.setCanEditTeamMemberNotes(r.isCanEditTeamMemberNotes());
+        c.setCanEditTeamMemberCalcs(r.isCanEditTeamMemberCalcs());
+        c.setCanEditTeamDetails(r.isCanEditTeamDetails());
+        c.setCanEditGamePlans(r.isCanEditGamePlans());
+    }
+
+    private String generateInviteToken() {
+        byte[] bytes = new byte[INVITE_TOKEN_BYTES];
+        secureRandom.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private void sendInviteEmail(TeamCollaborator invite, Team team, User owner) {
+        String acceptUrl = frontendUrl + "/invites/" + invite.getInviteToken();
+        String ownerName = owner != null ? owner.getUsername() : "Someone";
+        try {
+            emailService.sendCollaborationInvite(invite.getInviteEmail(), ownerName, team.getName(), acceptUrl);
+        } catch (RuntimeException e) {
+            // We don't want a flaky mail provider to roll back the invite row.
+            log.error("Failed to send collaboration invite email for invite {}: {}", invite.getId(), e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/TeamExportService.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/TeamExportService.java
@@ -35,6 +35,7 @@ public class TeamExportService {
     private final MatchRepository matchRepository;
     private final GamePlanRepository gamePlanRepository;
     private final TeamMemberRepository teamMemberRepository;
+    private final TeamAccessService teamAccessService;
     private final ObjectMapper objectMapper;
 
     // Rate limiting: 10 codes per user per day
@@ -54,9 +55,8 @@ public class TeamExportService {
     public ExportDTO.ExportData compileExportData(Long teamId, Long userId, ExportDTO.ExportOptions options) {
         log.info("Compiling export data for team ID: {} with options: {}", teamId, options);
 
-        // Fetch team and verify ownership
-        Team team = teamRepository.findByIdAndUserId(teamId, userId)
-                .orElseThrow(() -> new IllegalArgumentException("Team not found or not owned by user"));
+        // Allow any caller with team access to export (collaborators can fork into their own copy).
+        Team team = teamAccessService.resolve(teamId, userId).getTeam();
 
         // Build team data
         ExportDTO.TeamData teamData = ExportDTO.TeamData.builder()

--- a/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/TeamService.java
+++ b/backend/src/main/java/com/yeskatronics/vs_recorder_backend/services/TeamService.java
@@ -129,6 +129,16 @@ public class TeamService {
     }
 
     /**
+     * All teams the user can access: those they own plus those shared with them as an
+     * accepted collaborator.
+     */
+    @Transactional(readOnly = true)
+    public List<Team> getAccessibleTeams(Long userId) {
+        log.debug("Fetching all accessible teams for user ID: {}", userId);
+        return teamRepository.findAllAccessibleByUserId(userId);
+    }
+
+    /**
      * Get teams by user and regulation
      *
      * @param userId the user ID
@@ -163,11 +173,11 @@ public class TeamService {
      * @throws IllegalArgumentException if team not found or not owned by user
      */
     public Team updateTeam(Long id, Long userId, Team updates) {
-        log.info("Updating team ID: {} for user ID: {}", id, userId);
+        log.info("Updating team ID: {} (caller: {})", id, userId);
 
-        Team existingTeam = teamRepository.findByIdAndUserId(id, userId)
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "Team not found with ID: " + id + " for user: " + userId));
+        // Authorization happens in the controller via TeamAccessService; here we just load the team.
+        Team existingTeam = teamRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Team not found with ID: " + id));
 
         // Update fields if provided
         if (updates.getName() != null && !updates.getName().isEmpty()) {
@@ -208,11 +218,10 @@ public class TeamService {
      * @return the updated team
      */
     public Team addShowdownUsername(Long teamId, Long userId, String username) {
-        log.info("Adding showdown username '{}' to team ID: {}", username, teamId);
+        log.info("Adding showdown username '{}' to team ID: {} (caller: {})", username, teamId, userId);
 
-        Team team = teamRepository.findByIdAndUserId(teamId, userId)
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "Team not found with ID: " + teamId + " for user: " + userId));
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new IllegalArgumentException("Team not found with ID: " + teamId));
 
         team.addShowdownUsername(username);
         Team savedTeam = teamRepository.save(team);
@@ -229,11 +238,10 @@ public class TeamService {
      * @return the updated team
      */
     public Team removeShowdownUsername(Long teamId, Long userId, String username) {
-        log.info("Removing showdown username '{}' from team ID: {}", username, teamId);
+        log.info("Removing showdown username '{}' from team ID: {} (caller: {})", username, teamId, userId);
 
-        Team team = teamRepository.findByIdAndUserId(teamId, userId)
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "Team not found with ID: " + teamId + " for user: " + userId));
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new IllegalArgumentException("Team not found with ID: " + teamId));
 
         team.removeShowdownUsername(username);
         Team savedTeam = teamRepository.save(team);
@@ -249,11 +257,10 @@ public class TeamService {
      * @throws IllegalArgumentException if team not found or not owned by user
      */
     public void deleteTeam(Long id, Long userId) {
-        log.info("Deleting team ID: {} for user ID: {}", id, userId);
+        log.info("Deleting team ID: {} (caller: {})", id, userId);
 
-        if (!teamRepository.existsByIdAndUserId(id, userId)) {
-            throw new IllegalArgumentException(
-                    "Team not found with ID: " + id + " for user: " + userId);
+        if (!teamRepository.existsById(id)) {
+            throw new IllegalArgumentException("Team not found with ID: " + id);
         }
 
         teamRepository.deleteById(id);
@@ -321,11 +328,10 @@ public class TeamService {
      * @return SyncResult with the updated member list and change details
      */
     public SyncResult syncTeamMembersFromPokepaste(Long teamId, Long userId) {
-        log.info("Syncing team members from pokepaste for team ID: {} user ID: {}", teamId, userId);
+        log.info("Syncing team members from pokepaste for team ID: {} (caller: {})", teamId, userId);
 
-        Team team = teamRepository.findByIdAndUserId(teamId, userId)
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "Team not found with ID: " + teamId + " for user: " + userId));
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new IllegalArgumentException("Team not found with ID: " + teamId));
 
         if (team.getPokepaste() == null || team.getPokepaste().isEmpty()) {
             throw new IllegalArgumentException("Team has no pokepaste URL");
@@ -414,9 +420,8 @@ public class TeamService {
     public Team addTeamToFolder(Long teamId, Long folderId, Long userId) {
         log.info("Adding team {} to folder {} for user {}", teamId, folderId, userId);
 
-        Team team = teamRepository.findByIdAndUserId(teamId, userId)
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "Team not found with ID: " + teamId + " for user: " + userId));
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new IllegalArgumentException("Team not found with ID: " + teamId));
 
         Folder folder = folderRepository.findByIdAndUserId(folderId, userId)
                 .orElseThrow(() -> new IllegalArgumentException(
@@ -432,9 +437,8 @@ public class TeamService {
     public Team removeTeamFromFolder(Long teamId, Long folderId, Long userId) {
         log.info("Removing team {} from folder {} for user {}", teamId, folderId, userId);
 
-        Team team = teamRepository.findByIdAndUserId(teamId, userId)
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "Team not found with ID: " + teamId + " for user: " + userId));
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new IllegalArgumentException("Team not found with ID: " + teamId));
 
         Folder folder = folderRepository.findByIdAndUserId(folderId, userId)
                 .orElseThrow(() -> new IllegalArgumentException(

--- a/backend/src/test/java/com/yeskatronics/vs_recorder_backend/services/GamePlanServiceTest.java
+++ b/backend/src/test/java/com/yeskatronics/vs_recorder_backend/services/GamePlanServiceTest.java
@@ -3,6 +3,7 @@ package com.yeskatronics.vs_recorder_backend.services;
 import com.yeskatronics.vs_recorder_backend.entities.GamePlan;
 import com.yeskatronics.vs_recorder_backend.entities.GamePlanTeam;
 import com.yeskatronics.vs_recorder_backend.entities.User;
+import com.yeskatronics.vs_recorder_backend.exceptions.TeamAccessDeniedException;
 import com.yeskatronics.vs_recorder_backend.repositories.GamePlanRepository;
 import com.yeskatronics.vs_recorder_backend.repositories.GamePlanTeamRepository;
 import com.yeskatronics.vs_recorder_backend.repositories.UserRepository;
@@ -544,7 +545,7 @@ class GamePlanServiceTest {
         updates.setName("Hacked Name");
 
         // User2 tries to update User1's plan
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(TeamAccessDeniedException.class, () -> {
             gamePlanService.updateGamePlan(saved.getId(), testUser2.getId(), updates);
         }, "User should not update another user's game plan");
     }
@@ -556,7 +557,7 @@ class GamePlanServiceTest {
         GamePlan saved = gamePlanService.createGamePlan(gamePlan, testUser1.getId());
 
         // User2 tries to delete User1's plan
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(TeamAccessDeniedException.class, () -> {
             gamePlanService.deleteGamePlan(saved.getId(), testUser2.getId());
         }, "User should not delete another user's game plan");
     }

--- a/backend/src/test/java/com/yeskatronics/vs_recorder_backend/services/TeamAccessServiceTest.java
+++ b/backend/src/test/java/com/yeskatronics/vs_recorder_backend/services/TeamAccessServiceTest.java
@@ -1,0 +1,144 @@
+package com.yeskatronics.vs_recorder_backend.services;
+
+import com.yeskatronics.vs_recorder_backend.entities.Team;
+import com.yeskatronics.vs_recorder_backend.entities.TeamCollaborator;
+import com.yeskatronics.vs_recorder_backend.entities.TeamCollaborator.Status;
+import com.yeskatronics.vs_recorder_backend.entities.User;
+import com.yeskatronics.vs_recorder_backend.exceptions.TeamAccessDeniedException;
+import com.yeskatronics.vs_recorder_backend.repositories.TeamCollaboratorRepository;
+import com.yeskatronics.vs_recorder_backend.repositories.TeamRepository;
+import com.yeskatronics.vs_recorder_backend.repositories.UserRepository;
+import com.yeskatronics.vs_recorder_backend.services.TeamAccessService.Permission;
+import com.yeskatronics.vs_recorder_backend.services.TeamAccessService.Role;
+import com.yeskatronics.vs_recorder_backend.services.TeamAccessService.TeamAccess;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class TeamAccessServiceTest {
+
+    @Autowired private TeamAccessService teamAccessService;
+    @Autowired private TeamRepository teamRepository;
+    @Autowired private TeamCollaboratorRepository collaboratorRepository;
+    @Autowired private UserRepository userRepository;
+
+    private User owner;
+    private User collaboratorUser;
+    private User stranger;
+    private Team team;
+
+    @BeforeEach
+    void setUp() {
+        owner = saveUser("owner-tas", "owner-tas@example.com");
+        collaboratorUser = saveUser("collab-tas", "collab-tas@example.com");
+        stranger = saveUser("stranger-tas", "stranger-tas@example.com");
+
+        team = new Team();
+        team.setUser(owner);
+        team.setName("Access Service Test Team");
+        team.setPokepaste("https://pokepast.es/example");
+        team = teamRepository.save(team);
+    }
+
+    @Test
+    void resolve_ownerSeesAllPermissions() {
+        TeamAccess access = teamAccessService.resolve(team.getId(), owner.getId());
+        assertEquals(Role.OWNER, access.getRole());
+        for (Permission p : Permission.values()) {
+            assertTrue(teamAccessService.has(access, p), "owner should have " + p);
+        }
+    }
+
+    @Test
+    void resolve_collaboratorPermissionsAreMasked() {
+        TeamCollaborator membership = new TeamCollaborator();
+        membership.setTeam(team);
+        membership.setUser(collaboratorUser);
+        membership.setInviteEmail(collaboratorUser.getEmail());
+        membership.setStatus(Status.ACCEPTED);
+        membership.setInviteExpiresAt(LocalDateTime.now().plusDays(7));
+        membership.setCanAddReplays(true);
+        membership.setCanEditReplayNotes(true);
+        // deletes + team details off
+        collaboratorRepository.save(membership);
+
+        TeamAccess access = teamAccessService.resolve(team.getId(), collaboratorUser.getId());
+        assertEquals(Role.COLLABORATOR, access.getRole());
+        assertTrue(teamAccessService.has(access, Permission.ADD_REPLAYS));
+        assertTrue(teamAccessService.has(access, Permission.EDIT_REPLAY_NOTES));
+        assertFalse(teamAccessService.has(access, Permission.DELETE_REPLAYS));
+        assertFalse(teamAccessService.has(access, Permission.EDIT_TEAM_DETAILS));
+    }
+
+    @Test
+    void resolve_pendingCollaboratorIsDenied() {
+        TeamCollaborator pending = new TeamCollaborator();
+        pending.setTeam(team);
+        pending.setUser(collaboratorUser);
+        pending.setInviteEmail(collaboratorUser.getEmail());
+        pending.setStatus(Status.PENDING);
+        pending.setInviteExpiresAt(LocalDateTime.now().plusDays(7));
+        pending.setInviteToken("pending-token");
+        pending.setCanAddReplays(true);
+        collaboratorRepository.save(pending);
+
+        assertThrows(TeamAccessDeniedException.class,
+                () -> teamAccessService.resolve(team.getId(), collaboratorUser.getId()));
+    }
+
+    @Test
+    void resolve_strangerIsDenied() {
+        assertThrows(TeamAccessDeniedException.class,
+                () -> teamAccessService.resolve(team.getId(), stranger.getId()));
+    }
+
+    @Test
+    void requirePermission_throwsWhenCollaboratorLacksFlag() {
+        TeamCollaborator membership = new TeamCollaborator();
+        membership.setTeam(team);
+        membership.setUser(collaboratorUser);
+        membership.setInviteEmail(collaboratorUser.getEmail());
+        membership.setStatus(Status.ACCEPTED);
+        membership.setInviteExpiresAt(LocalDateTime.now().plusDays(7));
+        // notes only; no team-details
+        membership.setCanEditTeamMemberNotes(true);
+        collaboratorRepository.save(membership);
+
+        TeamAccess access = teamAccessService.resolve(team.getId(), collaboratorUser.getId());
+        assertDoesNotThrow(() -> teamAccessService.requirePermission(access, Permission.EDIT_TEAM_MEMBER_NOTES));
+        assertThrows(TeamAccessDeniedException.class,
+                () -> teamAccessService.requirePermission(access, Permission.EDIT_TEAM_DETAILS));
+    }
+
+    @Test
+    void requireOwner_rejectsCollaborator() {
+        TeamCollaborator membership = new TeamCollaborator();
+        membership.setTeam(team);
+        membership.setUser(collaboratorUser);
+        membership.setInviteEmail(collaboratorUser.getEmail());
+        membership.setStatus(Status.ACCEPTED);
+        membership.setInviteExpiresAt(LocalDateTime.now().plusDays(7));
+        membership.setCanEditTeamDetails(true); // even with all perms, owner-only is gated
+        collaboratorRepository.save(membership);
+
+        assertThrows(TeamAccessDeniedException.class,
+                () -> teamAccessService.requireOwner(team.getId(), collaboratorUser.getId()));
+        assertDoesNotThrow(() -> teamAccessService.requireOwner(team.getId(), owner.getId()));
+    }
+
+    private User saveUser(String username, String email) {
+        User u = new User();
+        u.setUsername(username);
+        u.setEmail(email);
+        u.setPasswordHash("hashed_password");
+        return userRepository.save(u);
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,8 @@ import TypeChartPage from "./pages/Team/TypeChartPage";
 import SpeedTiersPage from "./pages/Team/SpeedTiersPage";
 import RootRoute from "./components/auth/RootRoute";
 import PublicRoute from "./components/auth/PublicRoute";
+import SharedHubPage from "./pages/Collaboration/SharedHubPage";
+import AcceptInvitePage from "./pages/Collaboration/AcceptInvitePage";
 import * as pokemonService from "./services/pokemonService";
 
 export default function App() {
@@ -73,6 +75,8 @@ export default function App() {
           <Route index element={<HomePage />} />
           <Route path="about" element={<AboutPage />} />
           <Route path="announcements" element={<AnnouncementsPage />} />
+          <Route path="shared" element={<SharedHubPage />} />
+          <Route path="invites/:token" element={<AcceptInvitePage />} />
           <Route path="team/:teamId" element={<TeamLayout />}>
             <Route index element={<Navigate to="replays" replace />} />
             <Route path="replays" element={<ReplaysPage />} />

--- a/frontend/src/components/auth/PermissionGate.tsx
+++ b/frontend/src/components/auth/PermissionGate.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+import { useTeamPermissions, type Permission } from "../../hooks/useTeamPermissions";
+
+interface PermissionGateProps {
+  perm: Permission;
+  children: ReactNode;
+  /** Render this when denied. Default: render nothing. */
+  fallback?: ReactNode;
+  /**
+   * When true, render the children regardless but pass a `disabled` data attribute
+   * via the wrapping span so callers can style the disabled state inline. Most
+   * callers should leave this off and use `fallback`.
+   */
+  renderDisabled?: boolean;
+}
+
+/**
+ * Hide (or disable) a UI affordance when the active team's permissions don't allow it.
+ * Owners always pass. Renders `fallback` (default nothing) when the caller lacks the perm.
+ */
+export function PermissionGate({ perm, children, fallback = null, renderDisabled = false }: PermissionGateProps) {
+  const { can, isLoaded } = useTeamPermissions();
+  if (!isLoaded) {
+    return <>{children}</>;
+  }
+  if (can(perm)) {
+    return <>{children}</>;
+  }
+  if (renderDisabled) {
+    return <span data-permission-denied>{children}</span>;
+  }
+  return <>{fallback}</>;
+}
+
+export default PermissionGate;

--- a/frontend/src/components/modals/ManageCollaboratorsModal.tsx
+++ b/frontend/src/components/modals/ManageCollaboratorsModal.tsx
@@ -1,0 +1,339 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Mail, Trash2, ChevronDown, ChevronUp, RefreshCw } from "lucide-react";
+import { Modal } from "../ui/modal";
+import { collaboratorApi, type InvitePayload } from "../../services/api/collaboratorApi";
+import {
+  ALL_PERMISSIONS_FALSE,
+  type Collaborator,
+  type Team,
+  type TeamPermissions,
+} from "../../types";
+
+interface ManageCollaboratorsModalProps {
+  isOpen: boolean;
+  team: Team;
+  onClose: () => void;
+}
+
+const PERMISSION_LABELS: { key: keyof TeamPermissions; label: string; hint?: string }[] = [
+  { key: "canAddReplays", label: "Add replays" },
+  { key: "canDeleteReplays", label: "Delete replays" },
+  { key: "canEditReplayNotes", label: "Edit replay & match notes" },
+  { key: "canEditTeamMemberNotes", label: "Edit Pokemon notes" },
+  { key: "canEditTeamMemberCalcs", label: "Edit Pokemon calcs" },
+  { key: "canEditTeamDetails", label: "Edit team details" },
+  { key: "canEditGamePlans", label: "Edit game plans" },
+];
+
+const DEFAULT_INVITE_PERMISSIONS: TeamPermissions = {
+  canAddReplays: true,
+  canDeleteReplays: false,
+  canEditReplayNotes: true,
+  canEditTeamMemberNotes: true,
+  canEditTeamMemberCalcs: true,
+  canEditTeamDetails: false,
+  canEditGamePlans: true,
+};
+
+const ManageCollaboratorsModal: React.FC<ManageCollaboratorsModalProps> = ({
+  isOpen,
+  team,
+  onClose,
+}) => {
+  const [collaborators, setCollaborators] = useState<Collaborator[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Invite form
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [invitePerms, setInvitePerms] = useState<TeamPermissions>(DEFAULT_INVITE_PERMISSIONS);
+  const [inviteSubmitting, setInviteSubmitting] = useState(false);
+
+  // Inline edit state — collaboratorId -> draft permissions
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editDraft, setEditDraft] = useState<TeamPermissions>(ALL_PERMISSIONS_FALSE);
+  const [savingId, setSavingId] = useState<number | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await collaboratorApi.listForTeam(team.id);
+      setCollaborators(list);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load collaborators");
+    } finally {
+      setLoading(false);
+    }
+  }, [team.id]);
+
+  useEffect(() => {
+    if (isOpen) {
+      refresh();
+      setInviteEmail("");
+      setInvitePerms(DEFAULT_INVITE_PERMISSIONS);
+      setEditingId(null);
+    }
+  }, [isOpen, refresh]);
+
+  const handleInvite = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!inviteEmail.trim()) return;
+    setInviteSubmitting(true);
+    setError(null);
+    try {
+      const payload: InvitePayload = { email: inviteEmail.trim(), ...invitePerms };
+      await collaboratorApi.invite(team.id, payload);
+      setInviteEmail("");
+      setInvitePerms(DEFAULT_INVITE_PERMISSIONS);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to send invite");
+    } finally {
+      setInviteSubmitting(false);
+    }
+  };
+
+  const handleResend = async (c: Collaborator) => {
+    // Re-invite reuses the same row + permissions and sends a fresh email.
+    setError(null);
+    try {
+      await collaboratorApi.invite(team.id, {
+        email: c.inviteEmail,
+        canAddReplays: c.canAddReplays,
+        canDeleteReplays: c.canDeleteReplays,
+        canEditReplayNotes: c.canEditReplayNotes,
+        canEditTeamMemberNotes: c.canEditTeamMemberNotes,
+        canEditTeamMemberCalcs: c.canEditTeamMemberCalcs,
+        canEditTeamDetails: c.canEditTeamDetails,
+        canEditGamePlans: c.canEditGamePlans,
+      });
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to resend invite");
+    }
+  };
+
+  const handleRemove = async (c: Collaborator) => {
+    if (!confirm(`Remove ${c.username ?? c.inviteEmail} from this team?`)) return;
+    setError(null);
+    try {
+      await collaboratorApi.remove(team.id, c.id);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to remove collaborator");
+    }
+  };
+
+  const startEdit = (c: Collaborator) => {
+    setEditingId(c.id);
+    setEditDraft({
+      canAddReplays: c.canAddReplays,
+      canDeleteReplays: c.canDeleteReplays,
+      canEditReplayNotes: c.canEditReplayNotes,
+      canEditTeamMemberNotes: c.canEditTeamMemberNotes,
+      canEditTeamMemberCalcs: c.canEditTeamMemberCalcs,
+      canEditTeamDetails: c.canEditTeamDetails,
+      canEditGamePlans: c.canEditGamePlans,
+    });
+  };
+
+  const saveEdit = async (collaboratorId: number) => {
+    setSavingId(collaboratorId);
+    setError(null);
+    try {
+      await collaboratorApi.updatePermissions(team.id, collaboratorId, editDraft);
+      setEditingId(null);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update permissions");
+    } finally {
+      setSavingId(null);
+    }
+  };
+
+  const accepted = collaborators.filter((c) => c.status === "ACCEPTED");
+  const pending = collaborators.filter((c) => c.status === "PENDING");
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} className="max-w-2xl p-6 sm:p-8">
+      <h2 className="mb-2 text-xl font-semibold text-gray-800 dark:text-white/90">
+        Manage Collaborators
+      </h2>
+      <p className="mb-6 text-sm text-gray-500 dark:text-gray-400">
+        Invite others to <span className="font-medium text-gray-700 dark:text-gray-300">{team.name}</span>{" "}
+        and control what they can do.
+      </p>
+
+      {error && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-2.5 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      {/* Invite form */}
+      <form onSubmit={handleInvite} className="mb-6 rounded-lg border border-gray-200 p-4 dark:border-gray-700">
+        <h3 className="mb-3 text-sm font-medium text-gray-700 dark:text-gray-300">Invite a collaborator</h3>
+        <div className="flex gap-2">
+          <input
+            type="email"
+            required
+            value={inviteEmail}
+            onChange={(e) => setInviteEmail(e.target.value)}
+            placeholder="email@example.com"
+            className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
+          />
+          <button
+            type="submit"
+            disabled={inviteSubmitting || !inviteEmail.trim()}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Mail className="h-4 w-4" />
+            {inviteSubmitting ? "Sending..." : "Send invite"}
+          </button>
+        </div>
+        <div className="mt-3 grid grid-cols-1 gap-1.5 sm:grid-cols-2">
+          {PERMISSION_LABELS.map(({ key, label }) => (
+            <label key={key} className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+              <input
+                type="checkbox"
+                checked={invitePerms[key]}
+                onChange={(e) => setInvitePerms((p) => ({ ...p, [key]: e.target.checked }))}
+                className="h-4 w-4 rounded border-gray-300 text-brand-500 focus:ring-brand-500"
+              />
+              {label}
+            </label>
+          ))}
+        </div>
+      </form>
+
+      {/* Accepted collaborators */}
+      <div className="mb-6">
+        <h3 className="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+          Active collaborators ({accepted.length})
+        </h3>
+        {loading ? (
+          <div className="rounded-lg border border-gray-200 px-4 py-6 text-center text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+            Loading...
+          </div>
+        ) : accepted.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">No collaborators yet.</p>
+        ) : (
+          <ul className="divide-y divide-gray-200 rounded-lg border border-gray-200 dark:divide-gray-700 dark:border-gray-700">
+            {accepted.map((c) => (
+              <li key={c.id} className="px-4 py-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate font-medium text-gray-800 dark:text-gray-100">
+                      {c.username ?? c.inviteEmail}
+                    </div>
+                    <div className="truncate text-xs text-gray-500 dark:text-gray-400">{c.userEmail ?? c.inviteEmail}</div>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={() => (editingId === c.id ? setEditingId(null) : startEdit(c))}
+                      className="rounded-lg border border-gray-300 px-2 py-1 text-xs text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+                    >
+                      {editingId === c.id ? (
+                        <span className="inline-flex items-center gap-1"><ChevronUp className="h-3 w-3" /> Close</span>
+                      ) : (
+                        <span className="inline-flex items-center gap-1"><ChevronDown className="h-3 w-3" /> Permissions</span>
+                      )}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleRemove(c)}
+                      title="Remove collaborator"
+                      className="rounded-lg border border-red-200 px-2 py-1 text-xs text-red-600 hover:bg-red-50 dark:border-red-900/40 dark:text-red-400 dark:hover:bg-red-900/20"
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </button>
+                  </div>
+                </div>
+                {editingId === c.id && (
+                  <div className="mt-3 grid grid-cols-1 gap-1.5 rounded-lg bg-gray-50 p-3 sm:grid-cols-2 dark:bg-gray-800/50">
+                    {PERMISSION_LABELS.map(({ key, label }) => (
+                      <label key={key} className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                        <input
+                          type="checkbox"
+                          checked={editDraft[key]}
+                          onChange={(e) => setEditDraft((d) => ({ ...d, [key]: e.target.checked }))}
+                          className="h-4 w-4 rounded border-gray-300 text-brand-500 focus:ring-brand-500"
+                        />
+                        {label}
+                      </label>
+                    ))}
+                    <div className="col-span-full mt-2 flex justify-end">
+                      <button
+                        type="button"
+                        onClick={() => saveEdit(c.id)}
+                        disabled={savingId === c.id}
+                        className="rounded-lg bg-brand-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-brand-600 disabled:opacity-50"
+                      >
+                        {savingId === c.id ? "Saving..." : "Save"}
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Pending invites */}
+      <div className="mb-6">
+        <h3 className="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
+          Pending invites ({pending.length})
+        </h3>
+        {pending.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">No pending invites.</p>
+        ) : (
+          <ul className="divide-y divide-gray-200 rounded-lg border border-gray-200 dark:divide-gray-700 dark:border-gray-700">
+            {pending.map((c) => (
+              <li key={c.id} className="flex items-center justify-between gap-3 px-4 py-3">
+                <div className="min-w-0">
+                  <div className="truncate font-medium text-gray-800 dark:text-gray-100">{c.inviteEmail}</div>
+                  <div className="text-xs text-gray-500 dark:text-gray-400">
+                    Expires {new Date(c.inviteExpiresAt).toLocaleDateString()}
+                  </div>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    onClick={() => handleResend(c)}
+                    title="Resend invite email"
+                    className="rounded-lg border border-gray-300 px-2 py-1 text-xs text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+                  >
+                    <RefreshCw className="h-3 w-3" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleRemove(c)}
+                    title="Revoke invite"
+                    className="rounded-lg border border-red-200 px-2 py-1 text-xs text-red-600 hover:bg-red-50 dark:border-red-900/40 dark:text-red-400 dark:hover:bg-red-900/20"
+                  >
+                    <Trash2 className="h-3 w-3" />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+        >
+          Close
+        </button>
+      </div>
+    </Modal>
+  );
+};
+
+export default ManageCollaboratorsModal;

--- a/frontend/src/components/team/BestOf3Card.tsx
+++ b/frontend/src/components/team/BestOf3Card.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { ExternalLink, Edit3, Save, Tag, Trophy, CheckCircle2, AlertCircle, MessageSquare } from "lucide-react";
 import PokemonTeam from "../pokemon/PokemonTeam";
 import PokemonSprite from "../pokemon/PokemonSprite";
+import PermissionGate from "../auth/PermissionGate";
 import TagInput from "../form/TagInput";
 import { cleanPokemonName } from "../../utils/pokemonNameUtils";
 import { formatTimeAgo } from "../../utils/timeUtils";
@@ -294,14 +295,16 @@ export default function BestOf3Card({ match, onUpdateNotes, onUpdateTags }: Best
             Tags
           </h4>
           {!isEditingTags && (
-            <button
-              type="button"
-              onClick={() => setIsEditingTags(true)}
-              className="rounded p-1 text-gray-400 transition-colors hover:text-blue-600 dark:hover:text-blue-400"
-              title="Edit tags"
-            >
-              <Edit3 className="h-3 w-3" />
-            </button>
+            <PermissionGate perm="canEditReplayNotes">
+              <button
+                type="button"
+                onClick={() => setIsEditingTags(true)}
+                className="rounded p-1 text-gray-400 transition-colors hover:text-blue-600 dark:hover:text-blue-400"
+                title="Edit tags"
+              >
+                <Edit3 className="h-3 w-3" />
+              </button>
+            </PermissionGate>
           )}
         </div>
 
@@ -361,14 +364,16 @@ export default function BestOf3Card({ match, onUpdateNotes, onUpdateTags }: Best
             Match Notes
           </h4>
           {!isEditingNotes && (
-            <button
-              type="button"
-              onClick={() => setIsEditingNotes(true)}
-              className="rounded p-1 text-gray-400 transition-colors hover:text-blue-600 dark:hover:text-blue-400"
-              title="Edit notes"
-            >
-              <Edit3 className="h-3 w-3" />
-            </button>
+            <PermissionGate perm="canEditReplayNotes">
+              <button
+                type="button"
+                onClick={() => setIsEditingNotes(true)}
+                className="rounded p-1 text-gray-400 transition-colors hover:text-blue-600 dark:hover:text-blue-400"
+                title="Edit notes"
+              >
+                <Edit3 className="h-3 w-3" />
+              </button>
+            </PermissionGate>
           )}
         </div>
 

--- a/frontend/src/components/team/CompactReplayCard.tsx
+++ b/frontend/src/components/team/CompactReplayCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Trash2, Save, MessageSquare, ExternalLink, ChevronDown } from "lucide-react";
 import PokemonTeam from "../pokemon/PokemonTeam";
+import PermissionGate from "../auth/PermissionGate";
 import { getResultDisplay } from "../../utils/resultUtils";
 import { formatTimeAgo } from "../../utils/timeUtils";
 import { getOpponentPokemonFromReplay } from "../../utils/pokemonNameUtils";
@@ -98,29 +99,33 @@ const CompactReplayCard: React.FC<CompactReplayCardProps> = ({
 
         {/* Action Buttons */}
         <div className="ml-3 flex items-center gap-1">
-          <button
-            type="button"
-            onClick={() => onStartEditNote(replay)}
-            disabled={isEditingNote || isSavingNote}
-            className="rounded-md p-1.5 text-gray-400 transition-colors hover:bg-blue-50 hover:text-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-blue-500/10 dark:hover:text-blue-400"
-            title="Edit notes"
-          >
-            <MessageSquare className="h-3.5 w-3.5" />
-          </button>
+          <PermissionGate perm="canEditReplayNotes">
+            <button
+              type="button"
+              onClick={() => onStartEditNote(replay)}
+              disabled={isEditingNote || isSavingNote}
+              className="rounded-md p-1.5 text-gray-400 transition-colors hover:bg-blue-50 hover:text-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-blue-500/10 dark:hover:text-blue-400"
+              title="Edit notes"
+            >
+              <MessageSquare className="h-3.5 w-3.5" />
+            </button>
+          </PermissionGate>
 
-          <button
-            type="button"
-            onClick={() => onDelete(replay.id)}
-            disabled={isDeleting || isEditingNote}
-            className="rounded-md p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-red-500/10 dark:hover:text-red-400"
-            title="Delete replay"
-          >
-            {isDeleting ? (
-              <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-gray-300 border-t-transparent dark:border-gray-600" />
-            ) : (
-              <Trash2 className="h-3.5 w-3.5" />
-            )}
-          </button>
+          <PermissionGate perm="canDeleteReplays">
+            <button
+              type="button"
+              onClick={() => onDelete(replay.id)}
+              disabled={isDeleting || isEditingNote}
+              className="rounded-md p-1.5 text-gray-400 transition-colors hover:bg-red-50 hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-red-500/10 dark:hover:text-red-400"
+              title="Delete replay"
+            >
+              {isDeleting ? (
+                <div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-gray-300 border-t-transparent dark:border-gray-600" />
+              ) : (
+                <Trash2 className="h-3.5 w-3.5" />
+              )}
+            </button>
+          </PermissionGate>
         </div>
       </div>
 

--- a/frontend/src/components/team/GameCard.tsx
+++ b/frontend/src/components/team/GameCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ExternalLink, ChevronDown, MessageSquare, Save, CheckCircle2, Circle } from "lucide-react";
 import PokemonSprite from "../pokemon/PokemonSprite";
+import PermissionGate from "../auth/PermissionGate";
 import { cleanPokemonName } from "../../utils/pokemonNameUtils";
 import { getResultDisplay } from "../../utils/resultUtils";
 import { formatTimeAgo } from "../../utils/timeUtils";
@@ -166,24 +167,26 @@ export default function GameCard({
               Replay
             </a>
             {onToggleReviewed && (
-              <button
-                type="button"
-                onClick={() => onToggleReviewed(replay)}
-                disabled={isTogglingReviewed}
-                title={replay.reviewed ? "Mark as unreviewed" : "Mark as reviewed"}
-                className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs transition-colors disabled:opacity-50 ${
-                  replay.reviewed
-                    ? "bg-green-100 text-green-700 hover:bg-green-200 dark:bg-green-500/20 dark:text-green-400 dark:hover:bg-green-500/30"
-                    : "border border-gray-300 text-gray-500 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-400 dark:hover:bg-gray-700"
-                }`}
-              >
-                {replay.reviewed ? (
-                  <CheckCircle2 className="h-3 w-3" />
-                ) : (
-                  <Circle className="h-3 w-3" />
-                )}
-                Reviewed
-              </button>
+              <PermissionGate perm="canEditReplayNotes">
+                <button
+                  type="button"
+                  onClick={() => onToggleReviewed(replay)}
+                  disabled={isTogglingReviewed}
+                  title={replay.reviewed ? "Mark as unreviewed" : "Mark as reviewed"}
+                  className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs transition-colors disabled:opacity-50 ${
+                    replay.reviewed
+                      ? "bg-green-100 text-green-700 hover:bg-green-200 dark:bg-green-500/20 dark:text-green-400 dark:hover:bg-green-500/30"
+                      : "border border-gray-300 text-gray-500 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-400 dark:hover:bg-gray-700"
+                  }`}
+                >
+                  {replay.reviewed ? (
+                    <CheckCircle2 className="h-3 w-3" />
+                  ) : (
+                    <Circle className="h-3 w-3" />
+                  )}
+                  Reviewed
+                </button>
+              </PermissionGate>
             )}
           </div>
         </div>
@@ -334,14 +337,16 @@ export default function GameCard({
           ) : (
             <div className="flex-1" />
           )}
-          <button
-            type="button"
-            onClick={() => onStartEditNote(replay)}
-            className="shrink-0 rounded p-1.5 text-gray-400 transition-colors hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-600/10 dark:hover:text-blue-400"
-            title="Edit notes"
-          >
-            <MessageSquare className="h-3.5 w-3.5" />
-          </button>
+          <PermissionGate perm="canEditReplayNotes">
+            <button
+              type="button"
+              onClick={() => onStartEditNote(replay)}
+              className="shrink-0 rounded p-1.5 text-gray-400 transition-colors hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-600/10 dark:hover:text-blue-400"
+              title="Edit notes"
+            >
+              <MessageSquare className="h-3.5 w-3.5" />
+            </button>
+          </PermissionGate>
         </div>
       )}
 

--- a/frontend/src/components/team/PokemonNoteCard.tsx
+++ b/frontend/src/components/team/PokemonNoteCard.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import { Save, MessageSquare, ChevronDown, X } from "lucide-react";
 import PokemonSprite from "../pokemon/PokemonSprite";
+import PermissionGate from "../auth/PermissionGate";
+import { useTeamPermissions } from "../../hooks/useTeamPermissions";
 import type { TeamMember } from "../../types";
 
 const CALC_BG_DEFAULT =
@@ -48,6 +50,8 @@ const PokemonNoteCard: React.FC<PokemonNoteCardProps> = ({
   const [isNoteExpanded, setIsNoteExpanded] = useState(true);
   const [isCalcsExpanded, setIsCalcsExpanded] = useState(true);
   const [calcInput, setCalcInput] = useState("");
+  const { can } = useTeamPermissions();
+  const canEditCalcs = can("canEditTeamMemberCalcs");
 
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-4 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-white/[0.02] dark:hover:bg-white/[0.04]">
@@ -66,14 +70,16 @@ const PokemonNoteCard: React.FC<PokemonNoteCardProps> = ({
           </div>
         </div>
 
-        <button
-          onClick={() => onStartEditingNote(member)}
-          disabled={isEditingNote || isSavingNote}
-          className="rounded p-1.5 text-gray-400 transition-colors hover:bg-blue-50 hover:text-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-blue-500/10 dark:hover:text-blue-400"
-          title="Edit notes"
-        >
-          <MessageSquare className="h-4 w-4" />
-        </button>
+        <PermissionGate perm="canEditTeamMemberNotes">
+          <button
+            onClick={() => onStartEditingNote(member)}
+            disabled={isEditingNote || isSavingNote}
+            className="rounded p-1.5 text-gray-400 transition-colors hover:bg-blue-50 hover:text-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-blue-500/10 dark:hover:text-blue-400"
+            title="Edit notes"
+          >
+            <MessageSquare className="h-4 w-4" />
+          </button>
+        </PermissionGate>
       </div>
 
       {/* Collapsible Notes */}
@@ -183,30 +189,34 @@ const PokemonNoteCard: React.FC<PokemonNoteCardProps> = ({
                 <span className="flex-1 break-words text-sm text-gray-700 dark:text-gray-300">
                   {calc}
                 </span>
-                <button
-                  onClick={() => onRemoveCalc(member.id, index)}
-                  className="flex-shrink-0 p-0.5 text-gray-400 opacity-0 transition-all hover:text-red-500 group-hover/calc:opacity-100 dark:text-gray-500 dark:hover:text-red-400"
-                  title="Remove calc"
-                >
-                  <X className="h-3 w-3" />
-                </button>
+                {canEditCalcs && (
+                  <button
+                    onClick={() => onRemoveCalc(member.id, index)}
+                    className="flex-shrink-0 p-0.5 text-gray-400 opacity-0 transition-all hover:text-red-500 group-hover/calc:opacity-100 dark:text-gray-500 dark:hover:text-red-400"
+                    title="Remove calc"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                )}
               </div>
             ))}
 
-            <input
-              type="text"
-              value={calcInput}
-              onChange={(e) => setCalcInput(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && calcInput.trim()) {
-                  e.preventDefault();
-                  onAddCalc(member.id, calcInput.trim());
-                  setCalcInput("");
-                }
-              }}
-              placeholder="Paste a calc result and press Enter..."
-              className="w-full rounded border border-gray-200 bg-gray-50 px-2 py-1.5 text-xs text-gray-800 placeholder-gray-400 transition-colors focus:border-brand-300 focus:outline-none dark:border-gray-700 dark:bg-white/[0.03] dark:text-white/90 dark:placeholder-gray-500"
-            />
+            {canEditCalcs && (
+              <input
+                type="text"
+                value={calcInput}
+                onChange={(e) => setCalcInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && calcInput.trim()) {
+                    e.preventDefault();
+                    onAddCalc(member.id, calcInput.trim());
+                    setCalcInput("");
+                  }
+                }}
+                placeholder="Paste a calc result and press Enter..."
+                className="w-full rounded border border-gray-200 bg-gray-50 px-2 py-1.5 text-xs text-gray-800 placeholder-gray-400 transition-colors focus:border-brand-300 focus:outline-none dark:border-gray-700 dark:bg-white/[0.03] dark:text-white/90 dark:placeholder-gray-500"
+              />
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/components/team/TeamHeader.tsx
+++ b/frontend/src/components/team/TeamHeader.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from "react";
-import { Plus, ChevronUp, ChevronDown } from "lucide-react";
+import { Plus, ChevronUp, ChevronDown, Users } from "lucide-react";
 import { useActiveTeam } from "../../context/ActiveTeamContext";
 import { useTeamStats } from "../../hooks/useTeamStats";
 import PokemonTeam from "../pokemon/PokemonTeam";
+import PermissionGate from "../auth/PermissionGate";
 import AddReplayModal from "../modals/AddReplayModal";
 import { formatShortDate } from "../../utils/timeUtils";
 
@@ -76,14 +77,16 @@ const TeamHeader: React.FC = () => {
             <div className="flex-1" />
 
             {/* Add Replay button */}
-            <button
-              type="button"
-              onClick={() => setShowAddReplay(true)}
-              className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-brand-500 px-3 py-2 text-sm font-medium text-white hover:bg-brand-600"
-            >
-              <Plus className="h-4 w-4" />
-              <span className="hidden sm:inline">Add Replay</span>
-            </button>
+            <PermissionGate perm="canAddReplays">
+              <button
+                type="button"
+                onClick={() => setShowAddReplay(true)}
+                className="inline-flex shrink-0 items-center gap-1.5 rounded-lg bg-brand-500 px-3 py-2 text-sm font-medium text-white hover:bg-brand-600"
+              >
+                <Plus className="h-4 w-4" />
+                <span className="hidden sm:inline">Add Replay</span>
+              </button>
+            </PermissionGate>
 
             {/* Expand */}
             <button
@@ -125,14 +128,25 @@ const TeamHeader: React.FC = () => {
           </div>
 
           <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => setShowAddReplay(true)}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-brand-500 px-3 py-2 text-sm font-medium text-white hover:bg-brand-600"
-            >
-              <Plus className="h-4 w-4" />
-              Add Replay
-            </button>
+            {team?.role === "COLLABORATOR" && (
+              <span
+                className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-500/10 dark:text-amber-300"
+                title="This team is shared with you by another user"
+              >
+                <Users className="h-3 w-3" />
+                Shared
+              </span>
+            )}
+            <PermissionGate perm="canAddReplays">
+              <button
+                type="button"
+                onClick={() => setShowAddReplay(true)}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-brand-500 px-3 py-2 text-sm font-medium text-white hover:bg-brand-600"
+              >
+                <Plus className="h-4 w-4" />
+                Add Replay
+              </button>
+            </PermissionGate>
 
             <button
               type="button"

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -8,3 +8,5 @@ export { default as useTeamMembers } from "./useTeamMembers";
 export { default as useTeamPokemon } from "./useTeamPokemon";
 export { useOpponentTeams } from "./useOpponentTeams";
 export { useDamageCalc } from "./useDamageCalc";
+export { useTeamPermissions } from "./useTeamPermissions";
+export type { Permission as TeamPermission, TeamPermissionsHelpers } from "./useTeamPermissions";

--- a/frontend/src/hooks/useTeamPermissions.ts
+++ b/frontend/src/hooks/useTeamPermissions.ts
@@ -1,0 +1,54 @@
+import { useMemo } from "react";
+import { useActiveTeam } from "../context/ActiveTeamContext";
+import {
+  ALL_PERMISSIONS_FALSE,
+  ALL_PERMISSIONS_TRUE,
+  type TeamPermissions,
+  type TeamRole,
+} from "../types";
+
+export type Permission = keyof TeamPermissions;
+
+export interface TeamPermissionsHelpers {
+  role: TeamRole | null;
+  permissions: TeamPermissions;
+  isOwner: boolean;
+  isCollaborator: boolean;
+  isLoaded: boolean;
+  can: (perm: Permission) => boolean;
+}
+
+/**
+ * Read the caller's role + permissions on the currently active team. Owners
+ * implicitly have every permission. While the team is still loading (or no
+ * team is active), `isLoaded` is false and permission checks return false.
+ */
+export function useTeamPermissions(): TeamPermissionsHelpers {
+  const { team } = useActiveTeam();
+
+  return useMemo<TeamPermissionsHelpers>(() => {
+    if (!team) {
+      return {
+        role: null,
+        permissions: ALL_PERMISSIONS_FALSE,
+        isOwner: false,
+        isCollaborator: false,
+        isLoaded: false,
+        can: () => false,
+      };
+    }
+    const role: TeamRole = team.role ?? "OWNER";
+    // Older payloads may not carry permissions yet — treat as owner-all.
+    const permissions = team.permissions ?? (role === "OWNER" ? ALL_PERMISSIONS_TRUE : ALL_PERMISSIONS_FALSE);
+    return {
+      role,
+      permissions,
+      isOwner: role === "OWNER",
+      isCollaborator: role === "COLLABORATOR",
+      isLoaded: true,
+      can: (perm) => Boolean(permissions[perm]),
+    };
+  }, [team]);
+}
+
+export default useTeamPermissions;

--- a/frontend/src/layout/AppSidebar.tsx
+++ b/frontend/src/layout/AppSidebar.tsx
@@ -11,6 +11,8 @@ import {
   MoreHorizontal,
   Check,
   X,
+  Users,
+  UserPlus,
 } from "lucide-react";
 import { useDroppable } from "@dnd-kit/core";
 import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
@@ -22,6 +24,7 @@ import { useActiveTeam } from "../context/ActiveTeamContext";
 import { useFolderContext } from "../context/FolderContext";
 import EditTeamModal from "../components/modals/EditTeamModal";
 import ExportTeamModal from "../components/modals/ExportTeamModal";
+import ManageCollaboratorsModal from "../components/modals/ManageCollaboratorsModal";
 import ConfirmationModal from "../components/modals/ConfirmationModal";
 import * as teamService from "../services/teamService";
 import type { Team, Folder } from "../types";
@@ -201,6 +204,7 @@ const AppSidebar: React.FC = () => {
 
   const [showEditModal, setShowEditModal] = useState(false);
   const [showExportModal, setShowExportModal] = useState(false);
+  const [showCollaboratorsModal, setShowCollaboratorsModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
@@ -216,6 +220,7 @@ const AppSidebar: React.FC = () => {
   const activeFolderId = searchParams.get("folder") ? Number(searchParams.get("folder")) : null;
   const isHomePage = location.pathname === "/" && !activeFolderId;
   const isDashboard = location.pathname === "/";
+  const isSharedPage = location.pathname === "/shared";
 
   useEffect(() => {
     if (creatingFolder && newFolderRef.current) newFolderRef.current.focus();
@@ -308,7 +313,24 @@ const AppSidebar: React.FC = () => {
         { name: "Type Chart", path: `/team/${team.id}/type-chart`, dividerAfter: true },
         { name: "Edit Team", onClick: () => setShowEditModal(true), icon: <Pencil className="h-3 w-3" /> },
         { name: "Export Team", onClick: () => setShowExportModal(true), icon: <Share2 className="h-3 w-3" /> },
-        { name: "Delete Team", onClick: () => setShowDeleteModal(true), icon: <Trash2 className="h-3 w-3" /> },
+        ...(team.role !== "COLLABORATOR"
+          ? [
+              {
+                name: "Manage Collaborators",
+                onClick: () => setShowCollaboratorsModal(true),
+                icon: <UserPlus className="h-3 w-3" />,
+              } as SubItem,
+            ]
+          : []),
+        ...(team.role !== "COLLABORATOR"
+          ? [
+              {
+                name: "Delete Team",
+                onClick: () => setShowDeleteModal(true),
+                icon: <Trash2 className="h-3 w-3" />,
+              } as SubItem,
+            ]
+          : []),
       ]
     : [];
 
@@ -363,6 +385,25 @@ const AppSidebar: React.FC = () => {
                   {/* Home (droppable) */}
                   <li>
                     <DroppableHomeItem isActive={isHomePage} isVisible={isVisible} />
+                  </li>
+
+                  {/* Shared/Collab teams hub */}
+                  <li>
+                    <Link
+                      to="/shared"
+                      className={`menu-item group ${
+                        isSharedPage ? "menu-item-active" : "menu-item-inactive"
+                      }`}
+                    >
+                      <span
+                        className={`menu-item-icon-size ${
+                          isSharedPage ? "menu-item-icon-active" : "menu-item-icon-inactive"
+                        }`}
+                      >
+                        <Users className="h-5 w-5" />
+                      </span>
+                      {isVisible && <span className="menu-item-text">Shared</span>}
+                    </Link>
                   </li>
 
                   {/* Folders section (dashboard only) */}
@@ -503,6 +544,11 @@ const AppSidebar: React.FC = () => {
             isOpen={showExportModal}
             team={team}
             onClose={() => setShowExportModal(false)}
+          />
+          <ManageCollaboratorsModal
+            isOpen={showCollaboratorsModal}
+            team={team}
+            onClose={() => setShowCollaboratorsModal(false)}
           />
           <ConfirmationModal
             isOpen={showDeleteModal}

--- a/frontend/src/pages/Collaboration/AcceptInvitePage.tsx
+++ b/frontend/src/pages/Collaboration/AcceptInvitePage.tsx
@@ -1,0 +1,219 @@
+import { useCallback, useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router";
+import { Users, Check, X, Mail } from "lucide-react";
+import PageMeta from "../../components/common/PageMeta";
+import { collaboratorApi } from "../../services/api/collaboratorApi";
+import { useAuth } from "../../context/AuthContext";
+import type { InvitePreview } from "../../types";
+
+export default function AcceptInvitePage() {
+  const { token } = useParams<{ token: string }>();
+  const navigate = useNavigate();
+  const { user, isAuthenticated, loading: authLoading } = useAuth();
+
+  const [preview, setPreview] = useState<InvitePreview | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState<"accepted" | "declined" | null>(null);
+  const [acceptedTeamId, setAcceptedTeamId] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await collaboratorApi.previewInvite(token);
+      setPreview(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Invite not found");
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleAccept = async () => {
+    if (!token) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const accepted = await collaboratorApi.acceptInvite(token);
+      setDone("accepted");
+      setAcceptedTeamId(accepted.teamId);
+      // Auto-redirect into the team after a short moment so the user sees confirmation.
+      setTimeout(() => navigate(`/team/${accepted.teamId}`), 1200);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to accept invite");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDecline = async () => {
+    if (!token) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await collaboratorApi.declineInvite(token);
+      setDone("declined");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to decline invite");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (authLoading || loading) {
+    return (
+      <div className="mx-auto max-w-md px-4 py-12 text-center">
+        <div className="mx-auto h-8 w-8 animate-spin rounded-full border-2 border-gray-300 border-t-brand-500" />
+      </div>
+    );
+  }
+
+  if (error && !preview) {
+    return (
+      <div className="mx-auto max-w-md px-4 py-12">
+        <PageMeta title="Invite | VS Recorder" description="Team invite" />
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-4 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
+          {error}
+        </div>
+        <div className="mt-4 text-center">
+          <Link to="/" className="text-sm text-brand-500 hover:underline">Go home</Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (!preview) return null;
+
+  const isPending = preview.status === "PENDING" && !preview.expired;
+
+  return (
+    <div className="mx-auto max-w-lg px-4 py-12">
+      <PageMeta title="Team invite | VS Recorder" description="Accept a team collaboration invite" />
+
+      <div className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+        <div className="mb-4 flex items-center gap-3">
+          <div className="rounded-full bg-brand-50 p-2 dark:bg-brand-500/20">
+            <Users className="h-5 w-5 text-brand-500" />
+          </div>
+          <div>
+            <h1 className="text-lg font-semibold text-gray-800 dark:text-white/90">
+              {preview.ownerUsername ? `${preview.ownerUsername} invited you` : "You've been invited"}
+            </h1>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              to collaborate on <span className="font-medium text-gray-700 dark:text-gray-300">{preview.teamName}</span>
+            </p>
+          </div>
+        </div>
+
+        <div className="mb-6 rounded-lg bg-gray-50 px-4 py-3 text-xs text-gray-600 dark:bg-gray-800/60 dark:text-gray-400">
+          <Mail className="mr-1 inline h-3 w-3 align-text-bottom" />
+          Sent to <span className="font-mono">{preview.inviteEmail}</span>
+          {!preview.expired && (
+            <> · expires {new Date(preview.inviteExpiresAt).toLocaleDateString()}</>
+          )}
+        </div>
+
+        {preview.expired && (
+          <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-300">
+            This invite has expired. Ask the owner to resend it.
+          </div>
+        )}
+
+        {preview.status === "ACCEPTED" && (
+          <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-900/40 dark:bg-emerald-900/20 dark:text-emerald-300">
+            This invite has already been accepted.
+          </div>
+        )}
+
+        {preview.status === "REVOKED" && (
+          <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+            This invite was declined or revoked.
+          </div>
+        )}
+
+        {error && (
+          <div className="mt-3 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
+            {error}
+          </div>
+        )}
+
+        {done === "accepted" && (
+          <div className="mt-3 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-900/40 dark:bg-emerald-900/20 dark:text-emerald-300">
+            You're in! Taking you to the team{acceptedTeamId ? "..." : ""}
+          </div>
+        )}
+        {done === "declined" && (
+          <div className="mt-3 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+            Invite declined.
+          </div>
+        )}
+
+        {/* Action buttons */}
+        {isPending && !done && (
+          <div className="mt-4">
+            {!isAuthenticated ? (
+              <div className="space-y-3">
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Sign in or create an account to accept this invite. The email on the invite is{" "}
+                  <span className="font-mono">{preview.inviteEmail}</span> — sign up with that address and
+                  you'll be added automatically.
+                </p>
+                <div className="flex gap-2">
+                  <Link
+                    to={`/signin?redirect=/invites/${token}`}
+                    className="inline-flex flex-1 items-center justify-center rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600"
+                  >
+                    Sign in
+                  </Link>
+                  <Link
+                    to={`/signup?redirect=/invites/${token}`}
+                    className="inline-flex flex-1 items-center justify-center rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+                  >
+                    Create account
+                  </Link>
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {user && user.email && user.email.toLowerCase() !== preview.inviteEmail.toLowerCase() && (
+                  <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-900/40 dark:bg-amber-900/20 dark:text-amber-300">
+                    Heads up: you're signed in as <span className="font-mono">{user.email}</span>, but this
+                    invite was sent to <span className="font-mono">{preview.inviteEmail}</span>. The server
+                    will reject the accept unless the emails match.
+                  </div>
+                )}
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={handleAccept}
+                    disabled={submitting}
+                    className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-emerald-500 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-600 disabled:opacity-50"
+                  >
+                    <Check className="h-4 w-4" />
+                    {submitting ? "Accepting..." : "Accept"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleDecline}
+                    disabled={submitting}
+                    className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+                  >
+                    <X className="h-4 w-4" />
+                    Decline
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Collaboration/SharedHubPage.tsx
+++ b/frontend/src/pages/Collaboration/SharedHubPage.tsx
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router";
+import { Users, MailX, ExternalLink, Check, X } from "lucide-react";
+import PageMeta from "../../components/common/PageMeta";
+import { collaboratorApi } from "../../services/api/collaboratorApi";
+import type { Collaborator, TeamSummary } from "../../types";
+
+export default function SharedHubPage() {
+  const [pending, setPending] = useState<Collaborator[]>([]);
+  const [shared, setShared] = useState<TeamSummary[]>([]);
+  const [sharing, setSharing] = useState<TeamSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionId, setActionId] = useState<number | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [p, s, sh] = await Promise.all([
+        collaboratorApi.pendingInvites(),
+        collaboratorApi.sharedWithMe(),
+        collaboratorApi.teamsIAmSharing(),
+      ]);
+      setPending(p);
+      setShared(s);
+      setSharing(sh);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load collaborations");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleAccept = async (invite: Collaborator) => {
+    if (!invite.inviteToken) {
+      setError("This invite is no longer accessible. Try opening it from the email link.");
+      return;
+    }
+    setActionId(invite.id);
+    setError(null);
+    try {
+      await collaboratorApi.acceptInvite(invite.inviteToken);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to accept invite");
+    } finally {
+      setActionId(null);
+    }
+  };
+
+  const handleDecline = async (invite: Collaborator) => {
+    if (!invite.inviteToken) {
+      setError("This invite is no longer accessible.");
+      return;
+    }
+    setActionId(invite.id);
+    setError(null);
+    try {
+      await collaboratorApi.declineInvite(invite.inviteToken);
+      await refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to decline invite");
+    } finally {
+      setActionId(null);
+    }
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-5xl px-4 py-6">
+      <PageMeta title="Shared Teams | VS Recorder" description="Teams shared with you or that you are sharing" />
+
+      <header className="mb-6 flex items-center gap-3">
+        <Users className="h-6 w-6 text-brand-500" />
+        <h1 className="text-2xl font-semibold text-gray-800 dark:text-white/90">Shared Teams</h1>
+      </header>
+
+      {error && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-2.5 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-900/20 dark:text-red-300">
+          {error}
+        </div>
+      )}
+
+      {/* Pending invites */}
+      <section className="mb-8">
+        <h2 className="mb-2 text-lg font-medium text-gray-700 dark:text-gray-300">Pending invites ({pending.length})</h2>
+        {loading ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">Loading...</p>
+        ) : pending.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            No pending invites. Invites arrive by email — click the link in your inbox to accept.
+          </p>
+        ) : (
+          <ul className="divide-y divide-gray-200 rounded-lg border border-gray-200 dark:divide-gray-700 dark:border-gray-700">
+            {pending.map((p) => (
+              <li key={p.id} className="flex items-center justify-between gap-3 px-4 py-3">
+                <div className="min-w-0">
+                  <div className="truncate font-medium text-gray-800 dark:text-gray-100">
+                    {p.teamName ?? `Team #${p.teamId}`}
+                  </div>
+                  <div className="truncate text-xs text-gray-500 dark:text-gray-400">
+                    Invited to {p.inviteEmail} · expires {new Date(p.inviteExpiresAt).toLocaleDateString()}
+                  </div>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <button
+                    type="button"
+                    onClick={() => handleAccept(p)}
+                    disabled={actionId === p.id}
+                    className="inline-flex items-center gap-1 rounded-lg bg-emerald-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-600 disabled:opacity-50"
+                  >
+                    <Check className="h-3 w-3" />
+                    Accept
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDecline(p)}
+                    disabled={actionId === p.id}
+                    className="inline-flex items-center gap-1 rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+                  >
+                    <X className="h-3 w-3" />
+                    Decline
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Teams shared with me */}
+      <section className="mb-8">
+        <h2 className="mb-2 text-lg font-medium text-gray-700 dark:text-gray-300">Teams shared with me ({shared.length})</h2>
+        {loading ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">Loading...</p>
+        ) : shared.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">No teams are shared with you yet.</p>
+        ) : (
+          <ul className="grid gap-3 sm:grid-cols-2">
+            {shared.map((t) => (
+              <li key={t.id}>
+                <Link
+                  to={`/team/${t.id}`}
+                  className="block rounded-lg border border-gray-200 px-4 py-3 hover:border-brand-400 hover:bg-brand-50/40 dark:border-gray-700 dark:hover:border-brand-500 dark:hover:bg-brand-500/10"
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium text-gray-800 dark:text-gray-100">{t.name}</span>
+                    <ExternalLink className="h-4 w-4 text-gray-400" />
+                  </div>
+                  <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    {t.regulation || "Unknown reg"} · {t.replayCount} replay{t.replayCount === 1 ? "" : "s"} · {t.matchCount} match{t.matchCount === 1 ? "" : "es"}
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Teams I'm sharing */}
+      <section>
+        <h2 className="mb-2 text-lg font-medium text-gray-700 dark:text-gray-300">Teams I'm sharing ({sharing.length})</h2>
+        {loading ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">Loading...</p>
+        ) : sharing.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            You aren't sharing any teams yet. Open a team's "Manage Collaborators" to invite someone.
+          </p>
+        ) : (
+          <ul className="grid gap-3 sm:grid-cols-2">
+            {sharing.map((t) => (
+              <li key={t.id}>
+                <Link
+                  to={`/team/${t.id}`}
+                  className="block rounded-lg border border-gray-200 px-4 py-3 hover:border-brand-400 hover:bg-brand-50/40 dark:border-gray-700 dark:hover:border-brand-500 dark:hover:bg-brand-500/10"
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium text-gray-800 dark:text-gray-100">{t.name}</span>
+                    <ExternalLink className="h-4 w-4 text-gray-400" />
+                  </div>
+                  <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    {t.regulation || "Unknown reg"} · open Manage Collaborators from the sidebar
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {pending.length === 0 && shared.length === 0 && sharing.length === 0 && !loading && (
+        <div className="mt-8 rounded-lg border border-dashed border-gray-300 px-6 py-10 text-center text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+          <MailX className="mx-auto mb-3 h-6 w-6" />
+          Nothing here yet. Once a teammate invites you (or you invite them), it'll show up on this page.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/services/api/collaboratorApi.ts
+++ b/frontend/src/services/api/collaboratorApi.ts
@@ -1,0 +1,49 @@
+import apiClient from "./client";
+import type { Collaborator, InvitePreview, TeamPermissions, TeamSummary } from "../../types";
+
+export interface InvitePayload extends TeamPermissions {
+  email: string;
+}
+
+export const collaboratorApi = {
+  // Owner-side: per-team management
+  listForTeam: (teamId: number) =>
+    apiClient.get(`/api/teams/${teamId}/collaborators`) as Promise<Collaborator[]>,
+
+  invite: (teamId: number, payload: InvitePayload) =>
+    apiClient.post(`/api/teams/${teamId}/collaborators/invite`, payload) as Promise<Collaborator>,
+
+  updatePermissions: (teamId: number, collaboratorId: number, permissions: TeamPermissions) =>
+    apiClient.patch(
+      `/api/teams/${teamId}/collaborators/${collaboratorId}`,
+      permissions,
+    ) as Promise<Collaborator>,
+
+  remove: (teamId: number, collaboratorId: number) =>
+    apiClient.delete(`/api/teams/${teamId}/collaborators/${collaboratorId}`) as Promise<void>,
+
+  leave: (teamId: number) =>
+    apiClient.delete(`/api/teams/${teamId}/collaborators/me`) as Promise<void>,
+
+  // Caller-side: shared hub page
+  sharedWithMe: () =>
+    apiClient.get("/api/collaborations/shared-with-me") as Promise<TeamSummary[]>,
+
+  teamsIAmSharing: () =>
+    apiClient.get("/api/collaborations/sharing") as Promise<TeamSummary[]>,
+
+  pendingInvites: () =>
+    apiClient.get("/api/collaborations/pending-invites") as Promise<Collaborator[]>,
+
+  // Accept flow
+  previewInvite: (token: string) =>
+    apiClient.get(`/api/collaborations/invites/${token}`) as Promise<InvitePreview>,
+
+  acceptInvite: (token: string) =>
+    apiClient.post(`/api/collaborations/invites/${token}/accept`) as Promise<Collaborator>,
+
+  declineInvite: (token: string) =>
+    apiClient.post(`/api/collaborations/invites/${token}/decline`) as Promise<Collaborator>,
+};
+
+export default collaboratorApi;

--- a/frontend/src/services/api/index.ts
+++ b/frontend/src/services/api/index.ts
@@ -7,3 +7,5 @@ export { analyticsApi } from "./analyticsApi";
 export { gamePlanApi } from "./gamePlanApi";
 export { exportApi } from "./exportApi";
 export { teamMemberApi } from "./teamMemberApi";
+export { collaboratorApi } from "./collaboratorApi";
+export type { InvitePayload } from "./collaboratorApi";

--- a/frontend/src/types/collaborator.ts
+++ b/frontend/src/types/collaborator.ts
@@ -1,0 +1,57 @@
+export type TeamRole = "OWNER" | "COLLABORATOR";
+
+export interface TeamPermissions {
+  canAddReplays: boolean;
+  canDeleteReplays: boolean;
+  canEditReplayNotes: boolean;
+  canEditTeamMemberNotes: boolean;
+  canEditTeamMemberCalcs: boolean;
+  canEditTeamDetails: boolean;
+  canEditGamePlans: boolean;
+}
+
+export const ALL_PERMISSIONS_FALSE: TeamPermissions = {
+  canAddReplays: false,
+  canDeleteReplays: false,
+  canEditReplayNotes: false,
+  canEditTeamMemberNotes: false,
+  canEditTeamMemberCalcs: false,
+  canEditTeamDetails: false,
+  canEditGamePlans: false,
+};
+
+export const ALL_PERMISSIONS_TRUE: TeamPermissions = {
+  canAddReplays: true,
+  canDeleteReplays: true,
+  canEditReplayNotes: true,
+  canEditTeamMemberNotes: true,
+  canEditTeamMemberCalcs: true,
+  canEditTeamDetails: true,
+  canEditGamePlans: true,
+};
+
+export type CollaboratorStatus = "PENDING" | "ACCEPTED" | "REVOKED";
+
+export interface Collaborator extends TeamPermissions {
+  id: number;
+  teamId: number;
+  teamName: string | null;
+  userId: number | null;
+  username: string | null;
+  userEmail: string | null;
+  inviteEmail: string;
+  inviteToken: string | null;
+  status: CollaboratorStatus;
+  acceptedAt: string | null;
+  inviteExpiresAt: string;
+  createdAt: string;
+}
+
+export interface InvitePreview {
+  teamName: string;
+  ownerUsername: string;
+  inviteEmail: string;
+  status: CollaboratorStatus;
+  inviteExpiresAt: string;
+  expired: boolean;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,5 +1,13 @@
 export type { User, LoginCredentials, RegisterCredentials, AuthResponse } from "./auth";
-export type { Team } from "./team";
+export type { Team, TeamSummary } from "./team";
+export type {
+  TeamRole,
+  TeamPermissions,
+  Collaborator,
+  CollaboratorStatus,
+  InvitePreview,
+} from "./collaborator";
+export { ALL_PERMISSIONS_FALSE, ALL_PERMISSIONS_TRUE } from "./collaborator";
 export type { Folder } from "./folder";
 export type { Replay, BattleData } from "./replay";
 export type { Match, MatchStats } from "./match";

--- a/frontend/src/types/team.ts
+++ b/frontend/src/types/team.ts
@@ -1,3 +1,5 @@
+import type { TeamPermissions, TeamRole } from "./collaborator";
+
 export interface Team {
   id: number;
   name: string;
@@ -7,4 +9,22 @@ export interface Team {
   folderIds: number[];
   createdAt: string;
   updatedAt: string;
+  // Populated by the backend per-request based on the caller's access.
+  // Optional for compatibility with cached older payloads.
+  role?: TeamRole;
+  permissions?: TeamPermissions;
+}
+
+export interface TeamSummary {
+  id: number;
+  name: string;
+  pokepaste: string;
+  regulation: string;
+  createdAt: string;
+  updatedAt: string;
+  folderIds: number[];
+  replayCount: number;
+  matchCount: number;
+  winRate: number | null;
+  role?: TeamRole;
 }


### PR DESCRIPTION
## Summary
- Adds a **team collaboration** model: owners invite users by email to a single shared Team instance (no duplicate copies). Backed by a new `TeamCollaborator` entity with per-collaborator boolean permissions (add/delete replays, edit replay+match notes, edit Pokemon notes, edit Pokemon calcs, edit team details, edit game plans).
- Centralizes ownership/permission checks in a new `TeamAccessService` (replaces scattered `findByIdAndUserId` calls across Replay/Match/TeamMember/Team/Analytics/GamePlan/Export controllers).
- Email invites via the existing Resend integration; auto-accept on signup so invitees without an account land in the team after registering.
- Frontend: `useTeamPermissions` hook + `PermissionGate` component gate UI affordances. New `ManageCollaboratorsModal`, `/shared` hub page, and `/invites/:token` accept page. Sidebar gains "Shared" entry and an owner-only "Manage Collaborators" item.

Plan: [~/.claude/plans/i-want-to-add-foamy-lagoon.md](../blob/feat/team-collaborators/CLAUDE.md)

## Notable design choices
- Owner is implicit (the existing `Team.user_id`); no row in `team_collaborators` for owners. Owners get every permission.
- `Team.findAllAccessibleByUserId` joins owned ∪ accepted-collaborator teams; the dashboard list now uses it.
- Game plans become **team-scoped when attached to a team** — any collaborator with `canEditGamePlans` can read/edit the team's single plan. Pre-existing user-private plans (no `teamId`) keep their old user-scoped behavior.
- Owner-only actions (delete team, manage collaborators) gated via `TeamAccessService.requireOwner` regardless of collaborator booleans.
- 7-day invite TTL; tokens nulled on accept/decline; idempotent re-invite resends the email without creating a duplicate row.

## Test plan
Backend (covered):
- [x] `mvn test` — 162 tests pass (incl. new `TeamAccessServiceTest`: owner all-perms, collaborator masking, pending denied, stranger denied, owner-only gating)

Frontend:
- [x] `npm run build` clean (no type errors)

End-to-end (manual — needs `RESEND_API_KEY` set):
- [ ] Owner opens a team → sidebar "Manage Collaborators" → invite an email
- [ ] Invitee receives email → clicks link → preview renders at `/invites/{token}`
- [ ] Unauth invitee signs up with the invited email → invite auto-accepts → team visible at `/shared`
- [ ] Authed invitee clicks Accept → redirected into the team
- [ ] Permission gating: w/o `canDeleteReplays`, delete buttons hidden + API returns 403
- [ ] Permission gating: w/o `canEditTeamDetails`, EditTeamModal/showdown/folder actions blocked
- [ ] Owner toggles permissions → collaborator's UI updates on next team load
- [ ] Owner removes collaborator → team disappears from collaborator's `/shared`
- [ ] Re-invite same email → idempotent (single row, fresh email)
- [ ] Collaborator can still export the team (fork into a copy on their side)
- [ ] GamePlans: collaborator with perm can create/edit; without perm, mutations 403
- [ ] Edge cases: expired token, self-invite, duplicate active membership, team deletion cascades the membership

🤖 Generated with [Claude Code](https://claude.com/claude-code)