### PR TITLE
docs: add crob.at to team-building resources

### DIFF
--- a/frontend/src/data/resources.json
+++ b/frontend/src/data/resources.json
@@ -152,6 +152,11 @@
     "color": "text-cyan-500 bg-cyan-50 dark:bg-cyan-500/10",
     "resources": [
       {
+        "name": "crob.at",
+        "url": "https://crob.at/",
+        "description": "Create visual, shareable team pages from Pokémon Showdown exports and PokePaste links."
+      },
+      {
         "name": "teamsheet.gg",
         "url": "https://teamsheet.gg",
         "description": "Browse and create team reports."


### PR DESCRIPTION
Adding [crob.at](https://crob.at/) to the Team Building & Tools resources.

crob.at turns team exports into visual, shareable team pages. The main sharing team feature is similar to the old pokepast.es
