### PR TITLE
feat(resources): add public Resources page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import TeamLayout from "./layout/TeamLayout";
 import { ScrollToTop } from "./components/common/ScrollToTop";
 import HomePage from "./pages/Dashboard/HomePage";
 import AboutPage from "./pages/AboutPage";
+import ResourcesPage from "./pages/ResourcesPage";
 import AnnouncementsPage from "./pages/Announcements/AnnouncementsPage";
 import ReplaysPage from "./pages/Team/ReplaysPage";
 import GameByGamePage from "./pages/Team/GameByGamePage";
@@ -74,6 +75,7 @@ export default function App() {
         <Route path="/" element={<RootRoute />}>
           <Route index element={<HomePage />} />
           <Route path="about" element={<AboutPage />} />
+          <Route path="resources" element={<ResourcesPage />} />
           <Route path="announcements" element={<AnnouncementsPage />} />
           <Route path="shared" element={<SharedHubPage />} />
           <Route path="invites/:token" element={<AcceptInvitePage />} />

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router";
-import { Github, Info, Megaphone } from "lucide-react";
+import { Github, Info, Megaphone, Library } from "lucide-react";
 
 export default function Footer() {
   const version = import.meta.env.VITE_APP_VERSION ?? "dev";
@@ -37,6 +37,13 @@ export default function Footer() {
             >
               <Info className="h-3 w-3" />
               About
+            </Link>
+            <Link
+              to="/resources"
+              className="flex items-center gap-1.5 rounded px-3 py-1.5 text-sm text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-gray-300"
+            >
+              <Library className="h-3 w-3" />
+              Resources
             </Link>
             <Link
               to="/announcements"

--- a/frontend/src/data/announcements.json
+++ b/frontend/src/data/announcements.json
@@ -1,5 +1,11 @@
 [
   {
+    "id": "2026-06-30-resources-page",
+    "date": "2026-06-30",
+    "title": "New: Resources Page",
+    "message": "There's a new Resources page collecting the VGC tools, stats sites, paste databases, and tournament trackers worth bookmarking — plus the upstream projects VS Recorder is built on. Check the footer to find it."
+  },
+  {
     "id": "2026-06-17-reg-m-b-speed-tiers",
     "date": "2026-06-17",
     "title": "Regulation M-B Speed Tiers",

--- a/frontend/src/data/resources.json
+++ b/frontend/src/data/resources.json
@@ -1,0 +1,241 @@
+[
+  {
+    "id": "damage-calculators",
+    "label": "Damage Calculators",
+    "icon": "Calculator",
+    "color": "text-blue-500 bg-blue-50 dark:bg-blue-500/10",
+    "resources": [
+      {
+        "name": "VGC MultiCalc",
+        "url": "https://vgcmulticalc.com/",
+        "description": "Advanced damage calculator for working out spreads against multiple Pokémon at once."
+      }
+    ]
+  },
+  {
+    "id": "usage-stats",
+    "label": "Usage Stats & Data",
+    "icon": "BarChart3",
+    "color": "text-emerald-500 bg-emerald-50 dark:bg-emerald-500/10",
+    "resources": [
+      {
+        "name": "Pikalytics",
+        "url": "https://www.pikalytics.com/",
+        "description": "Usage stats, movesets, and common teammates across the current metagame."
+      },
+      {
+        "name": "StatCrusher",
+        "url": "https://statcrusher.com/",
+        "description": "Battle records and usage broken down by Elo tier, format (Bo1/Bo3), and season."
+      },
+      {
+        "name": "MunchStats",
+        "url": "https://www.munchstats.com/",
+        "description": "VGC usage statistics and metagame data."
+      },
+      {
+        "name": "MunchStats Replays",
+        "url": "https://munchstats.com/replays/",
+        "description": "Searchable database of VGC replays."
+      },
+      {
+        "name": "ARC VGC",
+        "url": "https://arcvgc.com/",
+        "description": "Analytics platform built on all public Showdown replays — browse aggregated data and metagame insights."
+      },
+      {
+        "name": "Pokédata",
+        "url": "https://pokedata.ovh/",
+        "description": "Standings tracking, player history, and team comparison tools across formats."
+      },
+      {
+        "name": "Nimbasa City Post",
+        "url": "https://www.nimbasacitypost.com/",
+        "description": "VGC news and metagame/data analysis."
+      },
+      {
+        "name": "VGC Matchup Lab",
+        "url": "https://brophy.website/vgc/matchuplab/",
+        "description": "Restricted (mega/legendary) matchup table paired with usage statistics."
+      }
+    ]
+  },
+  {
+    "id": "tournament-standings",
+    "label": "Tournament Standings & Brackets",
+    "icon": "Trophy",
+    "color": "text-amber-500 bg-amber-50 dark:bg-amber-500/10",
+    "resources": [
+      {
+        "name": "Limitless",
+        "url": "https://play.limitlesstcg.com/tournaments/?game=VGC",
+        "description": "Online tournament hosting with brackets and live standings."
+      },
+      {
+        "name": "RK9",
+        "url": "https://rk9.gg/tournaments",
+        "description": "Official event registration, pairings, and standings."
+      },
+      {
+        "name": "Reportworm Standings",
+        "url": "https://standings.reportworm.com/",
+        "description": "Live tournament standings tracker."
+      },
+      {
+        "name": "Cut Explorer",
+        "url": "https://cut-explorer.stalruth.dev/",
+        "description": "Predicts and analyzes whether a given record makes Day 2 cut."
+      },
+      {
+        "name": "NA CP Leaderboard",
+        "url": "https://lepotatochip.github.io/index.html",
+        "description": "Live leaderboard for North America Championship Point standings."
+      }
+    ]
+  },
+  {
+    "id": "tournament-info",
+    "label": "Tournament Info & Official",
+    "icon": "CalendarDays",
+    "color": "text-purple-500 bg-purple-50 dark:bg-purple-500/10",
+    "resources": [
+      {
+        "name": "Victory Road",
+        "url": "https://victoryroad.pro/",
+        "description": "VGC rules, schedules, Championship Point tracking, and guides."
+      },
+      {
+        "name": "Pokémon Events",
+        "url": "https://events.pokemon.com/en-us/events",
+        "description": "Official Play! Pokémon event locator."
+      }
+    ]
+  },
+  {
+    "id": "paste-databases",
+    "label": "Team Paste Databases",
+    "icon": "Database",
+    "color": "text-pink-500 bg-pink-50 dark:bg-pink-500/10",
+    "resources": [
+      {
+        "name": "VGC Pastes",
+        "url": "https://x.com/VGCPastes",
+        "description": "Large community archive of tournament team pastes.",
+        "links": [
+          { "label": "Spreadsheet", "url": "https://t.co/abV0elif3q" }
+        ]
+      },
+      {
+        "name": "PASRS",
+        "url": "https://docs.google.com/spreadsheets/d/1HdwhV6AlRP-El7WdfHoLwz315zov2O9BSeoyMG37NHo/copy?usp=sharing",
+        "description": "Palkia Academy Showdown Reporting Spreadsheet — log replays and track game-by-game, matchup, and move stats.",
+        "note": "Your data stays in your own Google Drive.",
+        "links": [
+          { "label": "@BauerdadVGC", "url": "https://x.com/BauerdadVGC" }
+        ]
+      },
+      {
+        "name": "SPAMS",
+        "url": "https://docs.google.com/spreadsheets/d/1b6NYv3NwytQ8D_oWTwprq0TNlZVz5q_s0TpJ0NR5Bgk/edit?gid=275325505",
+        "description": "Sableye's Planning and Analysis of Matchups Spreadsheet — build gameplans and matchup summaries you fully own.",
+        "note": "Your data stays in your own Google Drive.",
+        "links": [
+          { "label": "@SableyeVGC", "url": "https://x.com/SableyeVGC" }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "team-building",
+    "label": "Team Building & Tools",
+    "icon": "Wrench",
+    "color": "text-cyan-500 bg-cyan-50 dark:bg-cyan-500/10",
+    "resources": [
+      {
+        "name": "teamsheet.gg",
+        "url": "https://teamsheet.gg",
+        "description": "Build and format official-style team sheets."
+      },
+      {
+        "name": "Team List Creator",
+        "url": "https://dhsufi.github.io/PokemonTeamListCreator/",
+        "description": "Generates printable tournament team lists."
+      },
+      {
+        "name": "Marriland Team Builder",
+        "url": "https://marriland.com/tools/team-builder/",
+        "description": "Check a team's defensive weakness/resistance spread and offensive coverage."
+      }
+    ]
+  },
+  {
+    "id": "guides",
+    "label": "Guides & Learning",
+    "icon": "GraduationCap",
+    "color": "text-indigo-500 bg-indigo-50 dark:bg-indigo-500/10",
+    "resources": [
+      {
+        "name": "VGC Guide",
+        "url": "https://www.vgcguide.com/",
+        "description": "Older but still-valuable text guides on strategy, teambuilding, catching/breeding, and circuit info."
+      }
+    ]
+  },
+  {
+    "id": "data-references",
+    "label": "Data References",
+    "icon": "BookOpen",
+    "color": "text-teal-500 bg-teal-50 dark:bg-teal-500/10",
+    "resources": [
+      {
+        "name": "Serebii",
+        "url": "https://serebii.net/",
+        "description": "Pokémon news plus a complete Pokédex, move, and item database."
+      },
+      {
+        "name": "PokémonDB",
+        "url": "https://pokemondb.net/",
+        "description": "Clean Pokédex, movesets, type charts, and breeding/data reference."
+      }
+    ]
+  },
+  {
+    "id": "built-on",
+    "label": "Built on / Powered by",
+    "icon": "Link2",
+    "color": "text-brand-500 bg-brand-50 dark:bg-brand-500/10",
+    "intro": "VS Recorder is built on top of these excellent tools and data sources.",
+    "resources": [
+      {
+        "name": "Pokémon Showdown",
+        "url": "https://replay.pokemonshowdown.com",
+        "description": "Battle simulator whose replays power VS Recorder's import and analysis."
+      },
+      {
+        "name": "Pokepaste",
+        "url": "https://pokepast.es",
+        "description": "Team paste hosting used for importing teams."
+      },
+      {
+        "name": "Pokebin",
+        "url": "https://pokebin.com",
+        "description": "Team paste hosting used for importing teams."
+      },
+      {
+        "name": "VR Pastes",
+        "url": "https://vrpastes.com",
+        "description": "Team paste hosting used for importing teams."
+      },
+      {
+        "name": "LabMaus",
+        "url": "https://labmaus.net",
+        "description": "Tournament team data behind the recent-tournament team importer."
+      },
+      {
+        "name": "NCP VGC Damage Calculator",
+        "url": "https://nerd-of-now.github.io/NCP-VGC-Damage-Calculator/",
+        "description": "Nerd of Now's calculator; its set data powers the in-app calculator's preset sets."
+      }
+    ]
+  }
+]

--- a/frontend/src/data/resources.json
+++ b/frontend/src/data/resources.json
@@ -56,7 +56,7 @@
       {
         "name": "VGC Matchup Lab",
         "url": "https://brophy.website/vgc/matchuplab/",
-        "description": "Restricted (mega/legendary) matchup table paired with usage statistics."
+        "description": "Mega Pokémon matchup table paired with usage statistics."
       }
     ]
   },
@@ -84,7 +84,7 @@
       {
         "name": "Cut Explorer",
         "url": "https://cut-explorer.stalruth.dev/",
-        "description": "Predicts and analyzes whether a given record makes Day 2 cut."
+        "description": "View stats and details for high-placing teams from recent events."
       },
       {
         "name": "NA CP Leaderboard",
@@ -154,7 +154,7 @@
       {
         "name": "teamsheet.gg",
         "url": "https://teamsheet.gg",
-        "description": "Build and format official-style team sheets."
+        "description": "Browse and create team reports."
       },
       {
         "name": "Team List Creator",

--- a/frontend/src/pages/Landing/LandingFooter.tsx
+++ b/frontend/src/pages/Landing/LandingFooter.tsx
@@ -23,6 +23,12 @@ export default function LandingFooter() {
               About
             </Link>
             <Link
+              to="/resources"
+              className="transition-colors hover:text-gray-700 dark:hover:text-gray-300"
+            >
+              Resources
+            </Link>
+            <Link
               to="/announcements"
               className="transition-colors hover:text-gray-700 dark:hover:text-gray-300"
             >

--- a/frontend/src/pages/ResourcesPage.tsx
+++ b/frontend/src/pages/ResourcesPage.tsx
@@ -1,0 +1,140 @@
+import PageMeta from "../components/common/PageMeta";
+import {
+  Calculator,
+  BarChart3,
+  Trophy,
+  CalendarDays,
+  Database,
+  Wrench,
+  GraduationCap,
+  BookOpen,
+  Link2,
+  ExternalLink,
+  type LucideIcon,
+} from "lucide-react";
+import resources from "../data/resources.json";
+
+interface ResourceLink {
+  label: string;
+  url: string;
+}
+
+interface ResourceEntry {
+  name: string;
+  url: string;
+  description: string;
+  links?: ResourceLink[];
+  note?: string;
+}
+
+interface ResourceCategory {
+  id: string;
+  label: string;
+  icon: string;
+  color: string;
+  intro?: string;
+  resources: ResourceEntry[];
+}
+
+const ICON_MAP: Record<string, LucideIcon> = {
+  Calculator,
+  BarChart3,
+  Trophy,
+  CalendarDays,
+  Database,
+  Wrench,
+  GraduationCap,
+  BookOpen,
+  Link2,
+};
+
+const categories = resources as ResourceCategory[];
+
+export default function ResourcesPage() {
+  return (
+    <>
+      <PageMeta
+        title="Resources | VS Recorder"
+        description="Curated VGC tools, stats, and tournament resources"
+      />
+      <div className="mx-auto max-w-5xl">
+        <div className="mb-8 text-center">
+          <h1 className="text-3xl font-bold text-gray-800 dark:text-white/90">
+            Resources
+          </h1>
+          <p className="mt-2 text-gray-500 dark:text-gray-400">
+            Tools, stats, and community resources for VGC
+          </p>
+        </div>
+
+        {categories.map((category) => {
+          const Icon = ICON_MAP[category.icon] ?? Link2;
+          return (
+            <section key={category.id} className="mb-10">
+              <div className="mb-4 flex items-center gap-3">
+                <div
+                  className={`flex h-10 w-10 items-center justify-center rounded-lg ${category.color}`}
+                >
+                  <Icon className="h-5 w-5" />
+                </div>
+                <div>
+                  <h2 className="font-semibold text-gray-800 dark:text-white/90">
+                    {category.label}
+                  </h2>
+                  {category.intro && (
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {category.intro}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {category.resources.map((resource) => (
+                  <div
+                    key={resource.name}
+                    className="rounded-2xl border border-gray-200 bg-white p-5 transition-shadow hover:shadow-theme-md dark:border-gray-800 dark:bg-white/[0.03]"
+                  >
+                    <a
+                      href={resource.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="group flex items-center gap-1.5 font-semibold text-gray-800 transition-colors hover:text-brand-500 dark:text-white/90 dark:hover:text-brand-400"
+                    >
+                      {resource.name}
+                      <ExternalLink className="h-3 w-3 opacity-60" />
+                    </a>
+                    <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                      {resource.description}
+                    </p>
+                    {resource.note && (
+                      <p className="mt-1 text-xs italic text-gray-400 dark:text-gray-500">
+                        {resource.note}
+                      </p>
+                    )}
+                    {resource.links && resource.links.length > 0 && (
+                      <div className="mt-2 flex flex-wrap gap-3 text-xs">
+                        {resource.links.map((link) => (
+                          <a
+                            key={link.url}
+                            href={link.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex items-center gap-1 text-gray-500 transition-colors hover:text-brand-500 dark:text-gray-400 dark:hover:text-brand-400"
+                          >
+                            {link.label}
+                            <ExternalLink className="h-2.5 w-2.5" />
+                          </a>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </section>
+          );
+        })}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a public **Resources** page at `/resources` — same visibility as About (renders in the landing layout when logged out, AppLayout when logged in). It's a curated, categorized directory of external VGC tools and a "Built on / Powered by" attribution section for the upstream tools VS Recorder integrates with.

## Approach

- Content is driven entirely from **`frontend/src/data/resources.json`** (9 categories, 31 resources) — adding or editing a resource is a data-only change, no code edit.
- **`ResourcesPage.tsx`** renders it, reusing the existing `AboutPage`/`FeaturesSection` idiom (icon chips, accent colors, responsive card grid, external-link cards). Since JSON can't hold component refs, each category's `icon` string maps to a `lucide-react` component via an `ICON_MAP` lookup. Pattern mirrors the typed-cast JSON import in `SpeedTiersPage.tsx`.
- Linked from both footers (`components/Footer.tsx` and `Landing/LandingFooter.tsx`) next to About.

## Categories

Damage Calculators · Usage Stats & Data · Tournament Standings & Brackets · Tournament Info & Official · Team Paste Databases · Team Building & Tools · Guides & Learning · Data References · Built on / Powered by

## Verification

- `tsc -b` → passes
- `vite build` → passes (pre-existing CSS-minify and chunk-size warnings only, unrelated)
- Manual visual check of `/resources` logged out vs logged in still recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)